### PR TITLE
issues/313: iOS - prevent app from interrupting background audio on launch

### DIFF
--- a/composeApp/src/iosMain/kotlin/com/slovy/slovymovyapp/speech/Speech.ios.kt
+++ b/composeApp/src/iosMain/kotlin/com/slovy/slovymovyapp/speech/Speech.ios.kt
@@ -41,31 +41,22 @@ actual class TextToSpeechManager actual constructor(androidContext: Any?) {
             },
             onWordBoundary = { range -> onWordBoundary?.invoke(range) }
         )
-        configureAudioSession()
-    }
-
-    @OptIn(ExperimentalForeignApi::class)
-    private fun configureAudioSession() {
-        val audioSession = AVAudioSession.sharedInstance()
-        try {
-            audioSession.setCategory(
-                AVAudioSessionCategoryPlayback,
-                AVAudioSessionCategoryOptionDuckOthers,
-                null
-            )
-            // Don't activate here - only activate when speaking
-        } catch (e: Exception) {
-            // Audio session configuration failed
-        }
     }
 
     @OptIn(ExperimentalForeignApi::class)
     private fun activateAudioSession() {
         val audioSession = AVAudioSession.sharedInstance()
         try {
+            // Reapply category each time to ensure ducking is configured
+            // (another component may have changed the session category)
+            audioSession.setCategory(
+                AVAudioSessionCategoryPlayback,
+                AVAudioSessionCategoryOptionDuckOthers,
+                null
+            )
             audioSession.setActive(true, null)
         } catch (e: Exception) {
-            // Audio session activation failed
+            // Audio session configuration/activation failed
         }
     }
 
@@ -169,7 +160,10 @@ actual class TextToSpeechManager actual constructor(androidContext: Any?) {
 
     actual fun stop() {
         if (!synthesizer.isSpeaking()) {
-            // Nothing playing, just ensure we're in idle state
+            // Not speaking - but session might be active if synth failed to start
+            // Ensure clean state by deactivating and setting IDLE
+            deactivateAudioSession()
+            onStatusChange?.invoke(TTSStatus.IDLE)
             return
         }
         // Stop synthesizer - cancel callback will fire and handle deactivation/status

--- a/composeApp/src/iosMain/kotlin/com/slovy/slovymovyapp/speech/Speech.ios.kt
+++ b/composeApp/src/iosMain/kotlin/com/slovy/slovymovyapp/speech/Speech.ios.kt
@@ -74,9 +74,9 @@ actual class TextToSpeechManager actual constructor(androidContext: Any?) {
     }
 
     actual fun speak(text: String) {
-        if (text.isEmpty()) return
-        // Stop any current speech first - maintains consistent behavior regardless of voice state
+        // Stop any current speech first - maintains consistent behavior regardless of text/voice state
         synthesizer.stopSpeakingAtBoundary(AVSpeechBoundary.AVSpeechBoundaryImmediate)
+        if (text.isEmpty()) return
         val voice = currentVoice ?: return
         // Increment generation for the new utterance
         speechGeneration++
@@ -158,12 +158,11 @@ actual class TextToSpeechManager actual constructor(androidContext: Any?) {
     }
 
     actual fun stop() {
-        // Always stop synthesizer to cancel any queued utterances
-        synthesizer.stopSpeakingAtBoundary(AVSpeechBoundary.AVSpeechBoundaryImmediate)
-        // Clear any pending utterances from the map to prevent memory leak
+        // Clear map BEFORE stopping so any sync callback is ignored (generation won't match)
         delegate.clearUtterances()
+        // Stop synthesizer to cancel any queued utterances
+        synthesizer.stopSpeakingAtBoundary(AVSpeechBoundary.AVSpeechBoundaryImmediate)
         // Deactivate session and set idle state
-        // (callback may also fire, but generation won't match after clear)
         deactivateAudioSession()
         onStatusChange?.invoke(TTSStatus.IDLE)
     }

--- a/composeApp/src/iosMain/kotlin/com/slovy/slovymovyapp/speech/Speech.ios.kt
+++ b/composeApp/src/iosMain/kotlin/com/slovy/slovymovyapp/speech/Speech.ios.kt
@@ -28,29 +28,56 @@ actual class TextToSpeechManager actual constructor(androidContext: Any?) {
         synthesizer.delegate = delegate
         delegate.setCallbacks(
             onStart = { onStatusChange?.invoke(TTSStatus.SPEAKING) },
-            onFinish = { onStatusChange?.invoke(TTSStatus.IDLE) },
+            onFinish = {
+                deactivateAudioSession()
+                onStatusChange?.invoke(TTSStatus.IDLE)
+            },
             onWordBoundary = { range -> onWordBoundary?.invoke(range) }
         )
         configureAudioSession()
     }
 
     @OptIn(ExperimentalForeignApi::class)
-    //TODO it is right place to configure audio session?
     private fun configureAudioSession() {
         val audioSession = AVAudioSession.sharedInstance()
         try {
             audioSession.setCategory(
                 AVAudioSessionCategoryPlayback,
-                AVAudioSessionCategoryOptions.MIN_VALUE,
+                AVAudioSessionCategoryOptionDuckOthers,
                 null
             )
-            audioSession.setActive(true, null)
+            // Don't activate here - only activate when speaking
         } catch (e: Exception) {
             // Audio session configuration failed
         }
     }
 
+    @OptIn(ExperimentalForeignApi::class)
+    private fun activateAudioSession() {
+        val audioSession = AVAudioSession.sharedInstance()
+        try {
+            audioSession.setActive(true, null)
+        } catch (e: Exception) {
+            // Audio session activation failed
+        }
+    }
+
+    @OptIn(ExperimentalForeignApi::class)
+    private fun deactivateAudioSession() {
+        val audioSession = AVAudioSession.sharedInstance()
+        try {
+            audioSession.setActive(
+                false,
+                AVAudioSessionSetActiveOptionNotifyOthersOnDeactivation,
+                null
+            )
+        } catch (e: Exception) {
+            // Audio session deactivation failed
+        }
+    }
+
     actual fun speak(text: String) {
+        activateAudioSession()
         val utterance = AVSpeechUtterance.speechUtteranceWithString(text)
         //TODO maybe we need to make speed configurable
         utterance.rate = 0.3f
@@ -128,6 +155,7 @@ actual class TextToSpeechManager actual constructor(androidContext: Any?) {
 
     actual fun stop() {
         synthesizer.stopSpeakingAtBoundary(AVSpeechBoundary.AVSpeechBoundaryImmediate)
+        deactivateAudioSession()
         onStatusChange?.invoke(TTSStatus.IDLE)
     }
 

--- a/composeApp/src/iosMain/kotlin/com/slovy/slovymovyapp/speech/Speech.ios.kt
+++ b/composeApp/src/iosMain/kotlin/com/slovy/slovymovyapp/speech/Speech.ios.kt
@@ -77,13 +77,14 @@ actual class TextToSpeechManager actual constructor(androidContext: Any?) {
     }
 
     actual fun speak(text: String) {
+        val voice = currentVoice ?: return
         activateAudioSession()
         val utterance = AVSpeechUtterance.speechUtteranceWithString(text)
         //TODO maybe we need to make speed configurable
         utterance.rate = 0.3f
         utterance.pitchMultiplier = 1.0f
         utterance.volume = 1.0f
-        utterance.voice = currentVoice ?: return
+        utterance.voice = voice
 
         currentUtterance = utterance
         synthesizer.speakUtterance(utterance)
@@ -201,7 +202,10 @@ private class TTSDelegate : NSObject(), AVSpeechSynthesizerDelegateProtocol {
         didFinishSpeechUtterance: AVSpeechUtterance
     ) {
         started = false
-        onFinish?.invoke()
+        // Only notify finish when no more utterances are queued
+        if (!synthesizer.isSpeaking()) {
+            onFinish?.invoke()
+        }
     }
 
     override fun speechSynthesizer(

--- a/composeApp/src/iosMain/kotlin/com/slovy/slovymovyapp/speech/Speech.ios.kt
+++ b/composeApp/src/iosMain/kotlin/com/slovy/slovymovyapp/speech/Speech.ios.kt
@@ -4,6 +4,7 @@ package com.slovy.slovymovyapp.speech
 import com.slovy.slovymovyapp.data.Language
 import kotlinx.cinterop.CValue
 import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.ObjCSignatureOverride
 import kotlinx.cinterop.useContents
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.IO
@@ -24,13 +25,19 @@ actual class TextToSpeechManager actual constructor(androidContext: Any?) {
     private var onWordBoundary: ((IntRange) -> Unit)? = null
     private var onStatusChange: ((TTSStatus) -> Unit)? = null
 
+    // Generation counter to track speech requests and ignore stale callbacks
+    private var speechGeneration: Long = 0
+
     init {
         synthesizer.delegate = delegate
         delegate.setCallbacks(
             onStart = { onStatusChange?.invoke(TTSStatus.SPEAKING) },
-            onFinish = {
-                deactivateAudioSession()
-                onStatusChange?.invoke(TTSStatus.IDLE)
+            onSpeechEnded = { generation ->
+                // Only deactivate if this callback is for the current generation
+                if (generation == speechGeneration) {
+                    deactivateAudioSession()
+                    onStatusChange?.invoke(TTSStatus.IDLE)
+                }
             },
             onWordBoundary = { range -> onWordBoundary?.invoke(range) }
         )
@@ -78,8 +85,12 @@ actual class TextToSpeechManager actual constructor(androidContext: Any?) {
 
     actual fun speak(text: String) {
         val voice = currentVoice ?: return
+        // Increment generation so any pending callbacks from previous speech are ignored
+        speechGeneration++
+        val currentGeneration = speechGeneration
         // Stop any current speech without deactivating session (new speech follows immediately)
         synthesizer.stopSpeakingAtBoundary(AVSpeechBoundary.AVSpeechBoundaryImmediate)
+        delegate.setCurrentGeneration(currentGeneration)
         activateAudioSession()
         val utterance = AVSpeechUtterance.speechUtteranceWithString(text)
         //TODO maybe we need to make speed configurable
@@ -157,6 +168,8 @@ actual class TextToSpeechManager actual constructor(androidContext: Any?) {
     }
 
     actual fun stop() {
+        // Increment generation so delegate callbacks from stopped speech are ignored
+        speechGeneration++
         synthesizer.stopSpeakingAtBoundary(AVSpeechBoundary.AVSpeechBoundaryImmediate)
         deactivateAudioSession()
         onStatusChange?.invoke(TTSStatus.IDLE)
@@ -175,38 +188,47 @@ actual class TextToSpeechManager actual constructor(androidContext: Any?) {
 private class TTSDelegate : NSObject(), AVSpeechSynthesizerDelegateProtocol {
 
     private var onStart: (() -> Unit)? = null
-    private var onFinish: (() -> Unit)? = null
+    private var onSpeechEnded: ((Long) -> Unit)? = null
     private var onWordBoundary: ((IntRange) -> Unit)? = null
 
-    // TODO: see todo below
     private var started: Boolean = false
+    private var currentGeneration: Long = 0
 
     fun setCallbacks(
         onStart: () -> Unit,
-        onFinish: () -> Unit,
+        onSpeechEnded: (Long) -> Unit,
         onWordBoundary: (IntRange) -> Unit
     ) {
         this.onStart = onStart
-        this.onFinish = onFinish
+        this.onSpeechEnded = onSpeechEnded
         this.onWordBoundary = onWordBoundary
     }
 
-    // TODO: can't override it, because conflicts with didFinishSpeechUtterance
-    /*override fun speechSynthesizer(
-        synthesizer: AVSpeechSynthesizer,
-        didStartSpeechUtterance: AVSpeechUtterance
-    ) {
-        onStart?.invoke()
-    }*/
+    fun setCurrentGeneration(generation: Long) {
+        currentGeneration = generation
+    }
 
+    @ObjCSignatureOverride
     override fun speechSynthesizer(
         synthesizer: AVSpeechSynthesizer,
         didFinishSpeechUtterance: AVSpeechUtterance
     ) {
         started = false
-        // Only notify finish when no more utterances are queued
+        // Only notify when no more utterances are queued
         if (!synthesizer.isSpeaking()) {
-            onFinish?.invoke()
+            onSpeechEnded?.invoke(currentGeneration)
+        }
+    }
+
+    @ObjCSignatureOverride
+    override fun speechSynthesizer(
+        synthesizer: AVSpeechSynthesizer,
+        didCancelSpeechUtterance: AVSpeechUtterance
+    ) {
+        started = false
+        // Handle cancellation (system interruption, manual stop, etc.)
+        if (!synthesizer.isSpeaking()) {
+            onSpeechEnded?.invoke(currentGeneration)
         }
     }
 

--- a/composeApp/src/iosMain/kotlin/com/slovy/slovymovyapp/speech/Speech.ios.kt
+++ b/composeApp/src/iosMain/kotlin/com/slovy/slovymovyapp/speech/Speech.ios.kt
@@ -78,6 +78,8 @@ actual class TextToSpeechManager actual constructor(androidContext: Any?) {
 
     actual fun speak(text: String) {
         val voice = currentVoice ?: return
+        // Stop any current speech without deactivating session (new speech follows immediately)
+        synthesizer.stopSpeakingAtBoundary(AVSpeechBoundary.AVSpeechBoundaryImmediate)
         activateAudioSession()
         val utterance = AVSpeechUtterance.speechUtteranceWithString(text)
         //TODO maybe we need to make speed configurable

--- a/composeApp/src/iosMain/kotlin/com/slovy/slovymovyapp/speech/Speech.ios.kt
+++ b/composeApp/src/iosMain/kotlin/com/slovy/slovymovyapp/speech/Speech.ios.kt
@@ -85,12 +85,10 @@ actual class TextToSpeechManager actual constructor(androidContext: Any?) {
 
     actual fun speak(text: String) {
         val voice = currentVoice ?: return
-        // Increment generation so any pending callbacks from previous speech are ignored
-        speechGeneration++
-        val currentGeneration = speechGeneration
-        // Stop any current speech without deactivating session (new speech follows immediately)
+        // Stop any current speech - its cancel callback will have the OLD generation from the map
         synthesizer.stopSpeakingAtBoundary(AVSpeechBoundary.AVSpeechBoundaryImmediate)
-        delegate.setCurrentGeneration(currentGeneration)
+        // Increment generation for the new utterance
+        speechGeneration++
         activateAudioSession()
         val utterance = AVSpeechUtterance.speechUtteranceWithString(text)
         //TODO maybe we need to make speed configurable
@@ -100,6 +98,8 @@ actual class TextToSpeechManager actual constructor(androidContext: Any?) {
         utterance.voice = voice
 
         currentUtterance = utterance
+        // Register this utterance with its generation before speaking
+        delegate.registerUtterance(utterance, speechGeneration)
         synthesizer.speakUtterance(utterance)
     }
 
@@ -168,11 +168,13 @@ actual class TextToSpeechManager actual constructor(androidContext: Any?) {
     }
 
     actual fun stop() {
-        // Increment generation so delegate callbacks from stopped speech are ignored
-        speechGeneration++
+        if (!synthesizer.isSpeaking()) {
+            // Nothing playing, just ensure we're in idle state
+            return
+        }
+        // Stop synthesizer - cancel callback will fire and handle deactivation/status
+        // Generation stays the same so callback knows this is a valid stop
         synthesizer.stopSpeakingAtBoundary(AVSpeechBoundary.AVSpeechBoundaryImmediate)
-        deactivateAudioSession()
-        onStatusChange?.invoke(TTSStatus.IDLE)
     }
 
     actual fun setOnWordBoundaryListener(listener: (wordRange: IntRange) -> Unit) {
@@ -192,6 +194,9 @@ private class TTSDelegate : NSObject(), AVSpeechSynthesizerDelegateProtocol {
     private var onWordBoundary: ((IntRange) -> Unit)? = null
 
     private var started: Boolean = false
+
+    // Map utterance to its generation - allows correct generation lookup in async callbacks
+    private val utteranceGenerations = mutableMapOf<AVSpeechUtterance, Long>()
     private var currentGeneration: Long = 0
 
     fun setCallbacks(
@@ -204,8 +209,13 @@ private class TTSDelegate : NSObject(), AVSpeechSynthesizerDelegateProtocol {
         this.onWordBoundary = onWordBoundary
     }
 
-    fun setCurrentGeneration(generation: Long) {
+    fun registerUtterance(utterance: AVSpeechUtterance, generation: Long) {
         currentGeneration = generation
+        utteranceGenerations[utterance] = generation
+    }
+
+    private fun getAndRemoveGeneration(utterance: AVSpeechUtterance): Long {
+        return utteranceGenerations.remove(utterance) ?: -1
     }
 
     @ObjCSignatureOverride
@@ -214,9 +224,10 @@ private class TTSDelegate : NSObject(), AVSpeechSynthesizerDelegateProtocol {
         didFinishSpeechUtterance: AVSpeechUtterance
     ) {
         started = false
-        // Only notify when no more utterances are queued
-        if (!synthesizer.isSpeaking()) {
-            onSpeechEnded?.invoke(currentGeneration)
+        val utteranceGeneration = getAndRemoveGeneration(didFinishSpeechUtterance)
+        // Only notify if this utterance's generation matches current and nothing else queued
+        if (utteranceGeneration == currentGeneration && !synthesizer.isSpeaking()) {
+            onSpeechEnded?.invoke(utteranceGeneration)
         }
     }
 
@@ -226,9 +237,10 @@ private class TTSDelegate : NSObject(), AVSpeechSynthesizerDelegateProtocol {
         didCancelSpeechUtterance: AVSpeechUtterance
     ) {
         started = false
-        // Handle cancellation (system interruption, manual stop, etc.)
-        if (!synthesizer.isSpeaking()) {
-            onSpeechEnded?.invoke(currentGeneration)
+        val utteranceGeneration = getAndRemoveGeneration(didCancelSpeechUtterance)
+        // Only notify if this utterance's generation matches current and nothing else queued
+        if (utteranceGeneration == currentGeneration && !synthesizer.isSpeaking()) {
+            onSpeechEnded?.invoke(utteranceGeneration)
         }
     }
 

--- a/composeApp/src/iosMain/kotlin/com/slovy/slovymovyapp/speech/Speech.ios.kt
+++ b/composeApp/src/iosMain/kotlin/com/slovy/slovymovyapp/speech/Speech.ios.kt
@@ -19,7 +19,6 @@ actual class TextToSpeechManager actual constructor(androidContext: Any?) {
 
     private val synthesizer = AVSpeechSynthesizer()
     private val delegate = TTSDelegate()
-    private var currentUtterance: AVSpeechUtterance? = null
     private var currentVoice: AVSpeechSynthesisVoice? = null
 
     private var onWordBoundary: ((IntRange) -> Unit)? = null
@@ -75,9 +74,10 @@ actual class TextToSpeechManager actual constructor(androidContext: Any?) {
     }
 
     actual fun speak(text: String) {
-        val voice = currentVoice ?: return
-        // Stop any current speech - its cancel callback will have the OLD generation from the map
+        if (text.isEmpty()) return
+        // Stop any current speech first - maintains consistent behavior regardless of voice state
         synthesizer.stopSpeakingAtBoundary(AVSpeechBoundary.AVSpeechBoundaryImmediate)
+        val voice = currentVoice ?: return
         // Increment generation for the new utterance
         speechGeneration++
         activateAudioSession()
@@ -88,7 +88,6 @@ actual class TextToSpeechManager actual constructor(androidContext: Any?) {
         utterance.volume = 1.0f
         utterance.voice = voice
 
-        currentUtterance = utterance
         // Register this utterance with its generation before speaking
         delegate.registerUtterance(utterance, speechGeneration)
         synthesizer.speakUtterance(utterance)
@@ -159,16 +158,14 @@ actual class TextToSpeechManager actual constructor(androidContext: Any?) {
     }
 
     actual fun stop() {
-        if (!synthesizer.isSpeaking()) {
-            // Not speaking - but session might be active if synth failed to start
-            // Ensure clean state by deactivating and setting IDLE
-            deactivateAudioSession()
-            onStatusChange?.invoke(TTSStatus.IDLE)
-            return
-        }
-        // Stop synthesizer - cancel callback will fire and handle deactivation/status
-        // Generation stays the same so callback knows this is a valid stop
+        // Always stop synthesizer to cancel any queued utterances
         synthesizer.stopSpeakingAtBoundary(AVSpeechBoundary.AVSpeechBoundaryImmediate)
+        // Clear any pending utterances from the map to prevent memory leak
+        delegate.clearUtterances()
+        // Deactivate session and set idle state
+        // (callback may also fire, but generation won't match after clear)
+        deactivateAudioSession()
+        onStatusChange?.invoke(TTSStatus.IDLE)
     }
 
     actual fun setOnWordBoundaryListener(listener: (wordRange: IntRange) -> Unit) {
@@ -204,8 +201,17 @@ private class TTSDelegate : NSObject(), AVSpeechSynthesizerDelegateProtocol {
     }
 
     fun registerUtterance(utterance: AVSpeechUtterance, generation: Long) {
+        // Clear old entries to prevent memory leak if callbacks never fire
+        // (we use queue-flush behavior, so only one utterance at a time)
+        utteranceGenerations.clear()
         currentGeneration = generation
         utteranceGenerations[utterance] = generation
+    }
+
+    fun clearUtterances() {
+        // Clear map and reset generation so any pending callbacks are ignored
+        utteranceGenerations.clear()
+        currentGeneration = -1
     }
 
     private fun getAndRemoveGeneration(utterance: AVSpeechUtterance): Long {
@@ -219,8 +225,8 @@ private class TTSDelegate : NSObject(), AVSpeechSynthesizerDelegateProtocol {
     ) {
         started = false
         val utteranceGeneration = getAndRemoveGeneration(didFinishSpeechUtterance)
-        // Only notify if this utterance's generation matches current and nothing else queued
-        if (utteranceGeneration == currentGeneration && !synthesizer.isSpeaking()) {
+        // Only notify if this utterance's generation matches current, is valid (>0), and nothing else queued
+        if (utteranceGeneration > 0 && utteranceGeneration == currentGeneration && !synthesizer.isSpeaking()) {
             onSpeechEnded?.invoke(utteranceGeneration)
         }
     }
@@ -232,8 +238,8 @@ private class TTSDelegate : NSObject(), AVSpeechSynthesizerDelegateProtocol {
     ) {
         started = false
         val utteranceGeneration = getAndRemoveGeneration(didCancelSpeechUtterance)
-        // Only notify if this utterance's generation matches current and nothing else queued
-        if (utteranceGeneration == currentGeneration && !synthesizer.isSpeaking()) {
+        // Only notify if this utterance's generation matches current, is valid (>0), and nothing else queued
+        if (utteranceGeneration > 0 && utteranceGeneration == currentGeneration && !synthesizer.isSpeaking()) {
             onSpeechEnded?.invoke(utteranceGeneration)
         }
     }


### PR DESCRIPTION
Configure iOS audio session to only activate when TTS actually speaks, not on app initialization. Use DuckOthers option to lower background audio during speech instead of stopping it, and notify other apps to resume when TTS finishes.

Fixes #313