### PR TITLE
fixes #275 spaces: Allow multi-word translations in search results

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/data/remote/DictionaryRepository.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/data/remote/DictionaryRepository.kt
@@ -361,7 +361,7 @@ class DictionaryRepository(
                     val tq = tdb.translationQueries
                     val dq = dictDb.dictionaryQueries
                     val trRows =
-                        tq.selectSenseTranslationsByNormalizedSingleWord(lang.code, tgt.code, prefixStart, prefixEnd)
+                        tq.selectSenseTranslationsByNormalizedPrefix(lang.code, tgt.code, prefixStart, prefixEnd)
                             .executeAsList()
                     val lemmaRows =
                         dq.selectLemmasByIds(trRows.map { it.lemma_id }).executeAsList().associateBy { it.id }

--- a/shared/src/commonMain/sqldelight/translationdb/com/slovy/slovymovyapp/translation/Translation.sq
+++ b/shared/src/commonMain/sqldelight/translationdb/com/slovy/slovymovyapp/translation/Translation.sq
@@ -76,14 +76,13 @@ SELECT translation
 FROM example_translation
 WHERE sense_id = ? AND from_lang_code = ? AND target_lang_code = ? AND example_id = ?;
 
--- Lookup by normalized target word (excludes multi-word translations)
-selectSenseTranslationsByNormalizedSingleWord:
+-- Lookup by normalized target word prefix
+selectSenseTranslationsByNormalizedPrefix:
 SELECT sense_id, idx, target_lang_word, target_lang_word_normalized, target_lang_sense_clarification, lemma_id, lemma_pos_id
 FROM sense_translation INDEXED BY sense_translation_lang_word_normalized_idx
 WHERE from_lang_code = ? AND target_lang_code = ?
   AND target_lang_word_normalized >= ?
   AND target_lang_word_normalized < ?
-  AND instr(target_lang_word_normalized, ' ') = 0
 ORDER BY idx;
 
 selectDefinitionsBySenseIds:


### PR DESCRIPTION
## Summary                                                                                                                                                               
  - Remove space filter that excluded multi-word translations (e.g., "fire extinguisher") from main search results                                                         
  - Rename query from `selectSenseTranslationsByNormalizedSingleWord` to `selectSenseTranslationsByNormalizedPrefix`                                                       
                                                                                                                                                                           
  ## Test plan                                                                                                                                                             
  - [ ] Search for "fire extinguisher" → should show as translation of "brandblusser"                                                                                      
  - [ ] Verify single-word translation search still works                                     