### PR TITLE
UI polish: refine AppNavigationBar UI for cleaner look

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/AppNavigationBar.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/AppNavigationBar.kt
@@ -1,6 +1,5 @@
 package com.slovy.slovymovyapp.ui
 
-import androidx.compose.foundation.layout.offset
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Book
 import androidx.compose.material.icons.filled.Favorite
@@ -12,10 +11,8 @@ import androidx.compose.material.icons.outlined.Search
 import androidx.compose.material.icons.outlined.Settings
 import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.style.TextOverflow
-import androidx.compose.ui.unit.dp
 
 enum class AppScreen {
     SEARCH,
@@ -38,7 +35,9 @@ fun AppNavigationBar(
         selectedIconColor = MaterialTheme.colorScheme.primary,
         selectedTextColor = MaterialTheme.colorScheme.primary,
         unselectedIconColor = MaterialTheme.colorScheme.onSurfaceVariant,
-        unselectedTextColor = MaterialTheme.colorScheme.onSurfaceVariant
+        unselectedTextColor = MaterialTheme.colorScheme.onSurfaceVariant,
+        disabledIconColor = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.38f),
+        disabledTextColor = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.38f)
     )
 
     NavigationBar(
@@ -59,7 +58,6 @@ fun AppNavigationBar(
             label = {
                 Text(
                     "Search",
-                    modifier = Modifier.offset(y = (-4).dp),
                     maxLines = 1,
                     overflow = TextOverflow.Ellipsis,
                     style = MaterialTheme.typography.labelSmall
@@ -83,7 +81,6 @@ fun AppNavigationBar(
             label = {
                 Text(
                     "Favorites",
-                    modifier = Modifier.offset(y = (-4).dp),
                     maxLines = 1,
                     overflow = TextOverflow.Ellipsis,
                     style = MaterialTheme.typography.labelSmall
@@ -107,7 +104,6 @@ fun AppNavigationBar(
             label = {
                 Text(
                     wordDetailLabel ?: "Word Detail",
-                    modifier = Modifier.offset(y = (-4).dp),
                     maxLines = 1,
                     overflow = TextOverflow.Ellipsis,
                     style = MaterialTheme.typography.labelSmall
@@ -132,7 +128,6 @@ fun AppNavigationBar(
             label = {
                 Text(
                     "Settings",
-                    modifier = Modifier.offset(y = (-4).dp),
                     maxLines = 1,
                     overflow = TextOverflow.Ellipsis,
                     style = MaterialTheme.typography.labelSmall

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/AppNavigationBar.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/AppNavigationBar.kt
@@ -1,5 +1,6 @@
 package com.slovy.slovymovyapp.ui
 
+import androidx.compose.foundation.layout.offset
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Book
 import androidx.compose.material.icons.filled.Favorite
@@ -11,6 +12,10 @@ import androidx.compose.material.icons.outlined.Search
 import androidx.compose.material.icons.outlined.Settings
 import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
 
 enum class AppScreen {
     SEARCH,
@@ -28,6 +33,14 @@ fun AppNavigationBar(
     wordDetailLabel: String? = null,
     onNavigateToSettings: () -> Unit = {}
 ) {
+    val itemColors = NavigationBarItemDefaults.colors(
+        indicatorColor = Color.Transparent,
+        selectedIconColor = MaterialTheme.colorScheme.primary,
+        selectedTextColor = MaterialTheme.colorScheme.primary,
+        unselectedIconColor = MaterialTheme.colorScheme.onSurfaceVariant,
+        unselectedTextColor = MaterialTheme.colorScheme.onSurfaceVariant
+    )
+
     NavigationBar(
         containerColor = MaterialTheme.colorScheme.surfaceContainer,
         tonalElevation = com.slovy.slovymovyapp.ui.theme.AppElevation.level3
@@ -43,9 +56,18 @@ fun AppNavigationBar(
                     contentDescription = "Search"
                 )
             },
-            label = { Text("Search") },
+            label = {
+                Text(
+                    "Search",
+                    modifier = Modifier.offset(y = (-4).dp),
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                    style = MaterialTheme.typography.labelSmall
+                )
+            },
             selected = currentScreen == AppScreen.SEARCH,
-            onClick = onNavigateToSearch
+            onClick = onNavigateToSearch,
+            colors = itemColors
         )
         NavigationBarItem(
             icon = {
@@ -58,9 +80,18 @@ fun AppNavigationBar(
                     contentDescription = "Favorites"
                 )
             },
-            label = { Text("Favorites") },
+            label = {
+                Text(
+                    "Favorites",
+                    modifier = Modifier.offset(y = (-4).dp),
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                    style = MaterialTheme.typography.labelSmall
+                )
+            },
             selected = currentScreen == AppScreen.FAVORITES,
-            onClick = onNavigateToFavorites
+            onClick = onNavigateToFavorites,
+            colors = itemColors
         )
         NavigationBarItem(
             icon = {
@@ -73,10 +104,19 @@ fun AppNavigationBar(
                     contentDescription = "Word Detail"
                 )
             },
-            label = { Text(wordDetailLabel ?: "Word Detail") },
+            label = {
+                Text(
+                    wordDetailLabel ?: "Word Detail",
+                    modifier = Modifier.offset(y = (-4).dp),
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                    style = MaterialTheme.typography.labelSmall
+                )
+            },
             selected = currentScreen == AppScreen.WORD_DETAIL,
             enabled = wordDetailLabel != null,
-            onClick = onNavigateToWordDetail
+            onClick = onNavigateToWordDetail,
+            colors = itemColors
         )
         NavigationBarItem(
             icon = {
@@ -89,9 +129,18 @@ fun AppNavigationBar(
                     contentDescription = "Settings"
                 )
             },
-            label = { Text("Settings") },
+            label = {
+                Text(
+                    "Settings",
+                    modifier = Modifier.offset(y = (-4).dp),
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                    style = MaterialTheme.typography.labelSmall
+                )
+            },
             selected = currentScreen == AppScreen.SETTINGS,
-            onClick = onNavigateToSettings
+            onClick = onNavigateToSettings,
+            colors = itemColors
         )
     }
 }


### PR DESCRIPTION




- Remove pill indicator on active state, use color shift instead
- Use primary color for selected icon/text, onSurfaceVariant for unselected
- Reduce label font size with labelSmall typography
- Add single-line constraint with ellipsis for long labels
- Tighten icon-label spacing with offset

**What i didn't do because its not very safe (but would love to): word detail label shrink, overall navbar height reduction, space reduction between icon and label** 

-----
HERE IS REFS:

<img width="909" height="177" alt="Screenshot 2026-01-30 at 12 59 33" src="https://github.com/user-attachments/assets/63e94419-8f57-468c-89d2-1b3701c75268" />

HERE IS BEFORE-AFTER:
<img width="9750" height="5112" alt="image" src="https://github.com/user-attachments/assets/057559e8-9f0e-43be-b24d-81943c1319a1" />

