### PR TITLE
Issues/359: Settings - UX improvements for download and delete flows

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/data/remote/DownloadCoordinator.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/data/remote/DownloadCoordinator.kt
@@ -42,7 +42,7 @@ class DownloadCoordinator(
 
         val cancelToken = CancelToken()
         cancelTokens[key] = cancelToken
-        updateEntry(key, DownloadEntry(status = DownloadStatus.Running, progress = DownloadProgress(0, 1)))
+        updateEntry(key, DownloadEntry(status = DownloadStatus.Running, progress = null))
 
         val job = scope.launch {
             try {

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/SettingsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/SettingsScreen.kt
@@ -968,7 +968,7 @@ private fun DictionaryCard(
                 ) {
                     if (dictDownloading) {
                         CancellableProgressIndicator(
-                            progress = dictProgress?.percent?.toFloat()?.div(100f) ?: 0f,
+                            progress = dictProgress?.percent?.toFloat()?.div(100f) ?: -1f,
                             onCancel = { onCancelDownload(dictDownloadKey) },
                             size = 48.dp
                         )
@@ -1092,7 +1092,7 @@ private fun TranslationItem(
             ) {
                 if (isDownloading) {
                     CancellableProgressIndicator(
-                        progress = downloadProgress?.percent?.toFloat()?.div(100f) ?: 0f,
+                        progress = downloadProgress?.percent?.toFloat()?.div(100f) ?: -1f,
                         onCancel = onCancel,
                         size = 48.dp
                     )

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/SettingsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/SettingsScreen.kt
@@ -22,6 +22,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
@@ -1086,14 +1087,14 @@ private fun TranslationItem(
             }
 
             Box(
-                modifier = Modifier.size(40.dp),
+                modifier = Modifier.size(48.dp),
                 contentAlignment = Alignment.Center
             ) {
                 if (isDownloading) {
                     CancellableProgressIndicator(
                         progress = downloadProgress?.percent?.toFloat()?.div(100f) ?: 0f,
                         onCancel = onCancel,
-                        size = 32.dp
+                        size = 36.dp
                     )
                 } else if (isDownloaded) {
                     IconButton(onClick = onDelete) {
@@ -1515,7 +1516,10 @@ private fun CancellableProgressIndicator(
         modifier = modifier
             .size(size)
             .clip(CircleShape)
-            .clickable(onClick = onCancel),
+            .clickable(
+                onClick = onCancel,
+                role = Role.Button
+            ),
         contentAlignment = Alignment.Center
     ) {
         // Progress ring with track

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/SettingsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/SettingsScreen.kt
@@ -63,7 +63,7 @@ data class SettingsUiState(
     val languages: Map<Text2SpeechLanguage, LanguageUiState> = emptyMap(),
     val databases: List<DatabaseItemUiState> = emptyList(),
     val availableLanguages: List<AvailableLanguageInfo> = emptyList(),
-    val downloadingItems: Map<String, DownloadProgress> = emptyMap(),
+    val downloadingItems: Map<String, DownloadProgress?> = emptyMap(),
     val expandedDictionaries: Set<String> = emptySet(),
     val isLoading: Boolean = true,
     val isLoadingAvailable: Boolean = false,
@@ -474,7 +474,7 @@ class SettingsViewModel(
             downloadCoordinator.downloadEntries()
                 .map { entries ->
                     entries.filterValues { it.status == DownloadStatus.Running }
-                        .mapValues { (_, entry) -> entry.progress ?: DownloadProgress(0, 1) }
+                        .mapValues { (_, entry) -> entry.progress }
                 }
                 .distinctUntilChanged()
                 .collect { running ->
@@ -894,7 +894,7 @@ private fun DictionaryCard(
     onDownloadTranslation: (Language) -> Unit,
     onDeleteTranslation: (Language) -> Unit,
     downloadedTranslations: List<DatabaseItemUiState>,
-    downloadingItems: Map<String, DownloadProgress>
+    downloadingItems: Map<String, DownloadProgress?>
 ) {
     ElevatedCard(
         modifier = Modifier

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/SettingsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/SettingsScreen.kt
@@ -1526,12 +1526,12 @@ private fun CancellableProgressIndicator(
             .clip(CircleShape)
             .semantics(mergeDescendants = true) {
                 // Expose progress to screen readers
-                if (isIndeterminate) {
-                    stateDescription = "Downloading"
+                progressBarRangeInfo = if (isIndeterminate) {
+                    ProgressBarRangeInfo.Indeterminate
                 } else {
-                    progressBarRangeInfo = ProgressBarRangeInfo(clampedProgress, 0f..1f)
-                    stateDescription = "Downloading $progressPercent%"
+                    ProgressBarRangeInfo(clampedProgress, 0f..1f)
                 }
+                stateDescription = if (isIndeterminate) "Downloading" else "Downloading $progressPercent%"
             }
             .clickable(
                 onClick = onCancel,

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/SettingsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/SettingsScreen.kt
@@ -22,7 +22,11 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.semantics.ProgressBarRangeInfo
 import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.progressBarRangeInfo
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.stateDescription
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
@@ -1514,11 +1518,21 @@ private fun CancellableProgressIndicator(
     // Clamp progress to valid range, use indeterminate if unknown (-1)
     val clampedProgress = progress.coerceIn(0f, 1f)
     val isIndeterminate = progress < 0f
+    val progressPercent = if (isIndeterminate) null else (clampedProgress * 100).toInt()
 
     Box(
         modifier = modifier
             .size(size)
             .clip(CircleShape)
+            .semantics(mergeDescendants = true) {
+                // Expose progress to screen readers
+                if (isIndeterminate) {
+                    stateDescription = "Downloading"
+                } else {
+                    progressBarRangeInfo = ProgressBarRangeInfo(clampedProgress, 0f..1f)
+                    stateDescription = "Downloading $progressPercent%"
+                }
+            }
             .clickable(
                 onClick = onCancel,
                 onClickLabel = "Cancel download",

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/SettingsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/SettingsScreen.kt
@@ -596,7 +596,13 @@ fun SettingsScreenContent(
         Scaffold(
             topBar = {
                 CenterAlignedTopAppBar(
-                    title = { Text("Settings") }
+                    title = {
+                        Text(
+                            "Settings",
+                            style = MaterialTheme.typography.titleLarge,
+                            fontWeight = FontWeight.SemiBold
+                        )
+                    }
                 )
             },
             bottomBar = {

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/SettingsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/SettingsScreen.kt
@@ -70,8 +70,10 @@ data class SettingsUiState(
 )
 
 data class DeleteConfirmationState(
-    val displayName: String,
-    val additionalInfo: String? = null,
+    val title: String,
+    val message: String,
+    val warning: String? = null,
+    val toastMessage: String,
     val onConfirm: () -> Unit
 )
 
@@ -129,38 +131,53 @@ class SettingsViewModel(
                 val uiItems = files.map { fileInfo ->
                     when (fileInfo) {
                         is DatabaseFileInfo.Dictionary -> {
-                            val displayName = "Dictionary: ${fileInfo.language.selfName}"
+                            val langName = fileInfo.language.selfName
+                            val displayName = "Dictionary: $langName"
                             // Count how many translations will be deleted along with the dictionary
                             val translationCount = files.count {
                                 it is DatabaseFileInfo.Translation &&
                                         it.sourceLanguage == fileInfo.language
                             }
-                            val additionalInfo = if (translationCount > 0) {
-                                "$translationCount translation${if (translationCount > 1) "s" else ""} will also be deleted"
+                            val warning = if (translationCount > 0) {
+                                "This will also remove $translationCount translation${if (translationCount > 1) "s" else ""}."
                             } else null
 
+                            val toastMsg = "$langName dictionary deleted"
                             DatabaseItemUiState(
                                 displayName = displayName,
                                 sizeBytes = fileInfo.sizeBytes,
                                 deleteAction = {
-                                    showDeleteConfirmation(displayName, additionalInfo) {
-                                        deleteDictionary(fileInfo.language)
+                                    showDeleteConfirmation(
+                                        title = "Delete $langName Dictionary?",
+                                        message = "You can re-download it anytime.",
+                                        warning = warning,
+                                        toastMessage = toastMsg
+                                    ) {
+                                        deleteDictionary(fileInfo.language, toastMsg)
                                     }
                                 }
                             )
                         }
 
                         is DatabaseFileInfo.Translation -> {
-                            val displayName =
-                                "Translation: ${fileInfo.sourceLanguage.selfName} → ${fileInfo.targetLanguage.selfName}"
+                            val srcName = fileInfo.sourceLanguage.selfName
+                            val tgtName = fileInfo.targetLanguage.selfName
+                            val displayName = "Translation: $srcName → $tgtName"
+                            val toastMsg = "$srcName → $tgtName translation deleted"
                             DatabaseItemUiState(
                                 displayName = displayName,
                                 sizeBytes = fileInfo.sizeBytes,
                                 deleteAction = {
-                                    showDeleteConfirmation(displayName) {
+                                    showDeleteConfirmation(
+                                        title = "Delete $srcName → $tgtName Translation?",
+                                        message = "You can re-download it anytime.",
+                                        warning = null,
+                                        toastMessage = toastMsg
+                                    ) {
                                         deleteTranslation(
                                             fileInfo.sourceLanguage,
-                                            fileInfo.targetLanguage
+                                            fileInfo.targetLanguage,
+                                            toastMsg
                                         )
                                     }
                                 }
@@ -193,11 +210,19 @@ class SettingsViewModel(
         }
     }
 
-    fun showDeleteConfirmation(displayName: String, additionalInfo: String? = null, onConfirm: () -> Unit) {
+    fun showDeleteConfirmation(
+        title: String,
+        message: String,
+        warning: String? = null,
+        toastMessage: String,
+        onConfirm: () -> Unit
+    ) {
         state = state.copy(
             deleteConfirmation = DeleteConfirmationState(
-                displayName = displayName,
-                additionalInfo = additionalInfo,
+                title = title,
+                message = message,
+                warning = warning,
+                toastMessage = toastMessage,
                 onConfirm = onConfirm
             )
         )
@@ -212,28 +237,28 @@ class SettingsViewModel(
         state = state.copy(deleteConfirmation = null)
     }
 
-    private fun deleteDictionary(language: Language) {
+    private fun deleteDictionary(language: Language, toastMessage: String) {
         viewModelScope.launch {
             try {
                 dataDbManager.deleteDictionary(language)
                 dictionaryRepository.clearSenseCache()
                 reloadSettings()
-                snackbarHostState.showSnackbar("Database deleted successfully")
+                snackbarHostState.showSnackbar(toastMessage)
             } catch (e: Exception) {
-                state = state.copy(errorMessage = "Failed to delete database: ${e.message}")
+                state = state.copy(errorMessage = "Failed to delete: ${e.message}")
             }
         }
     }
 
-    private fun deleteTranslation(src: Language, tgt: Language) {
+    private fun deleteTranslation(src: Language, tgt: Language, toastMessage: String) {
         viewModelScope.launch {
             try {
                 dataDbManager.deleteTranslation(src, tgt)
                 dictionaryRepository.clearSenseCache()
                 loadDatabases()
-                snackbarHostState.showSnackbar("Database deleted successfully")
+                snackbarHostState.showSnackbar(toastMessage)
             } catch (e: Exception) {
-                state = state.copy(errorMessage = "Failed to delete database: ${e.message}")
+                state = state.copy(errorMessage = "Failed to delete: ${e.message}")
             }
         }
     }
@@ -835,8 +860,9 @@ fun SettingsScreenContent(
         // Delete confirmation dialog
         state.deleteConfirmation?.let { confirmation ->
             DeleteConfirmationDialog(
-                displayName = confirmation.displayName,
-                additionalInfo = confirmation.additionalInfo,
+                title = confirmation.title,
+                message = confirmation.message,
+                warning = confirmation.warning,
                 onConfirm = onConfirmDelete,
                 onDismiss = onDismissDeleteConfirmation
             )
@@ -1276,23 +1302,30 @@ private fun LoadingIndicator(modifier: Modifier = Modifier) {
 
 @Composable
 fun DeleteConfirmationDialog(
-    displayName: String,
-    additionalInfo: String? = null,
+    title: String,
+    message: String,
+    warning: String? = null,
     onConfirm: () -> Unit,
     onDismiss: () -> Unit
 ) {
     AlertDialog(
         onDismissRequest = onDismiss,
         title = {
-            Text("Delete Data?")
+            Text(
+                text = title,
+                style = MaterialTheme.typography.headlineSmall
+            )
         },
         text = {
-            Column {
-                Text("Are you sure you want to delete $displayName?")
-                if (additionalInfo != null) {
-                    Spacer(modifier = Modifier.height(8.dp))
+            Column(verticalArrangement = Arrangement.spacedBy(AppSpacing.sm)) {
+                Text(
+                    text = message,
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+                if (warning != null) {
                     Text(
-                        text = additionalInfo,
+                        text = warning,
                         style = MaterialTheme.typography.bodyMedium,
                         color = MaterialTheme.colorScheme.error
                     )
@@ -1310,7 +1343,12 @@ fun DeleteConfirmationDialog(
             }
         },
         dismissButton = {
-            TextButton(onClick = onDismiss) {
+            TextButton(
+                onClick = onDismiss,
+                colors = ButtonDefaults.textButtonColors(
+                    contentColor = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            ) {
                 Text("Cancel")
             }
         }
@@ -1767,8 +1805,10 @@ private fun SettingsScreenPreviewWithDeleteConfirmation(
                     )
                 ),
                 deleteConfirmation = DeleteConfirmationState(
-                    displayName = "Dictionary: English",
-                    additionalInfo = "2 translations will also be deleted",
+                    title = "Delete English Dictionary?",
+                    message = "You can re-download it anytime.",
+                    warning = "This will also remove 2 translations.",
+                    toastMessage = "English dictionary deleted",
                     onConfirm = {}
                 )
             )

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/SettingsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/SettingsScreen.kt
@@ -970,7 +970,7 @@ private fun DictionaryCard(
                         CancellableProgressIndicator(
                             progress = dictProgress?.percent?.toFloat()?.div(100f) ?: 0f,
                             onCancel = { onCancelDownload(dictDownloadKey) },
-                            size = 36.dp
+                            size = 48.dp
                         )
                     } else if (isDownloaded) {
                         IconButton(onClick = onDeleteDictionary) {
@@ -1094,7 +1094,7 @@ private fun TranslationItem(
                     CancellableProgressIndicator(
                         progress = downloadProgress?.percent?.toFloat()?.div(100f) ?: 0f,
                         onCancel = onCancel,
-                        size = 36.dp
+                        size = 48.dp
                     )
                 } else if (isDownloaded) {
                     IconButton(onClick = onDelete) {
@@ -1511,6 +1511,9 @@ private fun CancellableProgressIndicator(
 ) {
     val iconSize = size * 0.4f
     val strokeWidth = 2.5.dp
+    // Clamp progress to valid range, use indeterminate if unknown (-1)
+    val clampedProgress = progress.coerceIn(0f, 1f)
+    val isIndeterminate = progress < 0f
 
     Box(
         modifier = modifier
@@ -1518,18 +1521,28 @@ private fun CancellableProgressIndicator(
             .clip(CircleShape)
             .clickable(
                 onClick = onCancel,
+                onClickLabel = "Cancel download",
                 role = Role.Button
             ),
         contentAlignment = Alignment.Center
     ) {
         // Progress ring with track
-        CircularProgressIndicator(
-            progress = { progress },
-            modifier = Modifier.size(size),
-            strokeWidth = strokeWidth,
-            trackColor = MaterialTheme.colorScheme.surfaceVariant,
-            color = MaterialTheme.colorScheme.primary
-        )
+        if (isIndeterminate) {
+            CircularProgressIndicator(
+                modifier = Modifier.size(size),
+                strokeWidth = strokeWidth,
+                trackColor = MaterialTheme.colorScheme.surfaceVariant,
+                color = MaterialTheme.colorScheme.primary
+            )
+        } else {
+            CircularProgressIndicator(
+                progress = { clampedProgress },
+                modifier = Modifier.size(size),
+                strokeWidth = strokeWidth,
+                trackColor = MaterialTheme.colorScheme.surfaceVariant,
+                color = MaterialTheme.colorScheme.primary
+            )
+        }
 
         // Cancel icon with subtle background
         Surface(

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/SettingsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/SettingsScreen.kt
@@ -78,7 +78,6 @@ data class DeleteConfirmationState(
     val title: String,
     val message: String,
     val warning: String? = null,
-    val toastMessage: String,
     val onConfirm: () -> Unit
 )
 
@@ -155,8 +154,7 @@ class SettingsViewModel(
                                     showDeleteConfirmation(
                                         title = "Delete $langName Dictionary?",
                                         message = "You can re-download it anytime.",
-                                        warning = warning,
-                                        toastMessage = toastMsg
+                                        warning = warning
                                     ) {
                                         deleteDictionary(fileInfo.language, toastMsg)
                                     }
@@ -175,9 +173,7 @@ class SettingsViewModel(
                                 deleteAction = {
                                     showDeleteConfirmation(
                                         title = "Delete $srcName → $tgtName Translation?",
-                                        message = "You can re-download it anytime.",
-                                        warning = null,
-                                        toastMessage = toastMsg
+                                        message = "You can re-download it anytime."
                                     ) {
                                         deleteTranslation(
                                             fileInfo.sourceLanguage,
@@ -219,7 +215,6 @@ class SettingsViewModel(
         title: String,
         message: String,
         warning: String? = null,
-        toastMessage: String,
         onConfirm: () -> Unit
     ) {
         state = state.copy(
@@ -227,7 +222,6 @@ class SettingsViewModel(
                 title = title,
                 message = message,
                 warning = warning,
-                toastMessage = toastMessage,
                 onConfirm = onConfirm
             )
         )
@@ -1570,7 +1564,7 @@ private fun CancellableProgressIndicator(
             ) {
                 Icon(
                     imageVector = Icons.Rounded.Close,
-                    contentDescription = "Cancel download",
+                    contentDescription = null, // Parent provides accessibility label
                     modifier = Modifier.size(iconSize),
                     tint = MaterialTheme.colorScheme.onSurfaceVariant
                 )
@@ -1845,7 +1839,6 @@ private fun SettingsScreenPreviewWithDeleteConfirmation(
                     title = "Delete English Dictionary?",
                     message = "You can re-download it anytime.",
                     warning = "This will also remove 2 translations.",
-                    toastMessage = "English dictionary deleted",
                     onConfirm = {}
                 )
             )

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/SettingsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/SettingsScreen.kt
@@ -13,6 +13,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
 import androidx.compose.material.icons.automirrored.filled.VolumeUp
 import androidx.compose.material.icons.filled.*
+import androidx.compose.material.icons.rounded.Close
 import androidx.compose.material.icons.outlined.Feedback
 import androidx.compose.material.icons.outlined.Info
 import androidx.compose.material3.*
@@ -22,6 +23,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.compose.LifecycleResumeEffect
@@ -428,6 +430,10 @@ class SettingsViewModel(
         }
     }
 
+    fun cancelDownload(downloadKey: String) {
+        downloadCoordinator.cancel(downloadKey)
+    }
+
     override fun onCleared() {
         super.onCleared()
         ttsManager.stop()
@@ -469,6 +475,7 @@ class SettingsViewModel(
 
                         DownloadStatus.Cancelled -> {
                             downloadCoordinator.clear(downloadKey)
+                            snackbarHostState.showSnackbar("Download cancelled")
                             cancel()
                         }
 
@@ -516,6 +523,7 @@ fun SettingsScreen(
         onConfirmDelete = { viewModel.confirmDelete() },
         onDismissDeleteConfirmation = { viewModel.dismissDeleteConfirmation() },
         onDownloadDictionary = { language -> viewModel.downloadDictionary(language) },
+        onCancelDownload = { key -> viewModel.cancelDownload(key) },
         onDownloadTranslation = { src, tgt -> viewModel.downloadTranslation(src, tgt) },
         onToggleDictionaryExpansion = { languageCode -> viewModel.toggleDictionaryExpansion(languageCode) },
         wordDetailLabel = wordDetailLabel,
@@ -539,6 +547,7 @@ fun SettingsScreenContent(
     onConfirmDelete: () -> Unit = {},
     onDismissDeleteConfirmation: () -> Unit = {},
     onDownloadDictionary: (Language) -> Unit = {},
+    onCancelDownload: (String) -> Unit = {},
     onDownloadTranslation: (Language, Language) -> Unit = { _, _ -> },
     onToggleDictionaryExpansion: (String) -> Unit = {},
     wordDetailLabel: String? = null,
@@ -640,6 +649,7 @@ fun SettingsScreenContent(
                                         isExpanded = state.expandedDictionaries.contains(langInfo.language.code),
                                         onExpand = { onToggleDictionaryExpansion(langInfo.language.code) },
                                         onDownloadDictionary = { onDownloadDictionary(langInfo.language) },
+                                        onCancelDownload = onCancelDownload,
                                         onDeleteDictionary = { dictDb?.deleteAction?.invoke() },
                                         onDownloadTranslation = { tgtLang ->
                                             onDownloadTranslation(langInfo.language, tgtLang)
@@ -696,6 +706,7 @@ fun SettingsScreenContent(
                                         isExpanded = state.expandedDictionaries.contains(langInfo.language.code),
                                         onExpand = { onToggleDictionaryExpansion(langInfo.language.code) },
                                         onDownloadDictionary = { onDownloadDictionary(langInfo.language) },
+                                        onCancelDownload = onCancelDownload,
                                         onDeleteDictionary = { dictDb?.deleteAction?.invoke() },
                                         onDownloadTranslation = { tgtLang ->
                                             onDownloadTranslation(langInfo.language, tgtLang)
@@ -841,6 +852,7 @@ private fun DictionaryCard(
     isExpanded: Boolean,
     onExpand: () -> Unit,
     onDownloadDictionary: () -> Unit,
+    onCancelDownload: (String) -> Unit,
     onDeleteDictionary: () -> Unit,
     onDownloadTranslation: (Language) -> Unit,
     onDeleteTranslation: (Language) -> Unit,
@@ -922,10 +934,10 @@ private fun DictionaryCard(
                     contentAlignment = Alignment.Center
                 ) {
                     if (dictDownloading) {
-                        CircularProgressIndicator(
-                            modifier = Modifier.size(24.dp),
-                            strokeWidth = 2.dp,
-                            progress = { dictProgress?.percent?.toFloat()?.div(100f) ?: 0f }
+                        CancellableProgressIndicator(
+                            progress = dictProgress?.percent?.toFloat()?.div(100f) ?: 0f,
+                            onCancel = { onCancelDownload(dictDownloadKey) },
+                            size = 36.dp
                         )
                     } else if (isDownloaded) {
                         IconButton(onClick = onDeleteDictionary) {
@@ -990,6 +1002,7 @@ private fun DictionaryCard(
                             isDownloading = transDownloading,
                             downloadProgress = transProgress,
                             onDownload = { onDownloadTranslation(translation.targetLanguage) },
+                            onCancel = { onCancelDownload(transDownloadKey) },
                             onDelete = { onDeleteTranslation(translation.targetLanguage) }
                         )
                     }
@@ -1007,6 +1020,7 @@ private fun TranslationItem(
     isDownloading: Boolean,
     downloadProgress: DownloadProgress?,
     onDownload: () -> Unit,
+    onCancel: () -> Unit,
     onDelete: () -> Unit
 ) {
     Surface(
@@ -1044,10 +1058,10 @@ private fun TranslationItem(
                 contentAlignment = Alignment.Center
             ) {
                 if (isDownloading) {
-                    CircularProgressIndicator(
-                        modifier = Modifier.size(20.dp),
-                        strokeWidth = 2.dp,
-                        progress = { downloadProgress?.percent?.toFloat()?.div(100f) ?: 0f }
+                    CancellableProgressIndicator(
+                        progress = downloadProgress?.percent?.toFloat()?.div(100f) ?: 0f,
+                        onCancel = onCancel,
+                        size = 32.dp
                     )
                 } else if (isDownloaded) {
                     IconButton(onClick = onDelete) {
@@ -1437,6 +1451,53 @@ private fun VoiceItem(
                     contentDescription = "Selected",
                     tint = MaterialTheme.colorScheme.onPrimaryContainer,
                     modifier = Modifier.size(20.dp)
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun CancellableProgressIndicator(
+    progress: Float,
+    onCancel: () -> Unit,
+    modifier: Modifier = Modifier,
+    size: Dp = 40.dp
+) {
+    val iconSize = size * 0.4f
+    val strokeWidth = 2.5.dp
+
+    Box(
+        modifier = modifier
+            .size(size)
+            .clip(CircleShape)
+            .clickable(onClick = onCancel),
+        contentAlignment = Alignment.Center
+    ) {
+        // Progress ring with track
+        CircularProgressIndicator(
+            progress = { progress },
+            modifier = Modifier.size(size),
+            strokeWidth = strokeWidth,
+            trackColor = MaterialTheme.colorScheme.surfaceVariant,
+            color = MaterialTheme.colorScheme.primary
+        )
+
+        // Cancel icon with subtle background
+        Surface(
+            modifier = Modifier.size(iconSize + 6.dp),
+            shape = CircleShape,
+            color = MaterialTheme.colorScheme.surfaceVariant
+        ) {
+            Box(
+                modifier = Modifier.fillMaxSize(),
+                contentAlignment = Alignment.Center
+            ) {
+                Icon(
+                    imageVector = Icons.Rounded.Close,
+                    contentDescription = "Cancel download",
+                    modifier = Modifier.size(iconSize),
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant
                 )
             }
         }


### PR DESCRIPTION
                                                                                                                                                                  
  ## Summary                                                                                                                                                               
  - Add cancel button to download progress indicators                                                                                                                      
  - Improve delete confirmation dialog with clearer messaging                                                                                                              
  - Match Settings screen title style with Favorites screen                                                                                                                
                                                                                                                                                                           
  ## Test plan                                                                                                                                                             
  - [ ] Test cancelling a dictionary download in progress                                                                                                                  
  - [ ] Test cancelling a translation download in progress                                                                                                                 
  - [ ] Test delete confirmation dialog for dictionary (with translations)                                                                                                 
  - [ ] Test delete confirmation dialog for translation                                                                                                                    
  - [ ] Verify toast messages after deletion are specific (e.g., "English dictionary deleted")                                                                             
  - [ ] Verify Settings title style matches Favorites screen         


Didn't solve the issue: download icon freezes after repetitive taps. Claude was chasing his tail and spending credits.   
Didn't solve: download progress bar flashes on tap.
Claudine is not on top of her form today.