### PR TITLE
Add language switcher to favorites screen (#187)

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -97,6 +97,7 @@ kotlin {
         }
         commonTest.dependencies {
             implementation(libs.kotlin.test)
+            implementation(libs.kotlinx.coroutinesTest)
         }
         desktopMain.dependencies {
             implementation(compose.desktop.currentOs)

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/FavoritesScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/FavoritesScreen.kt
@@ -124,7 +124,7 @@ class FavoritesViewModel(
         state = content.copy(isLanguageDropdownExpanded = expanded)
     }
 
-    private suspend fun loadFavoritesInternal(query: String) {
+    internal suspend fun loadFavoritesInternal(query: String) {
         val currentContent = state as? FavoritesUiState.Content
         val currentSenses = currentContent?.senses.orEmpty()
         val currentById = currentSenses.associateBy { it.senseId }
@@ -191,7 +191,8 @@ class FavoritesViewModel(
             favoriteLemmas = allFavorites.map { it.lemma }.toSet(),
             availableLanguages = availableLanguages,
             selectedLanguage = selectedLanguage,
-            isLanguageDropdownExpanded = currentContent?.isLanguageDropdownExpanded ?: false
+            isLanguageDropdownExpanded = if (availableLanguages.size > 1)
+                currentContent?.isLanguageDropdownExpanded ?: false else false
         )
 
         prefetchSenses(senses.take(PREFETCH_LIMIT))

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/FavoritesScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/FavoritesScreen.kt
@@ -95,10 +95,13 @@ class FavoritesViewModel(
             queryFlow
                 .debounce(QUERY_DEBOUNCE_MS)
                 .flatMapLatest { queryState ->
-                    flow { emit(loadFavoritesInternal(queryState.query)) }
+                    flow { emit(computeFavoritesState(queryState.query)) }
                         .flowOn(Dispatchers.Default)
                 }
-                .collect { }
+                .collect { newState ->
+                    state = newState
+                    prefetchSenses(newState.senses.take(PREFETCH_LIMIT))
+                }
         }
     }
 
@@ -125,7 +128,11 @@ class FavoritesViewModel(
         state = content.copy(isLanguageDropdownExpanded = expanded)
     }
 
-    internal suspend fun loadFavoritesInternal(query: String) {
+    /**
+     * Computes the new favorites state from the repository. Safe to call from any dispatcher.
+     * Returns the new [FavoritesUiState.Content] without mutating [state].
+     */
+    internal suspend fun computeFavoritesState(query: String): FavoritesUiState.Content {
         val currentContent = state as? FavoritesUiState.Content
         val currentSenses = currentContent?.senses.orEmpty()
         val currentById = currentSenses.associateBy { it.senseId }
@@ -185,7 +192,7 @@ class FavoritesViewModel(
             buildSenseItem(favorite, cached, existing)
         }
 
-        state = FavoritesUiState.Content(
+        return FavoritesUiState.Content(
             senses = senses,
             query = query,
             hasAnyFavorites = hasAnyFavorites,
@@ -195,9 +202,14 @@ class FavoritesViewModel(
             isLanguageDropdownExpanded = if (availableLanguages.size > 1)
                 currentContent?.isLanguageDropdownExpanded ?: false else false
         )
-
-        prefetchSenses(senses.take(PREFETCH_LIMIT))
     }
+
+    /** Computes and applies favorites state. Exposed for tests; production code uses the
+     *  debounced flow or [toggleFavorite] which handle threading via [Dispatchers.Default]. */
+    internal suspend fun loadAndApplyState(query: String) {
+        state = computeFavoritesState(query)
+    }
+
 
     private fun buildSenseItem(
         favorite: Favorite,
@@ -255,7 +267,9 @@ class FavoritesViewModel(
 
             // Recompute languages and filtered senses from repository (handles query
             // filtering, language switches, and all edge cases correctly)
-            withContext(Dispatchers.Default) { loadFavoritesInternal(content.query) }
+            val newState = withContext(Dispatchers.Default) { computeFavoritesState(content.query) }
+            state = newState
+            prefetchSenses(newState.senses.take(PREFETCH_LIMIT))
 
             // Show snackbar with an undo option
             val result = snackbarHostState.showSnackbar(

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/FavoritesScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/FavoritesScreen.kt
@@ -24,8 +24,6 @@ import com.slovy.slovymovyapp.data.Language
 import com.slovy.slovymovyapp.data.favorites.Favorite
 import com.slovy.slovymovyapp.data.favorites.FavoritesRepository
 import com.slovy.slovymovyapp.data.remote.*
-import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.tooling.preview.PreviewParameter
 import com.slovy.slovymovyapp.ui.components.AppSearchBar
 import com.slovy.slovymovyapp.ui.components.CompactEmptyState
 import com.slovy.slovymovyapp.ui.components.EmptyState

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/FavoritesScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/FavoritesScreen.kt
@@ -24,6 +24,9 @@ import com.slovy.slovymovyapp.data.Language
 import com.slovy.slovymovyapp.data.favorites.Favorite
 import com.slovy.slovymovyapp.data.favorites.FavoritesRepository
 import com.slovy.slovymovyapp.data.remote.*
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewParameter
+import com.slovy.slovymovyapp.ui.components.AppSearchBar
 import com.slovy.slovymovyapp.ui.components.CompactEmptyState
 import com.slovy.slovymovyapp.ui.components.EmptyState
 import com.slovy.slovymovyapp.ui.word.*
@@ -453,7 +456,7 @@ fun FavoritesScreenContent(
                             horizontalArrangement = Arrangement.spacedBy(8.dp),
                             verticalAlignment = Alignment.CenterVertically
                         ) {
-                            com.slovy.slovymovyapp.ui.components.AppSearchBar(
+                            AppSearchBar(
                                 query = state.query,
                                 onQueryChange = onQueryChange,
                                 modifier = Modifier.weight(1f),
@@ -850,10 +853,10 @@ fun PreviewFavoritesScreenLoadingAndError(
     }
 }
 
-@androidx.compose.ui.tooling.preview.Preview
+@Preview
 @Composable
 fun PreviewFavoritesScreenMultiLanguage(
-    @androidx.compose.ui.tooling.preview.PreviewParameter(ThemePreviewProvider::class) isDark: Boolean
+    @PreviewParameter(ThemePreviewProvider::class) isDark: Boolean
 ) {
     ThemedPreview(darkTheme = isDark) {
         val state = FavoritesUiState.Content(

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/FavoritesScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/FavoritesScreen.kt
@@ -119,14 +119,9 @@ class FavoritesViewModel(
         queryFlow.value = QueryState(content.query, Uuid.random())
     }
 
-    fun toggleLanguageDropdown() {
+    fun setLanguageDropdownExpanded(expanded: Boolean) {
         val content = state as? FavoritesUiState.Content ?: return
-        state = content.copy(isLanguageDropdownExpanded = !content.isLanguageDropdownExpanded)
-    }
-
-    fun dismissLanguageDropdown() {
-        val content = state as? FavoritesUiState.Content ?: return
-        state = content.copy(isLanguageDropdownExpanded = false)
+        state = content.copy(isLanguageDropdownExpanded = expanded)
     }
 
     private suspend fun loadFavoritesInternal(query: String) {
@@ -251,39 +246,14 @@ class FavoritesViewModel(
             // Fetch the favorite to get its createdAt before removal
             val favorite = favoritesRepository.getOne(senseId, item.targetLang) ?: return@launch
 
-            // Remove from repository and UI
+            // Remove from repository, then remove from displayed list for immediate feedback
             favoritesRepository.remove(senseId, favorite.language)
             val content = state as? FavoritesUiState.Content ?: return@launch
-            val remainingSenses = content.senses.filter { it.senseId != senseId }
+            state = content.copy(senses = content.senses.filter { it.senseId != senseId })
 
-            // Derive available languages from all languages, removing current only if no senses remain
-            val remainingLanguages = if (remainingSenses.isEmpty()) {
-                content.availableLanguages.filter { it != content.selectedLanguage }
-            } else {
-                content.availableLanguages
-            }
-            val needsLanguageSwitch = content.selectedLanguage !in remainingLanguages
-            val newSelectedLanguage = if (needsLanguageSwitch) {
-                remainingLanguages.firstOrNull()
-            } else {
-                content.selectedLanguage
-            }
-
-            if (needsLanguageSwitch && newSelectedLanguage != null) {
-                // Set new language without clearing senses to avoid empty screen flash,
-                // then load new language's favorites directly (bypassing debounce)
-                state = content.copy(
-                    availableLanguages = remainingLanguages,
-                    selectedLanguage = newSelectedLanguage
-                )
-                loadFavoritesInternal(content.query)
-            } else {
-                state = content.copy(
-                    senses = remainingSenses,
-                    availableLanguages = remainingLanguages,
-                    selectedLanguage = newSelectedLanguage
-                )
-            }
+            // Recompute languages and filtered senses from repository (handles query
+            // filtering, language switches, and all edge cases correctly)
+            loadFavoritesInternal(content.query)
 
             // Show snackbar with an undo option
             val result = snackbarHostState.showSnackbar(
@@ -368,8 +338,7 @@ fun FavoritesScreen(
         onNavigateToSettings = onNavigateToSettings,
         onPrefetchVisible = { senses, range -> viewModel.prefetchVisibleRange(senses, range) },
         onLanguageSelected = { viewModel.setSelectedLanguage(it) },
-        onToggleLanguageDropdown = { viewModel.toggleLanguageDropdown() },
-        onDismissLanguageDropdown = { viewModel.dismissLanguageDropdown() }
+        onSetLanguageDropdownExpanded = { viewModel.setLanguageDropdownExpanded(it) }
     )
 }
 
@@ -389,8 +358,7 @@ fun FavoritesScreenContent(
     onNavigateToSettings: () -> Unit = {},
     onPrefetchVisible: (List<FavoriteSenseItem>, IntRange) -> Unit = { _, _ -> },
     onLanguageSelected: (Language) -> Unit = {},
-    onToggleLanguageDropdown: () -> Unit = {},
-    onDismissLanguageDropdown: () -> Unit = {}
+    onSetLanguageDropdownExpanded: (Boolean) -> Unit = {}
 ) {
     val focusManager = LocalFocusManager.current
     Scaffold(
@@ -476,7 +444,7 @@ fun FavoritesScreenContent(
 
                                 ExposedDropdownMenuBox(
                                     expanded = state.isLanguageDropdownExpanded,
-                                    onExpandedChange = { onToggleLanguageDropdown() }
+                                    onExpandedChange = onSetLanguageDropdownExpanded
                                 ) {
                                     Surface(
                                         modifier = Modifier
@@ -503,7 +471,7 @@ fun FavoritesScreenContent(
                                     }
                                     ExposedDropdownMenu(
                                         expanded = state.isLanguageDropdownExpanded,
-                                        onDismissRequest = onDismissLanguageDropdown,
+                                        onDismissRequest = { onSetLanguageDropdownExpanded(false) },
                                         modifier = Modifier.width(200.dp),
                                         shape = MaterialTheme.shapes.small,
                                         containerColor = MaterialTheme.colorScheme.surfaceContainerHigh,
@@ -522,7 +490,7 @@ fun FavoritesScreenContent(
                                                 },
                                                 onClick = {
                                                     onLanguageSelected(language)
-                                                    onDismissLanguageDropdown()
+                                                    onSetLanguageDropdownExpanded(false)
                                                 },
                                                 contentPadding = ExposedDropdownMenuDefaults.ItemContentPadding
                                             )

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/FavoritesScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/FavoritesScreen.kt
@@ -95,7 +95,8 @@ class FavoritesViewModel(
             queryFlow
                 .debounce(QUERY_DEBOUNCE_MS)
                 .flatMapLatest { queryState ->
-                    flow { emit(computeFavoritesState(queryState.query)) }
+                    val snapshot = state as? FavoritesUiState.Content
+                    flow { emit(computeFavoritesState(queryState.query, snapshot)) }
                         .flowOn(Dispatchers.Default)
                 }
                 .collect { newState ->
@@ -131,9 +132,13 @@ class FavoritesViewModel(
     /**
      * Computes the new favorites state from the repository. Safe to call from any dispatcher.
      * Returns the new [FavoritesUiState.Content] without mutating [state].
+     *
+     * @param currentContent snapshot of the current UI state, captured on Main before dispatching.
      */
-    internal suspend fun computeFavoritesState(query: String): FavoritesUiState.Content {
-        val currentContent = state as? FavoritesUiState.Content
+    internal suspend fun computeFavoritesState(
+        query: String,
+        currentContent: FavoritesUiState.Content? = state as? FavoritesUiState.Content
+    ): FavoritesUiState.Content {
         val currentSenses = currentContent?.senses.orEmpty()
         val currentById = currentSenses.associateBy { it.senseId }
 
@@ -267,7 +272,8 @@ class FavoritesViewModel(
 
             // Recompute languages and filtered senses from repository (handles query
             // filtering, language switches, and all edge cases correctly)
-            val newState = withContext(Dispatchers.Default) { computeFavoritesState(content.query) }
+            val snapshot = state as? FavoritesUiState.Content
+            val newState = withContext(Dispatchers.Default) { computeFavoritesState(content.query, snapshot) }
             state = newState
             prefetchSenses(newState.senses.take(PREFETCH_LIMIT))
 

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/FavoritesScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/FavoritesScreen.kt
@@ -137,7 +137,7 @@ class FavoritesViewModel(
      */
     internal suspend fun computeFavoritesState(
         query: String,
-        currentContent: FavoritesUiState.Content? = state as? FavoritesUiState.Content
+        currentContent: FavoritesUiState.Content?
     ): FavoritesUiState.Content {
         val currentSenses = currentContent?.senses.orEmpty()
         val currentById = currentSenses.associateBy { it.senseId }
@@ -212,7 +212,7 @@ class FavoritesViewModel(
     /** Computes and applies favorites state. Exposed for tests; production code uses the
      *  debounced flow or [toggleFavorite] which handle threading via [Dispatchers.Default]. */
     internal suspend fun loadAndApplyState(query: String) {
-        state = computeFavoritesState(query)
+        state = computeFavoritesState(query, state as? FavoritesUiState.Content)
     }
 
 

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/FavoritesScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/FavoritesScreen.kt
@@ -30,6 +30,7 @@ import com.slovy.slovymovyapp.ui.word.*
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.withContext
 import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.launch
 import kotlinx.datetime.*
@@ -254,7 +255,7 @@ class FavoritesViewModel(
 
             // Recompute languages and filtered senses from repository (handles query
             // filtering, language switches, and all edge cases correctly)
-            loadFavoritesInternal(content.query)
+            withContext(Dispatchers.Default) { loadFavoritesInternal(content.query) }
 
             // Show snackbar with an undo option
             val result = snackbarHostState.showSnackbar(

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/FavoritesScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/FavoritesScreen.kt
@@ -58,9 +58,13 @@ sealed interface FavoritesUiState {
         val senses: List<FavoriteSenseItem>,
         val query: String = "",
         val hasAnyFavorites: Boolean = false,
-        val favoriteLemmas: Set<String> = emptySet()
+        val favoriteLemmas: Set<String> = emptySet(),
+        val availableLanguages: List<Language> = emptyList(),
+        val selectedLanguage: Language? = null,
+        val isLanguageDropdownExpanded: Boolean = false
     ) : FavoritesUiState {
         val showNoResults: Boolean get() = senses.isEmpty() && query.isNotEmpty()
+        val showLanguagePicker: Boolean get() = availableLanguages.size > 1
     }
 }
 
@@ -108,33 +112,73 @@ class FavoritesViewModel(
         queryFlow.value = QueryState(currentQuery, Uuid.random())
     }
 
+    fun setSelectedLanguage(language: Language) {
+        val content = state as? FavoritesUiState.Content ?: return
+        if (content.selectedLanguage == language) return
+        state = content.copy(selectedLanguage = language)
+        queryFlow.value = QueryState(content.query, Uuid.random())
+    }
+
+    fun toggleLanguageDropdown() {
+        val content = state as? FavoritesUiState.Content ?: return
+        state = content.copy(isLanguageDropdownExpanded = !content.isLanguageDropdownExpanded)
+    }
+
+    fun dismissLanguageDropdown() {
+        val content = state as? FavoritesUiState.Content ?: return
+        state = content.copy(isLanguageDropdownExpanded = false)
+    }
+
     private suspend fun loadFavoritesInternal(query: String) {
-        val currentSenses = (state as? FavoritesUiState.Content)?.senses.orEmpty()
+        val currentContent = state as? FavoritesUiState.Content
+        val currentSenses = currentContent?.senses.orEmpty()
         val currentById = currentSenses.associateBy { it.senseId }
 
         val allFavorites = favoritesRepository.getAllGroupedByLangAndLemma()
         val hasAnyFavorites = allFavorites.isNotEmpty()
 
+        // Derive available languages from all favorites
+        val availableLanguages = allFavorites.map { it.language }.distinct().sorted()
+
+        // Determine selected language: keep current if still valid, else first available
+        val selectedLanguage = when {
+            availableLanguages.size <= 1 -> availableLanguages.firstOrNull()
+            currentContent?.selectedLanguage in availableLanguages -> currentContent?.selectedLanguage
+            else -> availableLanguages.first()
+        }
+
+        // Filter favorites to selected language when multi-language
+        val langFiltered = if (availableLanguages.size > 1 && selectedLanguage != null) {
+            allFavorites.filter { it.language == selectedLanguage }
+        } else {
+            allFavorites
+        }
+
         val trimmedQuery = query.trim()
         val favorites = if (trimmedQuery.isEmpty()) {
-            allFavorites
+            langFiltered
         } else {
-            // Search by lemma
+            // Search by lemma — scope to language-filtered favorites
             val lemmaMatches = favoritesRepository.searchByLemma(trimmedQuery)
-            val lemmaMatchIds = lemmaMatches.map { it.senseId }.toSet()
+            val langFilteredSenseIds = langFiltered.map { it.senseId }.toSet()
+            val lemmaMatchIds = lemmaMatches.filter { it.senseId in langFilteredSenseIds }
+                .map { it.senseId }.toSet()
 
-            // Search by translation - for each source language in favorites
-            val sourceLanguages = allFavorites.map { it.language }.distinct()
+            // Search by translation — scoped to selected language
+            val searchLanguages = if (selectedLanguage != null) listOf(selectedLanguage)
+            else langFiltered.map { it.language }.distinct()
 
-            val translationMatchIds = sourceLanguages.flatMap { lang ->
-                dictionaryRepository.searchSenseIdsByTranslation(allFavorites.filter { it.language == lang }
-                    .map { it.senseId }.toSet(), trimmedQuery, lang)
+            val translationMatchIds = searchLanguages.flatMap { lang ->
+                dictionaryRepository.searchSenseIdsByTranslation(
+                    langFiltered.filter { it.language == lang }.map { it.senseId }.toSet(),
+                    trimmedQuery, lang
+                )
             }.toSet()
 
             // Prioritize lemma matches first, then translation-only matches
-            val lemmaMatchFavorites = allFavorites.filter { it.senseId in lemmaMatchIds }
+            val lemmaMatchFavorites = langFiltered.filter { it.senseId in lemmaMatchIds }
             val translationOnlyIds = translationMatchIds - lemmaMatchIds
-            val translationOnlyFavorites = allFavorites.filter { it.senseId in translationOnlyIds }
+            val translationOnlyFavorites = langFiltered.filter { it.senseId in translationOnlyIds }
 
             lemmaMatchFavorites + translationOnlyFavorites
         }
@@ -149,7 +193,10 @@ class FavoritesViewModel(
             senses = senses,
             query = query,
             hasAnyFavorites = hasAnyFavorites,
-            favoriteLemmas = allFavorites.map { it.lemma }.toSet()
+            favoriteLemmas = allFavorites.map { it.lemma }.toSet(),
+            availableLanguages = availableLanguages,
+            selectedLanguage = selectedLanguage,
+            isLanguageDropdownExpanded = currentContent?.isLanguageDropdownExpanded ?: false
         )
 
         prefetchSenses(senses.take(PREFETCH_LIMIT))
@@ -207,7 +254,36 @@ class FavoritesViewModel(
             // Remove from repository and UI
             favoritesRepository.remove(senseId, favorite.language)
             val content = state as? FavoritesUiState.Content ?: return@launch
-            state = content.copy(senses = content.senses.filter { it.senseId != senseId })
+            val remainingSenses = content.senses.filter { it.senseId != senseId }
+
+            // Derive available languages from all languages, removing current only if no senses remain
+            val remainingLanguages = if (remainingSenses.isEmpty()) {
+                content.availableLanguages.filter { it != content.selectedLanguage }
+            } else {
+                content.availableLanguages
+            }
+            val needsLanguageSwitch = content.selectedLanguage !in remainingLanguages
+            val newSelectedLanguage = if (needsLanguageSwitch) {
+                remainingLanguages.firstOrNull()
+            } else {
+                content.selectedLanguage
+            }
+
+            if (needsLanguageSwitch && newSelectedLanguage != null) {
+                // Set new language without clearing senses to avoid empty screen flash,
+                // then load new language's favorites directly (bypassing debounce)
+                state = content.copy(
+                    availableLanguages = remainingLanguages,
+                    selectedLanguage = newSelectedLanguage
+                )
+                loadFavoritesInternal(content.query)
+            } else {
+                state = content.copy(
+                    senses = remainingSenses,
+                    availableLanguages = remainingLanguages,
+                    selectedLanguage = newSelectedLanguage
+                )
+            }
 
             // Show snackbar with an undo option
             val result = snackbarHostState.showSnackbar(
@@ -290,7 +366,10 @@ fun FavoritesScreen(
         wordDetailLabel = wordDetailLabel,
         onNavigateToLastWordDetail = onNavigateToLastWordDetail,
         onNavigateToSettings = onNavigateToSettings,
-        onPrefetchVisible = { senses, range -> viewModel.prefetchVisibleRange(senses, range) }
+        onPrefetchVisible = { senses, range -> viewModel.prefetchVisibleRange(senses, range) },
+        onLanguageSelected = { viewModel.setSelectedLanguage(it) },
+        onToggleLanguageDropdown = { viewModel.toggleLanguageDropdown() },
+        onDismissLanguageDropdown = { viewModel.dismissLanguageDropdown() }
     )
 }
 
@@ -308,7 +387,10 @@ fun FavoritesScreenContent(
     wordDetailLabel: String? = null,
     onNavigateToLastWordDetail: () -> Unit = {},
     onNavigateToSettings: () -> Unit = {},
-    onPrefetchVisible: (List<FavoriteSenseItem>, IntRange) -> Unit = { _, _ -> }
+    onPrefetchVisible: (List<FavoriteSenseItem>, IntRange) -> Unit = { _, _ -> },
+    onLanguageSelected: (Language) -> Unit = {},
+    onToggleLanguageDropdown: () -> Unit = {},
+    onDismissLanguageDropdown: () -> Unit = {}
 ) {
     val focusManager = LocalFocusManager.current
     Scaffold(
@@ -374,14 +456,81 @@ fun FavoritesScreenContent(
                         .padding(innerPadding)
                 ) {
                     if (state.hasAnyFavorites) {
-                        com.slovy.slovymovyapp.ui.components.AppSearchBar(
-                            query = state.query,
-                            onQueryChange = onQueryChange,
+                        Row(
                             modifier = Modifier
                                 .fillMaxWidth()
                                 .padding(horizontal = 16.dp),
-                            placeholder = "Type a word..."
-                        )
+                            horizontalArrangement = Arrangement.spacedBy(8.dp),
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            com.slovy.slovymovyapp.ui.components.AppSearchBar(
+                                query = state.query,
+                                onQueryChange = onQueryChange,
+                                modifier = Modifier.weight(1f),
+                                placeholder = "Type a word..."
+                            )
+
+                            if (state.showLanguagePicker) {
+                                val currentLanguage = state.selectedLanguage
+                                    ?: state.availableLanguages.firstOrNull()
+
+                                ExposedDropdownMenuBox(
+                                    expanded = state.isLanguageDropdownExpanded,
+                                    onExpandedChange = { onToggleLanguageDropdown() }
+                                ) {
+                                    Surface(
+                                        modifier = Modifier
+                                            .menuAnchor(ExposedDropdownMenuAnchorType.PrimaryEditable)
+                                            .height(56.dp)
+                                            .widthIn(min = 56.dp),
+                                        shape = MaterialTheme.shapes.extraLarge,
+                                        tonalElevation = 1.dp,
+                                        shadowElevation = 1.dp,
+                                        color = MaterialTheme.colorScheme.surfaceContainerHighest
+                                    ) {
+                                        Row(
+                                            modifier = Modifier.padding(start = 16.dp, end = 8.dp),
+                                            verticalAlignment = Alignment.CenterVertically
+                                        ) {
+                                            Text(
+                                                text = currentLanguage?.flag ?: "",
+                                                style = MaterialTheme.typography.bodyLarge
+                                            )
+                                            ExposedDropdownMenuDefaults.TrailingIcon(
+                                                expanded = state.isLanguageDropdownExpanded
+                                            )
+                                        }
+                                    }
+                                    ExposedDropdownMenu(
+                                        expanded = state.isLanguageDropdownExpanded,
+                                        onDismissRequest = onDismissLanguageDropdown,
+                                        modifier = Modifier.width(200.dp),
+                                        shape = MaterialTheme.shapes.small,
+                                        containerColor = MaterialTheme.colorScheme.surfaceContainerHigh,
+                                        shadowElevation = 2.dp
+                                    ) {
+                                        state.availableLanguages.forEach { language ->
+                                            DropdownMenuItem(
+                                                text = {
+                                                    Row(
+                                                        horizontalArrangement = Arrangement.spacedBy(8.dp),
+                                                        verticalAlignment = Alignment.CenterVertically
+                                                    ) {
+                                                        Text(language.flag)
+                                                        Text(language.selfName)
+                                                    }
+                                                },
+                                                onClick = {
+                                                    onLanguageSelected(language)
+                                                    onDismissLanguageDropdown()
+                                                },
+                                                contentPadding = ExposedDropdownMenuDefaults.ItemContentPadding
+                                            )
+                                        }
+                                    }
+                                }
+                            }
+                        }
                         Spacer(modifier = Modifier.height(4.dp))
                     }
 
@@ -706,6 +855,37 @@ fun PreviewFavoritesScreenLoadingAndError(
                 )
             ),
             hasAnyFavorites = true
+        )
+        FavoritesScreenContent(state = state)
+    }
+}
+
+@androidx.compose.ui.tooling.preview.Preview
+@Composable
+fun PreviewFavoritesScreenMultiLanguage(
+    @androidx.compose.ui.tooling.preview.PreviewParameter(ThemePreviewProvider::class) isDark: Boolean
+) {
+    ThemedPreview(darkTheme = isDark) {
+        val state = FavoritesUiState.Content(
+            senses = listOf(
+                createSenseItem(
+                    senseId = "run-1",
+                    lemma = "run",
+                    targetLang = Language.ENGLISH,
+                    sense = createMockSense("run-1", "to move swiftly on foot"),
+                    pos = PartOfSpeech.VERB
+                ),
+                createSenseItem(
+                    senseId = "book-1",
+                    lemma = "book",
+                    targetLang = Language.ENGLISH,
+                    sense = createMockSense("book-1", "a written or printed work"),
+                    pos = PartOfSpeech.NOUN
+                )
+            ),
+            hasAnyFavorites = true,
+            availableLanguages = listOf(Language.ENGLISH, Language.POLISH),
+            selectedLanguage = Language.ENGLISH
         )
         FavoritesScreenContent(state = state)
     }

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/FavoritesScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/FavoritesScreen.kt
@@ -202,7 +202,7 @@ class FavoritesViewModel(
             senses = senses,
             query = query,
             hasAnyFavorites = hasAnyFavorites,
-            favoriteLemmas = allFavorites.map { it.lemma }.toSet(),
+            favoriteLemmas = langFiltered.map { it.lemma }.toSet(),
             availableLanguages = availableLanguages,
             selectedLanguage = selectedLanguage,
             isLanguageDropdownExpanded = if (availableLanguages.size > 1)

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/SearchScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/SearchScreen.kt
@@ -198,12 +198,8 @@ class SearchViewModel(
         }
     }
 
-    fun toggleLanguageDropdown() {
-        state = state.copy(isLanguageDropdownExpanded = !state.isLanguageDropdownExpanded)
-    }
-
-    fun dismissLanguageDropdown() {
-        state = state.copy(isLanguageDropdownExpanded = false)
+    fun setLanguageDropdownExpanded(expanded: Boolean) {
+        state = state.copy(isLanguageDropdownExpanded = expanded)
     }
 
     fun setShowLanguageIndicators(show: Boolean) {
@@ -264,8 +260,7 @@ fun SearchScreen(
             viewModel.setSelectedLanguage(language)
             // TODO: search is not relaunched or query
         },
-        onToggleLanguageDropdown = { viewModel.toggleLanguageDropdown() },
-        onDismissLanguageDropdown = { viewModel.dismissLanguageDropdown() },
+        onSetLanguageDropdownExpanded = { viewModel.setLanguageDropdownExpanded(it) },
         onRefreshSuggestions = { viewModel.refreshSuggestionsFromPull() },
         wordDetailLabel = wordDetailLabel,
         onNavigateToWordDetail = onNavigateToWordDetail,
@@ -282,8 +277,7 @@ fun SearchScreenContent(
     onResultSelected: (DictionaryRepository.SearchItem) -> Unit = {},
     onSuggestionSelected: (String) -> Unit = {},
     onLanguageSelected: (Language?) -> Unit = {},
-    onToggleLanguageDropdown: () -> Unit = {},
-    onDismissLanguageDropdown: () -> Unit = {},
+    onSetLanguageDropdownExpanded: (Boolean) -> Unit = {},
     onRefreshSuggestions: () -> Unit = {},
     wordDetailLabel: String? = null,
     onNavigateToWordDetail: () -> Unit = {},
@@ -348,7 +342,7 @@ fun SearchScreenContent(
 
                         ExposedDropdownMenuBox(
                             expanded = state.isLanguageDropdownExpanded,
-                            onExpandedChange = { onToggleLanguageDropdown() }
+                            onExpandedChange = onSetLanguageDropdownExpanded
                         ) {
                             Surface(
                                 modifier = Modifier
@@ -375,7 +369,7 @@ fun SearchScreenContent(
                             }
                             ExposedDropdownMenu(
                                 expanded = state.isLanguageDropdownExpanded,
-                                onDismissRequest = onDismissLanguageDropdown,
+                                onDismissRequest = { onSetLanguageDropdownExpanded(false) },
                                 modifier = Modifier.width(200.dp),
                                 shape = MaterialTheme.shapes.small,
                                 containerColor = MaterialTheme.colorScheme.surfaceContainerHigh,
@@ -394,7 +388,7 @@ fun SearchScreenContent(
                                         },
                                         onClick = {
                                             onLanguageSelected(language)
-                                            onDismissLanguageDropdown()
+                                            onSetLanguageDropdownExpanded(false)
                                         },
                                         contentPadding = ExposedDropdownMenuDefaults.ItemContentPadding
                                     )

--- a/composeApp/src/commonTest/kotlin/com/slovy/slovymovyapp/ui/FavoritesViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/slovy/slovymovyapp/ui/FavoritesViewModelTest.kt
@@ -1,0 +1,208 @@
+package com.slovy.slovymovyapp.ui
+
+import com.slovy.slovymovyapp.data.Language
+import com.slovy.slovymovyapp.data.favorites.FavoritesRepository
+import com.slovy.slovymovyapp.data.remote.DictionaryRepository
+import com.slovy.slovymovyapp.test.BaseTest
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalCoroutinesApi::class)
+open class FavoritesViewModelTest : BaseTest() {
+
+    private val testDispatcher = StandardTestDispatcher()
+
+    @BeforeTest
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+    }
+
+    @AfterTest
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    private fun favoritesRepository(): FavoritesRepository {
+        return FavoritesRepository(testAppDatabaseHolder().database)
+    }
+
+    private fun dictionaryRepository(favoritesRepo: FavoritesRepository): DictionaryRepository {
+        return DictionaryRepository(testDataDbManager(), testLocalDbManager(), favoritesRepo)
+    }
+
+    private fun contentState(vm: FavoritesViewModel): FavoritesUiState.Content {
+        assertIs<FavoritesUiState.Content>(vm.state, "Expected Content but was ${vm.state::class.simpleName}")
+        return vm.state as FavoritesUiState.Content
+    }
+
+    @Test
+    fun initialLoad_singleLanguage_hiddenPicker() = runTest(testDispatcher) {
+        val favRepo = favoritesRepository()
+        favRepo.deleteAll()
+        favRepo.add("s1", Language.ENGLISH, "hello")
+        favRepo.add("s2", Language.ENGLISH, "world")
+
+        val vm = FavoritesViewModel(favRepo, dictionaryRepository(favRepo))
+        vm.loadFavoritesInternal("")
+
+        val content = contentState(vm)
+        assertEquals(2, content.senses.size)
+        assertEquals(Language.ENGLISH, content.selectedLanguage)
+        assertFalse(content.showLanguagePicker, "Picker should be hidden with single language")
+    }
+
+    @Test
+    fun initialLoad_multiLanguage_showsPicker_defaultsToFirst() = runTest(testDispatcher) {
+        val favRepo = favoritesRepository()
+        favRepo.deleteAll()
+        favRepo.add("s1", Language.ENGLISH, "hello")
+        favRepo.add("s2", Language.RUSSIAN, "привет")
+
+        val vm = FavoritesViewModel(favRepo, dictionaryRepository(favRepo))
+        vm.loadFavoritesInternal("")
+
+        val content = contentState(vm)
+        assertTrue(content.showLanguagePicker)
+        assertEquals(listOf(Language.ENGLISH, Language.RUSSIAN), content.availableLanguages)
+        assertEquals(Language.ENGLISH, content.selectedLanguage, "Should default to first language")
+        assertTrue(content.senses.all { it.targetLang == Language.ENGLISH },
+            "Should only show selected language's favorites")
+    }
+
+    @Test
+    fun setSelectedLanguage_filtersFavoritesToThatLanguage() = runTest(testDispatcher) {
+        val favRepo = favoritesRepository()
+        favRepo.deleteAll()
+        favRepo.add("s1", Language.ENGLISH, "hello")
+        favRepo.add("s2", Language.ENGLISH, "world")
+        favRepo.add("s3", Language.RUSSIAN, "привет")
+
+        val vm = FavoritesViewModel(favRepo, dictionaryRepository(favRepo))
+        vm.loadFavoritesInternal("")
+
+        var content = contentState(vm)
+        assertTrue(content.senses.all { it.targetLang == Language.ENGLISH })
+        assertEquals(2, content.senses.size)
+
+        // Switch to Russian — update selectedLanguage then reload
+        vm.setSelectedLanguage(Language.RUSSIAN)
+        vm.loadFavoritesInternal("")
+
+        content = contentState(vm)
+        assertEquals(Language.RUSSIAN, content.selectedLanguage)
+        assertEquals(1, content.senses.size)
+        assertTrue(content.senses.all { it.targetLang == Language.RUSSIAN })
+    }
+
+    @Test
+    fun removingLastFavoriteInLanguage_switchesToOtherLanguage() = runTest(testDispatcher) {
+        val favRepo = favoritesRepository()
+        favRepo.deleteAll()
+        favRepo.add("s1", Language.ENGLISH, "hello")
+        favRepo.add("s2", Language.ENGLISH, "world")
+        favRepo.add("s3", Language.RUSSIAN, "привет")
+
+        val vm = FavoritesViewModel(favRepo, dictionaryRepository(favRepo))
+        vm.loadFavoritesInternal("")
+
+        // Switch to Russian (only 1 favorite)
+        vm.setSelectedLanguage(Language.RUSSIAN)
+        vm.loadFavoritesInternal("")
+        assertEquals(Language.RUSSIAN, contentState(vm).selectedLanguage)
+
+        // Remove the only Russian favorite and reload (simulates toggleFavorite's logic)
+        favRepo.remove("s3", Language.RUSSIAN)
+        vm.loadFavoritesInternal("")
+
+        val content = contentState(vm)
+        assertEquals(Language.ENGLISH, content.selectedLanguage,
+            "Should switch to the remaining language")
+        assertFalse(content.showLanguagePicker, "Picker should hide with single language left")
+        assertEquals(2, content.senses.size, "Should show English favorites")
+    }
+
+    @Test
+    fun removingLastVisibleResult_withActiveQuery_staysOnSameLanguage() = runTest(testDispatcher) {
+        val favRepo = favoritesRepository()
+        favRepo.deleteAll()
+        favRepo.add("s1", Language.ENGLISH, "hello")
+        favRepo.add("s2", Language.ENGLISH, "world")
+        favRepo.add("s3", Language.RUSSIAN, "привет")
+
+        val vm = FavoritesViewModel(favRepo, dictionaryRepository(favRepo))
+        vm.loadFavoritesInternal("")
+
+        // Search for "hello" — only matches s1 in English
+        vm.loadFavoritesInternal("hello")
+
+        var content = contentState(vm)
+        assertEquals(1, content.senses.size)
+        assertEquals("s1", content.senses[0].senseId)
+
+        // Remove "hello" — English still has "world", should stay on English
+        favRepo.remove("s1", Language.ENGLISH)
+        vm.loadFavoritesInternal("hello")
+
+        content = contentState(vm)
+        assertEquals(Language.ENGLISH, content.selectedLanguage,
+            "Should stay on English since 'world' still exists")
+        assertTrue(content.showLanguagePicker, "Picker should remain visible")
+    }
+
+    @Test
+    fun queryResults_scopedToSelectedLanguage() = runTest(testDispatcher) {
+        val favRepo = favoritesRepository()
+        favRepo.deleteAll()
+        // Same lemma in two languages
+        favRepo.add("s1", Language.ENGLISH, "hello")
+        favRepo.add("s2", Language.RUSSIAN, "hello")
+
+        val vm = FavoritesViewModel(favRepo, dictionaryRepository(favRepo))
+        vm.loadFavoritesInternal("")
+
+        // Search for "hello" while on English
+        vm.loadFavoritesInternal("hello")
+
+        val content = contentState(vm)
+        assertEquals(Language.ENGLISH, content.selectedLanguage)
+        assertEquals(1, content.senses.size, "Should only match within selected language")
+        assertEquals("s1", content.senses[0].senseId)
+    }
+
+    @Test
+    fun dropdownExpandedState_resetsWhenPickerBecomesHidden() = runTest(testDispatcher) {
+        val favRepo = favoritesRepository()
+        favRepo.deleteAll()
+        favRepo.add("s1", Language.ENGLISH, "hello")
+        favRepo.add("s2", Language.RUSSIAN, "привет")
+
+        val vm = FavoritesViewModel(favRepo, dictionaryRepository(favRepo))
+        vm.loadFavoritesInternal("")
+
+        // Switch to Russian and open the dropdown
+        vm.setSelectedLanguage(Language.RUSSIAN)
+        vm.loadFavoritesInternal("")
+        vm.setLanguageDropdownExpanded(true)
+        assertTrue(contentState(vm).isLanguageDropdownExpanded)
+
+        // Remove the only Russian favorite — picker becomes hidden
+        favRepo.remove("s2", Language.RUSSIAN)
+        vm.loadFavoritesInternal("")
+
+        val content = contentState(vm)
+        assertFalse(content.showLanguagePicker)
+        assertFalse(content.isLanguageDropdownExpanded,
+            "Dropdown expanded state should reset when picker becomes hidden")
+    }
+}

--- a/composeApp/src/commonTest/kotlin/com/slovy/slovymovyapp/ui/FavoritesViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/slovy/slovymovyapp/ui/FavoritesViewModelTest.kt
@@ -1,5 +1,6 @@
 package com.slovy.slovymovyapp.ui
 
+import androidx.lifecycle.ViewModelStore
 import com.slovy.slovymovyapp.data.Language
 import com.slovy.slovymovyapp.data.favorites.FavoritesRepository
 import com.slovy.slovymovyapp.data.remote.DictionaryRepository
@@ -22,6 +23,7 @@ import kotlin.test.assertTrue
 open class FavoritesViewModelTest : BaseTest() {
 
     private val testDispatcher = StandardTestDispatcher()
+    private val viewModelStore = ViewModelStore()
 
     @BeforeTest
     fun setUp() {
@@ -30,6 +32,7 @@ open class FavoritesViewModelTest : BaseTest() {
 
     @AfterTest
     fun tearDown() {
+        viewModelStore.clear()
         Dispatchers.resetMain()
     }
 
@@ -39,6 +42,15 @@ open class FavoritesViewModelTest : BaseTest() {
 
     private fun dictionaryRepository(favoritesRepo: FavoritesRepository): DictionaryRepository {
         return DictionaryRepository(testDataDbManager(), testLocalDbManager(), favoritesRepo)
+    }
+
+    private fun createViewModel(
+        favRepo: FavoritesRepository,
+        dictRepo: DictionaryRepository = dictionaryRepository(favRepo)
+    ): FavoritesViewModel {
+        val vm = FavoritesViewModel(favRepo, dictRepo)
+        viewModelStore.put("test", vm)
+        return vm
     }
 
     private fun contentState(vm: FavoritesViewModel): FavoritesUiState.Content {
@@ -53,7 +65,7 @@ open class FavoritesViewModelTest : BaseTest() {
         favRepo.add("s1", Language.ENGLISH, "hello")
         favRepo.add("s2", Language.ENGLISH, "world")
 
-        val vm = FavoritesViewModel(favRepo, dictionaryRepository(favRepo))
+        val vm = createViewModel(favRepo)
         vm.loadAndApplyState("")
 
         val content = contentState(vm)
@@ -69,7 +81,7 @@ open class FavoritesViewModelTest : BaseTest() {
         favRepo.add("s1", Language.ENGLISH, "hello")
         favRepo.add("s2", Language.RUSSIAN, "привет")
 
-        val vm = FavoritesViewModel(favRepo, dictionaryRepository(favRepo))
+        val vm = createViewModel(favRepo)
         vm.loadAndApplyState("")
 
         val content = contentState(vm)
@@ -88,7 +100,7 @@ open class FavoritesViewModelTest : BaseTest() {
         favRepo.add("s2", Language.ENGLISH, "world")
         favRepo.add("s3", Language.RUSSIAN, "привет")
 
-        val vm = FavoritesViewModel(favRepo, dictionaryRepository(favRepo))
+        val vm = createViewModel(favRepo)
         vm.loadAndApplyState("")
 
         var content = contentState(vm)
@@ -113,7 +125,7 @@ open class FavoritesViewModelTest : BaseTest() {
         favRepo.add("s2", Language.ENGLISH, "world")
         favRepo.add("s3", Language.RUSSIAN, "привет")
 
-        val vm = FavoritesViewModel(favRepo, dictionaryRepository(favRepo))
+        val vm = createViewModel(favRepo)
         vm.loadAndApplyState("")
 
         // Switch to Russian (only 1 favorite)
@@ -140,7 +152,7 @@ open class FavoritesViewModelTest : BaseTest() {
         favRepo.add("s2", Language.ENGLISH, "world")
         favRepo.add("s3", Language.RUSSIAN, "привет")
 
-        val vm = FavoritesViewModel(favRepo, dictionaryRepository(favRepo))
+        val vm = createViewModel(favRepo)
         vm.loadAndApplyState("")
 
         // Search for "hello" — only matches s1 in English
@@ -168,7 +180,7 @@ open class FavoritesViewModelTest : BaseTest() {
         favRepo.add("s1", Language.ENGLISH, "hello")
         favRepo.add("s2", Language.RUSSIAN, "hello")
 
-        val vm = FavoritesViewModel(favRepo, dictionaryRepository(favRepo))
+        val vm = createViewModel(favRepo)
         vm.loadAndApplyState("")
 
         // Search for "hello" while on English
@@ -187,7 +199,7 @@ open class FavoritesViewModelTest : BaseTest() {
         favRepo.add("s1", Language.ENGLISH, "hello")
         favRepo.add("s2", Language.RUSSIAN, "привет")
 
-        val vm = FavoritesViewModel(favRepo, dictionaryRepository(favRepo))
+        val vm = createViewModel(favRepo)
         vm.loadAndApplyState("")
 
         // Switch to Russian and open the dropdown

--- a/composeApp/src/commonTest/kotlin/com/slovy/slovymovyapp/ui/FavoritesViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/slovy/slovymovyapp/ui/FavoritesViewModelTest.kt
@@ -54,7 +54,7 @@ open class FavoritesViewModelTest : BaseTest() {
         favRepo.add("s2", Language.ENGLISH, "world")
 
         val vm = FavoritesViewModel(favRepo, dictionaryRepository(favRepo))
-        vm.loadFavoritesInternal("")
+        vm.loadAndApplyState("")
 
         val content = contentState(vm)
         assertEquals(2, content.senses.size)
@@ -70,7 +70,7 @@ open class FavoritesViewModelTest : BaseTest() {
         favRepo.add("s2", Language.RUSSIAN, "привет")
 
         val vm = FavoritesViewModel(favRepo, dictionaryRepository(favRepo))
-        vm.loadFavoritesInternal("")
+        vm.loadAndApplyState("")
 
         val content = contentState(vm)
         assertTrue(content.showLanguagePicker)
@@ -89,7 +89,7 @@ open class FavoritesViewModelTest : BaseTest() {
         favRepo.add("s3", Language.RUSSIAN, "привет")
 
         val vm = FavoritesViewModel(favRepo, dictionaryRepository(favRepo))
-        vm.loadFavoritesInternal("")
+        vm.loadAndApplyState("")
 
         var content = contentState(vm)
         assertTrue(content.senses.all { it.targetLang == Language.ENGLISH })
@@ -97,7 +97,7 @@ open class FavoritesViewModelTest : BaseTest() {
 
         // Switch to Russian — update selectedLanguage then reload
         vm.setSelectedLanguage(Language.RUSSIAN)
-        vm.loadFavoritesInternal("")
+        vm.loadAndApplyState("")
 
         content = contentState(vm)
         assertEquals(Language.RUSSIAN, content.selectedLanguage)
@@ -114,16 +114,16 @@ open class FavoritesViewModelTest : BaseTest() {
         favRepo.add("s3", Language.RUSSIAN, "привет")
 
         val vm = FavoritesViewModel(favRepo, dictionaryRepository(favRepo))
-        vm.loadFavoritesInternal("")
+        vm.loadAndApplyState("")
 
         // Switch to Russian (only 1 favorite)
         vm.setSelectedLanguage(Language.RUSSIAN)
-        vm.loadFavoritesInternal("")
+        vm.loadAndApplyState("")
         assertEquals(Language.RUSSIAN, contentState(vm).selectedLanguage)
 
         // Remove the only Russian favorite and reload (simulates toggleFavorite's logic)
         favRepo.remove("s3", Language.RUSSIAN)
-        vm.loadFavoritesInternal("")
+        vm.loadAndApplyState("")
 
         val content = contentState(vm)
         assertEquals(Language.ENGLISH, content.selectedLanguage,
@@ -141,10 +141,10 @@ open class FavoritesViewModelTest : BaseTest() {
         favRepo.add("s3", Language.RUSSIAN, "привет")
 
         val vm = FavoritesViewModel(favRepo, dictionaryRepository(favRepo))
-        vm.loadFavoritesInternal("")
+        vm.loadAndApplyState("")
 
         // Search for "hello" — only matches s1 in English
-        vm.loadFavoritesInternal("hello")
+        vm.loadAndApplyState("hello")
 
         var content = contentState(vm)
         assertEquals(1, content.senses.size)
@@ -152,7 +152,7 @@ open class FavoritesViewModelTest : BaseTest() {
 
         // Remove "hello" — English still has "world", should stay on English
         favRepo.remove("s1", Language.ENGLISH)
-        vm.loadFavoritesInternal("hello")
+        vm.loadAndApplyState("hello")
 
         content = contentState(vm)
         assertEquals(Language.ENGLISH, content.selectedLanguage,
@@ -169,10 +169,10 @@ open class FavoritesViewModelTest : BaseTest() {
         favRepo.add("s2", Language.RUSSIAN, "hello")
 
         val vm = FavoritesViewModel(favRepo, dictionaryRepository(favRepo))
-        vm.loadFavoritesInternal("")
+        vm.loadAndApplyState("")
 
         // Search for "hello" while on English
-        vm.loadFavoritesInternal("hello")
+        vm.loadAndApplyState("hello")
 
         val content = contentState(vm)
         assertEquals(Language.ENGLISH, content.selectedLanguage)
@@ -188,17 +188,17 @@ open class FavoritesViewModelTest : BaseTest() {
         favRepo.add("s2", Language.RUSSIAN, "привет")
 
         val vm = FavoritesViewModel(favRepo, dictionaryRepository(favRepo))
-        vm.loadFavoritesInternal("")
+        vm.loadAndApplyState("")
 
         // Switch to Russian and open the dropdown
         vm.setSelectedLanguage(Language.RUSSIAN)
-        vm.loadFavoritesInternal("")
+        vm.loadAndApplyState("")
         vm.setLanguageDropdownExpanded(true)
         assertTrue(contentState(vm).isLanguageDropdownExpanded)
 
         // Remove the only Russian favorite — picker becomes hidden
         favRepo.remove("s2", Language.RUSSIAN)
-        vm.loadFavoritesInternal("")
+        vm.loadAndApplyState("")
 
         val content = contentState(vm)
         assertFalse(content.showLanguagePicker)

--- a/composeApp/src/commonTest/kotlin/com/slovy/slovymovyapp/ui/FavoritesViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/slovy/slovymovyapp/ui/FavoritesViewModelTest.kt
@@ -5,35 +5,21 @@ import com.slovy.slovymovyapp.data.Language
 import com.slovy.slovymovyapp.data.favorites.FavoritesRepository
 import com.slovy.slovymovyapp.data.remote.DictionaryRepository
 import com.slovy.slovymovyapp.test.BaseTest
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.StandardTestDispatcher
-import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
-import kotlinx.coroutines.test.setMain
 import kotlin.test.AfterTest
-import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertIs
 import kotlin.test.assertTrue
 
-@OptIn(ExperimentalCoroutinesApi::class)
 open class FavoritesViewModelTest : BaseTest() {
 
-    private val testDispatcher = StandardTestDispatcher()
     private val viewModelStore = ViewModelStore()
-
-    @BeforeTest
-    fun setUp() {
-        Dispatchers.setMain(testDispatcher)
-    }
 
     @AfterTest
     fun tearDown() {
         viewModelStore.clear()
-        Dispatchers.resetMain()
     }
 
     private fun favoritesRepository(): FavoritesRepository {
@@ -59,7 +45,7 @@ open class FavoritesViewModelTest : BaseTest() {
     }
 
     @Test
-    fun initialLoad_singleLanguage_hiddenPicker() = runTest(testDispatcher) {
+    fun initialLoad_singleLanguage_hiddenPicker() = runTest {
         val favRepo = favoritesRepository()
         favRepo.deleteAll()
         favRepo.add("s1", Language.ENGLISH, "hello")
@@ -75,7 +61,7 @@ open class FavoritesViewModelTest : BaseTest() {
     }
 
     @Test
-    fun initialLoad_multiLanguage_showsPicker_defaultsToFirst() = runTest(testDispatcher) {
+    fun initialLoad_multiLanguage_showsPicker_defaultsToFirst() = runTest {
         val favRepo = favoritesRepository()
         favRepo.deleteAll()
         favRepo.add("s1", Language.ENGLISH, "hello")
@@ -93,7 +79,7 @@ open class FavoritesViewModelTest : BaseTest() {
     }
 
     @Test
-    fun setSelectedLanguage_filtersFavoritesToThatLanguage() = runTest(testDispatcher) {
+    fun setSelectedLanguage_filtersFavoritesToThatLanguage() = runTest {
         val favRepo = favoritesRepository()
         favRepo.deleteAll()
         favRepo.add("s1", Language.ENGLISH, "hello")
@@ -118,7 +104,7 @@ open class FavoritesViewModelTest : BaseTest() {
     }
 
     @Test
-    fun removingLastFavoriteInLanguage_switchesToOtherLanguage() = runTest(testDispatcher) {
+    fun removingLastFavoriteInLanguage_switchesToOtherLanguage() = runTest {
         val favRepo = favoritesRepository()
         favRepo.deleteAll()
         favRepo.add("s1", Language.ENGLISH, "hello")
@@ -145,7 +131,7 @@ open class FavoritesViewModelTest : BaseTest() {
     }
 
     @Test
-    fun removingLastVisibleResult_withActiveQuery_staysOnSameLanguage() = runTest(testDispatcher) {
+    fun removingLastVisibleResult_withActiveQuery_staysOnSameLanguage() = runTest {
         val favRepo = favoritesRepository()
         favRepo.deleteAll()
         favRepo.add("s1", Language.ENGLISH, "hello")
@@ -173,7 +159,7 @@ open class FavoritesViewModelTest : BaseTest() {
     }
 
     @Test
-    fun queryResults_scopedToSelectedLanguage() = runTest(testDispatcher) {
+    fun queryResults_scopedToSelectedLanguage() = runTest {
         val favRepo = favoritesRepository()
         favRepo.deleteAll()
         // Same lemma in two languages
@@ -193,7 +179,7 @@ open class FavoritesViewModelTest : BaseTest() {
     }
 
     @Test
-    fun dropdownExpandedState_resetsWhenPickerBecomesHidden() = runTest(testDispatcher) {
+    fun dropdownExpandedState_resetsWhenPickerBecomesHidden() = runTest {
         val favRepo = favoritesRepository()
         favRepo.deleteAll()
         favRepo.add("s1", Language.ENGLISH, "hello")

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -63,6 +63,7 @@ kotlinx-serializationJson = { module = "org.jetbrains.kotlinx:kotlinx-serializat
 kotlinx-datetime = { module = "org.jetbrains.kotlinx:kotlinx-datetime", version.ref = "kotlinx-datetime" }
 kotlinx-coroutinesCore = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlinx-coroutines" }
 kotlinx-coroutinesSwing = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-swing", version.ref = "kotlinx-coroutines" }
+kotlinx-coroutinesTest = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlinx-coroutines" }
 logback = { module = "ch.qos.logback:logback-classic", version.ref = "logback" }
 ktor-serverCore = { module = "io.ktor:ktor-server-core-jvm", version.ref = "ktor" }
 ktor-serverNetty = { module = "io.ktor:ktor-server-netty-jvm", version.ref = "ktor" }


### PR DESCRIPTION
Show a language picker dropdown next to the search bar when the user has favorites in 2+ languages. 
Filtering, search, and statistics are scoped to the selected language. 
Removing the last favorite in a language switches seamlessly to the next available language without flashing an empty screen.