### PR TITLE
Add support for general user feedback with GitHub Discussions integra…

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/App.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/App.kt
@@ -115,6 +115,7 @@ fun App(
                 dataManager,
                 downloadCoordinator,
                 dictionaryRepository,
+                dictionaryClient,
                 buildConfig
             )
         }

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/data/remote/DictionaryClient.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/data/remote/DictionaryClient.kt
@@ -107,6 +107,9 @@ class DictionaryClient(
     @Serializable
     data class FeedbackResponse(val issueUrl: String)
 
+    @Serializable
+    data class GeneralFeedbackResponse(val discussionUrl: String)
+
     /**
      * Fetches word data with progressive updates.
      *
@@ -478,6 +481,42 @@ class DictionaryClient(
 
             val body = response.bodyAsText()
             return json.decodeFromString(FeedbackResponse.serializer(), body)
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            if (e is DictionaryClientException) throw e
+            throw DictionaryClientException.NetworkException(
+                NetworkErrorClassifier.userMessage(e),
+                e
+            )
+        }
+    }
+
+    suspend fun sendGeneralFeedback(
+        comment: String,
+        email: String? = null
+    ): GeneralFeedbackResponse {
+        val url = "$serverBaseUrl/feedback"
+
+        try {
+            val response = httpClient.post(url) {
+                contentType(ContentType.Application.Json)
+                val trimmedEmail = email?.trim()?.takeIf { it.isNotBlank() }
+                setBody(
+                    json.encodeToString(
+                        FeedbackRequest.serializer(),
+                        FeedbackRequest(comment.trim(), trimmedEmail)
+                    )
+                )
+            }
+
+            if (!response.status.isSuccess()) {
+                val body = response.bodyAsText()
+                throw DictionaryClientException.ServerException(response.status.value, body)
+            }
+
+            val body = response.bodyAsText()
+            return json.decodeFromString(GeneralFeedbackResponse.serializer(), body)
         } catch (e: CancellationException) {
             throw e
         } catch (e: Exception) {

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/FeedbackDialog.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/FeedbackDialog.kt
@@ -1,0 +1,200 @@
+package com.slovy.slovymovyapp.ui
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.material3.*
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalUriHandler
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewParameter
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun FeedbackDialog(
+    title: String,
+    comment: String,
+    email: String,
+    isSending: Boolean,
+    error: String?,
+    resultUrl: String?,
+    onCommentChange: (String) -> Unit,
+    onEmailChange: (String) -> Unit,
+    onDismiss: () -> Unit,
+    onSend: () -> Unit
+) {
+    if (resultUrl != null) {
+        val uriHandler = LocalUriHandler.current
+        AlertDialog(
+            onDismissRequest = onDismiss,
+            title = { Text("Feedback sent!") },
+            text = {
+                Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                    Text(
+                        text = "Thank you for your feedback.",
+                        style = MaterialTheme.typography.bodyMedium
+                    )
+                    TextButton(
+                        onClick = { uriHandler.openUri(resultUrl) },
+                        contentPadding = PaddingValues(0.dp)
+                    ) {
+                        Text("View on GitHub")
+                    }
+                }
+            },
+            confirmButton = {
+                TextButton(onClick = onDismiss) {
+                    Text("Close")
+                }
+            }
+        )
+    } else {
+        AlertDialog(
+            onDismissRequest = {
+                if (!isSending) onDismiss()
+            },
+            title = {
+                Text(title)
+            },
+            text = {
+                Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                    OutlinedTextField(
+                        value = comment,
+                        onValueChange = onCommentChange,
+                        modifier = Modifier.fillMaxWidth(),
+                        minLines = 3,
+                        maxLines = 6,
+                        singleLine = false,
+                        enabled = !isSending,
+                        label = { Text("Comment") },
+                        isError = error != null
+                    )
+                    OutlinedTextField(
+                        value = email,
+                        onValueChange = onEmailChange,
+                        modifier = Modifier.fillMaxWidth(),
+                        singleLine = true,
+                        enabled = !isSending,
+                        label = { Text("Email (optional)") },
+                        supportingText = {
+                            Text("May be publicly visible on GitHub")
+                        }
+                    )
+                    if (error != null) {
+                        Text(
+                            text = error,
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.error
+                        )
+                    }
+                }
+            },
+            confirmButton = {
+                TextButton(
+                    onClick = onSend,
+                    enabled = !isSending && comment.isNotBlank()
+                ) {
+                    if (isSending) {
+                        CircularProgressIndicator(
+                            modifier = Modifier.size(16.dp),
+                            strokeWidth = 2.dp
+                        )
+                    } else {
+                        Text("Send")
+                    }
+                }
+            },
+            dismissButton = {
+                TextButton(
+                    onClick = onDismiss,
+                    enabled = !isSending
+                ) {
+                    Text("Cancel")
+                }
+            }
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun FeedbackDialogInputPreview(
+    @PreviewParameter(ThemePreviewProvider::class) isDark: Boolean
+) {
+    ThemedPreview(darkTheme = isDark) {
+        FeedbackDialog(
+            title = "App feedback",
+            comment = "",
+            email = "",
+            isSending = false,
+            error = null,
+            resultUrl = null,
+            onCommentChange = {},
+            onEmailChange = {},
+            onDismiss = {},
+            onSend = {}
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun FeedbackDialogSendingPreview(
+    @PreviewParameter(ThemePreviewProvider::class) isDark: Boolean
+) {
+    ThemedPreview(darkTheme = isDark) {
+        FeedbackDialog(
+            title = "App feedback",
+            comment = "Great app!",
+            email = "user@example.com",
+            isSending = true,
+            error = null,
+            resultUrl = null,
+            onCommentChange = {},
+            onEmailChange = {},
+            onDismiss = {},
+            onSend = {}
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun FeedbackDialogErrorPreview(
+    @PreviewParameter(ThemePreviewProvider::class) isDark: Boolean
+) {
+    ThemedPreview(darkTheme = isDark) {
+        FeedbackDialog(
+            title = "App feedback",
+            comment = "",
+            email = "",
+            isSending = false,
+            error = "Comment is required",
+            resultUrl = null,
+            onCommentChange = {},
+            onEmailChange = {},
+            onDismiss = {},
+            onSend = {}
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun FeedbackDialogSuccessPreview(
+    @PreviewParameter(ThemePreviewProvider::class) isDark: Boolean
+) {
+    ThemedPreview(darkTheme = isDark) {
+        FeedbackDialog(
+            title = "App feedback",
+            comment = "",
+            email = "",
+            isSending = false,
+            error = null,
+            resultUrl = "https://github.com/slovymovy/slovy-movy-app/discussions/1",
+            onCommentChange = {},
+            onEmailChange = {},
+            onDismiss = {},
+            onSend = {}
+        )
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/SettingsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/SettingsScreen.kt
@@ -22,6 +22,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.semantics.*
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
@@ -70,7 +71,13 @@ data class SettingsUiState(
     val testingVoice: Text2SpeechVoice? = null,
     val ttsStatus: TTSStatus = TTSStatus.IDLE,
     val deleteConfirmation: DeleteConfirmationState? = null,
-    val buildConfig: AppBuildConfig = AppBuildConfig("compile", 42, true, "com.slovy.slovymovyapp")
+    val buildConfig: AppBuildConfig = AppBuildConfig("compile", 42, true, "com.slovy.slovymovyapp"),
+    val feedbackDialogVisible: Boolean = false,
+    val feedbackComment: String = "",
+    val feedbackEmail: String = "",
+    val feedbackSubmitting: Boolean = false,
+    val feedbackError: String? = null,
+    val feedbackDiscussionUrl: String? = null
 )
 
 data class DeleteConfirmationState(
@@ -100,6 +107,7 @@ class SettingsViewModel(
     private val dataDbManager: DataDbManager,
     private val downloadCoordinator: DownloadCoordinator,
     private val dictionaryRepository: DictionaryRepository,
+    private val dictionaryClient: DictionaryClient,
     buildConfig: AppBuildConfig
 ) : ViewModel() {
 
@@ -467,6 +475,88 @@ class SettingsViewModel(
         downloadCoordinator.cancel(downloadKey)
     }
 
+    var pendingDiscussionUrl by mutableStateOf<String?>(null)
+        private set
+
+    fun consumePendingDiscussionUrl(): String? {
+        val url = pendingDiscussionUrl
+        pendingDiscussionUrl = null
+        return url
+    }
+
+    fun openFeedbackDialog() {
+        state = state.copy(
+            feedbackDialogVisible = true,
+            feedbackComment = "",
+            feedbackEmail = "",
+            feedbackSubmitting = false,
+            feedbackError = null,
+            feedbackDiscussionUrl = null
+        )
+    }
+
+    fun dismissFeedbackDialog() {
+        if (state.feedbackSubmitting) return
+        val discussionUrl = state.feedbackDiscussionUrl
+        state = state.copy(
+            feedbackDialogVisible = false,
+            feedbackComment = "",
+            feedbackEmail = "",
+            feedbackError = null,
+            feedbackDiscussionUrl = null
+        )
+        if (discussionUrl != null) {
+            viewModelScope.launch {
+                val result = snackbarHostState.showSnackbar(
+                    message = "Feedback sent",
+                    actionLabel = "View",
+                    duration = SnackbarDuration.Long
+                )
+                if (result == SnackbarResult.ActionPerformed) {
+                    pendingDiscussionUrl = discussionUrl
+                }
+            }
+        }
+    }
+
+    fun updateFeedbackComment(comment: String) {
+        state = state.copy(feedbackComment = comment, feedbackError = null)
+    }
+
+    fun updateFeedbackEmail(email: String) {
+        state = state.copy(feedbackEmail = email)
+    }
+
+    fun submitFeedback() {
+        if (state.feedbackSubmitting) return
+
+        val comment = state.feedbackComment.trim()
+        if (comment.isBlank()) {
+            state = state.copy(feedbackError = "Comment is required")
+            return
+        }
+
+        state = state.copy(feedbackSubmitting = true, feedbackError = null)
+        viewModelScope.launch {
+            try {
+                val response = dictionaryClient.sendGeneralFeedback(
+                    comment = comment,
+                    email = state.feedbackEmail.trim().takeIf { it.isNotBlank() }
+                )
+                state = state.copy(
+                    feedbackSubmitting = false,
+                    feedbackError = null,
+                    feedbackDiscussionUrl = response.discussionUrl
+                )
+            } catch (e: Exception) {
+                state = state.copy(
+                    feedbackSubmitting = false,
+                    feedbackError = NetworkErrorClassifier.userMessage(e)
+                )
+            }
+        }
+    }
+
     override fun onCleared() {
         super.onCleared()
         ttsManager.stop()
@@ -548,6 +638,15 @@ fun SettingsScreen(
         onPauseOrDispose { }
     }
 
+    val uriHandler = LocalUriHandler.current
+
+    // Handle pending discussion URL from snackbar action
+    LaunchedEffect(viewModel.pendingDiscussionUrl) {
+        viewModel.consumePendingDiscussionUrl()?.let { url ->
+            uriHandler.openUri(url)
+        }
+    }
+
     SettingsScreenContent(
         state = viewModel.state,
         scrollState = viewModel.scrollState,
@@ -566,6 +665,11 @@ fun SettingsScreen(
         onCancelDownload = { key -> viewModel.cancelDownload(key) },
         onDownloadTranslation = { src, tgt -> viewModel.downloadTranslation(src, tgt) },
         onToggleDictionaryExpansion = { languageCode -> viewModel.toggleDictionaryExpansion(languageCode) },
+        onSendFeedback = { viewModel.openFeedbackDialog() },
+        onDismissFeedback = { viewModel.dismissFeedbackDialog() },
+        onFeedbackCommentChange = { viewModel.updateFeedbackComment(it) },
+        onFeedbackEmailChange = { viewModel.updateFeedbackEmail(it) },
+        onSubmitFeedback = { viewModel.submitFeedback() },
         wordDetailLabel = wordDetailLabel,
         onNavigateToSearch = onNavigateToSearch,
         onNavigateToFavorites = onNavigateToFavorites,
@@ -593,6 +697,11 @@ fun SettingsScreenContent(
     onCancelDownload: (String) -> Unit = {},
     onDownloadTranslation: (Language, Language) -> Unit = { _, _ -> },
     onToggleDictionaryExpansion: (String) -> Unit = {},
+    onSendFeedback: () -> Unit = {},
+    onDismissFeedback: () -> Unit = {},
+    onFeedbackCommentChange: (String) -> Unit = {},
+    onFeedbackEmailChange: (String) -> Unit = {},
+    onSubmitFeedback: () -> Unit = {},
     wordDetailLabel: String? = null,
     onNavigateToSearch: () -> Unit = {},
     onNavigateToFavorites: () -> Unit = {},
@@ -925,7 +1034,8 @@ fun SettingsScreenContent(
 
                                 item {
                                     AboutSection(
-                                        buildConfig = buildConfig
+                                        buildConfig = buildConfig,
+                                        onSendFeedback = onSendFeedback
                                     )
                                 }
                             }
@@ -943,6 +1053,21 @@ fun SettingsScreenContent(
                 warning = confirmation.warning,
                 onConfirm = onConfirmDelete,
                 onDismiss = onDismissDeleteConfirmation
+            )
+        }
+
+        if (state.feedbackDialogVisible) {
+            FeedbackDialog(
+                title = "App feedback",
+                comment = state.feedbackComment,
+                email = state.feedbackEmail,
+                isSending = state.feedbackSubmitting,
+                error = state.feedbackError,
+                resultUrl = state.feedbackDiscussionUrl,
+                onCommentChange = onFeedbackCommentChange,
+                onEmailChange = onFeedbackEmailChange,
+                onDismiss = onDismissFeedback,
+                onSend = onSubmitFeedback
             )
         }
     }
@@ -1304,7 +1429,8 @@ private fun VoiceSectionItem(
 
 @Composable
 private fun AboutSection(
-    buildConfig: AppBuildConfig
+    buildConfig: AppBuildConfig,
+    onSendFeedback: () -> Unit = {}
 ) {
     ElevatedCard(
         modifier = Modifier.fillMaxWidth(),
@@ -1319,7 +1445,7 @@ private fun AboutSection(
                 icon = Icons.Outlined.Feedback,
                 title = "Send us feedback",
                 subtitle = "We'd love to hear from you",
-                onClick = {}
+                onClick = onSendFeedback
             )
             HorizontalDivider(
                 modifier = Modifier.padding(horizontal = AppSpacing.lg),

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/word/WordDetailsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/word/WordDetailsScreen.kt
@@ -849,121 +849,17 @@ fun WordDetailScreenContent(
     }
 
     if (state is WordDetailUiState.Content && state.feedbackDialogVisible) {
-        FeedbackDialog(
+        com.slovy.slovymovyapp.ui.FeedbackDialog(
+            title = "Propose correction",
             comment = state.feedbackComment,
             email = state.feedbackEmail,
             isSending = state.feedbackSubmitting,
             error = state.feedbackError,
-            issueUrl = state.feedbackIssueUrl,
+            resultUrl = state.feedbackIssueUrl,
             onCommentChange = onFeedbackCommentChange,
             onEmailChange = onFeedbackEmailChange,
             onDismiss = onDismissFeedback,
             onSend = onSubmitFeedback
-        )
-    }
-}
-
-@Composable
-private fun FeedbackDialog(
-    comment: String,
-    email: String,
-    isSending: Boolean,
-    error: String?,
-    issueUrl: String?,
-    onCommentChange: (String) -> Unit,
-    onEmailChange: (String) -> Unit,
-    onDismiss: () -> Unit,
-    onSend: () -> Unit
-) {
-    if (issueUrl != null) {
-        val uriHandler = LocalUriHandler.current
-        AlertDialog(
-            onDismissRequest = onDismiss,
-            title = { Text("Feedback sent!") },
-            text = {
-                Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
-                    Text(
-                        text = "Thank you for your feedback.",
-                        style = MaterialTheme.typography.bodyMedium
-                    )
-                    TextButton(
-                        onClick = { uriHandler.openUri(issueUrl) },
-                        contentPadding = PaddingValues(0.dp)
-                    ) {
-                        Text("View on GitHub")
-                    }
-                }
-            },
-            confirmButton = {
-                TextButton(onClick = onDismiss) {
-                    Text("Close")
-                }
-            }
-        )
-    } else {
-        AlertDialog(
-            onDismissRequest = {
-                if (!isSending) onDismiss()
-            },
-            title = {
-                Text("Send feedback")
-            },
-            text = {
-                Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
-                    OutlinedTextField(
-                        value = comment,
-                        onValueChange = onCommentChange,
-                        modifier = Modifier.fillMaxWidth(),
-                        minLines = 3,
-                        maxLines = 6,
-                        singleLine = false,
-                        enabled = !isSending,
-                        label = { Text("Comment") },
-                        isError = error != null
-                    )
-                    OutlinedTextField(
-                        value = email,
-                        onValueChange = onEmailChange,
-                        modifier = Modifier.fillMaxWidth(),
-                        singleLine = true,
-                        enabled = !isSending,
-                        label = { Text("Email (optional)") },
-                        supportingText = {
-                            Text("May be publicly visible on GitHub")
-                        }
-                    )
-                    if (error != null) {
-                        Text(
-                            text = error,
-                            style = MaterialTheme.typography.bodySmall,
-                            color = MaterialTheme.colorScheme.error
-                        )
-                    }
-                }
-            },
-            confirmButton = {
-                TextButton(
-                    onClick = onSend,
-                    enabled = !isSending && comment.isNotBlank()
-                ) {
-                    if (isSending) {
-                        CircularProgressIndicator(
-                            modifier = Modifier.size(16.dp),
-                            strokeWidth = 2.dp
-                        )
-                    } else {
-                        Text("Send")
-                    }
-                }
-            },
-            dismissButton = {
-                TextButton(
-                    onClick = onDismiss,
-                    enabled = !isSending
-                ) {
-                    Text("Cancel")
-                }
-            }
         )
     }
 }

--- a/server/src/main/kotlin/com/slovy/slovymovyapp/Application.kt
+++ b/server/src/main/kotlin/com/slovy/slovymovyapp/Application.kt
@@ -54,6 +54,19 @@ private data class FeedbackIssueResponse(
     val issueUrl: String
 )
 
+@Serializable
+private data class GeneralFeedbackRequest(
+    val comment: String,
+    val email: String? = null
+)
+
+@Serializable
+private data class GeneralFeedbackResponse(
+    val discussionNumber: Int,
+    val discussionTitle: String,
+    val discussionUrl: String
+)
+
 fun main() {
     val port = System.getenv(SERVER_PORT_ENV)?.toIntOrNull() ?: SERVER_PORT
     embeddedServer(Netty, port = port, host = "0.0.0.0", module = Application::module)
@@ -187,6 +200,53 @@ fun Application.module() {
             } catch (e: Exception) {
                 call.application.environment.log.error("Failed to process $lang/$word: ${e.message}", e)
                 call.respond(HttpStatusCode.InternalServerError, "Failed to process word: ${e.message}")
+            }
+        }
+
+        post("/feedback") {
+            if (!GitHubClient.isAvailable()) {
+                call.respond(HttpStatusCode.ServiceUnavailable, "GitHub token not configured")
+                return@post
+            }
+
+            val json = Json { ignoreUnknownKeys = true }
+            val feedbackRequest = try {
+                json.decodeFromString(
+                    GeneralFeedbackRequest.serializer(),
+                    call.receiveText()
+                )
+            } catch (_: Exception) {
+                call.respond(HttpStatusCode.BadRequest, "Invalid request body")
+                return@post
+            }
+
+            val comment = feedbackRequest.comment.trim()
+            if (comment.isBlank()) {
+                call.respond(HttpStatusCode.BadRequest, "Missing comment")
+                return@post
+            }
+
+            try {
+                val discussion = GitHubClient.createFeedbackDiscussion(
+                    comment = comment,
+                    email = feedbackRequest.email
+                )
+                val response = GeneralFeedbackResponse(
+                    discussionNumber = discussion.number,
+                    discussionTitle = discussion.title,
+                    discussionUrl = discussion.url
+                )
+                call.respondText(
+                    text = json.encodeToString(GeneralFeedbackResponse.serializer(), response),
+                    contentType = ContentType.Application.Json,
+                    status = HttpStatusCode.Created
+                )
+            } catch (e: Exception) {
+                call.application.environment.log.error(
+                    "Failed to create feedback discussion: ${e.message}",
+                    e
+                )
+                call.respond(HttpStatusCode.InternalServerError, "Failed to create feedback discussion")
             }
         }
 

--- a/server/src/main/kotlin/com/slovy/slovymovyapp/server/github/GitHubClient.kt
+++ b/server/src/main/kotlin/com/slovy/slovymovyapp/server/github/GitHubClient.kt
@@ -1,8 +1,12 @@
 package com.slovy.slovymovyapp.server.github
 
+import kotlinx.serialization.json.*
 import org.kohsuke.github.*
 import java.io.File
 import java.net.URI
+import java.net.http.HttpClient
+import java.net.http.HttpRequest
+import java.net.http.HttpResponse
 
 /**
  * GitHub client provider for accessing private repository content.
@@ -25,6 +29,17 @@ object GitHubClient {
     private const val FEEDBACK_LABEL = "feedback"
     private const val FEEDBACK_LABEL_COLOR = "0E8A16"
     private const val FEEDBACK_LABEL_DESCRIPTION = "Feedback reported from application users"
+
+    private const val GRAPHQL_ENDPOINT = "https://api.github.com/graphql"
+    private const val FEEDBACK_DISCUSSION_CATEGORY = "Feedback"
+    private const val DISCUSSION_REPO_OWNER = "slovymovy"
+    private const val DISCUSSION_REPO_NAME = "slovy-movy-app"
+
+    data class CreatedDiscussion(
+        val number: Int,
+        val title: String,
+        val url: String
+    )
 
     data class CreatedIssue(
         val number: Int,
@@ -387,6 +402,143 @@ object GitHubClient {
                 FEEDBACK_LABEL_DESCRIPTION
             )
         }
+    }
+
+    /**
+     * Creates a feedback discussion in the slovy-movy-app repository.
+     */
+    fun createFeedbackDiscussion(
+        comment: String,
+        email: String? = null
+    ): CreatedDiscussion {
+        val (repoId, categoryId) = resolveDiscussionCategoryId()
+        val title = "App feedback"
+        val body = buildGeneralFeedbackBody(comment, email)
+
+        val mutation = """
+            mutation CreateDiscussion(${'$'}repoId: ID!, ${'$'}categoryId: ID!, ${'$'}title: String!, ${'$'}body: String!) {
+              createDiscussion(input: {repositoryId: ${'$'}repoId, categoryId: ${'$'}categoryId, title: ${'$'}title, body: ${'$'}body}) {
+                discussion {
+                  number
+                  title
+                  url
+                }
+              }
+            }
+        """.trimIndent()
+
+        val variables = buildJsonObject {
+            put("repoId", repoId)
+            put("categoryId", categoryId)
+            put("title", title)
+            put("body", body)
+        }
+
+        val result = executeGraphQL(mutation, variables)
+        val discussion = result.jsonObject["data"]
+            ?.jsonObject?.get("createDiscussion")
+            ?.jsonObject?.get("discussion")
+            ?.jsonObject
+            ?: throw IllegalStateException(
+                "Failed to create discussion: ${result.jsonObject["errors"] ?: result}"
+            )
+
+        return CreatedDiscussion(
+            number = discussion["number"]!!.jsonPrimitive.int,
+            title = discussion["title"]!!.jsonPrimitive.content,
+            url = discussion["url"]!!.jsonPrimitive.content
+        )
+    }
+
+    internal fun buildGeneralFeedbackBody(comment: String, email: String? = null): String {
+        return buildString {
+            appendLine("Feedback submitted from application.")
+            appendLine()
+            if (!email.isNullOrBlank()) {
+                val obfuscated = email.trim().replace("@", " [feedback] ")
+                appendLine("- Email: `$obfuscated`")
+                appendLine()
+            }
+            appendLine("Comment:")
+            appendLine(comment.trim())
+        }
+    }
+
+    private val httpClient: HttpClient by lazy { HttpClient.newHttpClient() }
+
+    @Volatile
+    private var cachedDiscussionIds: Pair<String, String>? = null
+
+    private fun executeGraphQL(query: String, variables: JsonObject? = null): JsonElement {
+        val requestBody = buildJsonObject {
+            put("query", query)
+            if (variables != null) put("variables", variables)
+        }
+
+        val request = HttpRequest.newBuilder()
+            .uri(URI.create(GRAPHQL_ENDPOINT))
+            .header("Authorization", "bearer ${getToken()}")
+            .header("Content-Type", "application/json")
+            .POST(HttpRequest.BodyPublishers.ofString(requestBody.toString()))
+            .build()
+
+        val response = httpClient.send(request, HttpResponse.BodyHandlers.ofString())
+        val parsed = Json.parseToJsonElement(response.body())
+
+        if (response.statusCode() != 200) {
+            throw IllegalStateException(
+                "GraphQL request failed with status ${response.statusCode()}: ${response.body()}"
+            )
+        }
+
+        val errors = parsed.jsonObject["errors"]
+        if (errors != null && errors is JsonArray && errors.isNotEmpty()) {
+            throw IllegalStateException("GraphQL errors: $errors")
+        }
+
+        return parsed
+    }
+
+    private fun resolveDiscussionCategoryId(): Pair<String, String> {
+        cachedDiscussionIds?.let { return it }
+
+        val query = """
+            query(${'$'}owner: String!, ${'$'}name: String!) {
+              repository(owner: ${'$'}owner, name: ${'$'}name) {
+                id
+                discussionCategories(first: 25) {
+                  nodes {
+                    id
+                    name
+                  }
+                }
+              }
+            }
+        """.trimIndent()
+
+        val variables = buildJsonObject {
+            put("owner", DISCUSSION_REPO_OWNER)
+            put("name", DISCUSSION_REPO_NAME)
+        }
+
+        val result = executeGraphQL(query, variables)
+        val repo = result.jsonObject["data"]?.jsonObject?.get("repository")?.jsonObject
+            ?: throw IllegalStateException("Repository $DISCUSSION_REPO_OWNER/$DISCUSSION_REPO_NAME not found")
+
+        val repoId = repo["id"]!!.jsonPrimitive.content
+        val categories = repo["discussionCategories"]?.jsonObject?.get("nodes")?.jsonArray
+            ?: throw IllegalStateException("No discussion categories found")
+
+        val feedbackCategory = categories.firstOrNull {
+            it.jsonObject["name"]?.jsonPrimitive?.content == FEEDBACK_DISCUSSION_CATEGORY
+        }?.jsonObject ?: throw IllegalStateException(
+            "'$FEEDBACK_DISCUSSION_CATEGORY' discussion category not found in $DISCUSSION_REPO_OWNER/$DISCUSSION_REPO_NAME"
+        )
+
+        val categoryId = feedbackCategory["id"]!!.jsonPrimitive.content
+        val ids = repoId to categoryId
+        cachedDiscussionIds = ids
+        return ids
     }
 
     private fun loadToken(): String {

--- a/server/src/test/kotlin/com/slovy/slovymovyapp/ApplicationTest.kt
+++ b/server/src/test/kotlin/com/slovy/slovymovyapp/ApplicationTest.kt
@@ -179,6 +179,7 @@ class ApplicationTest {
         assertEquals("base", chunks.first()["stage"]?.jsonPrimitive?.content)
     }
 
+    @Ignore("Avoid repo pollution")
     @Test
     fun testFeedback_createsIssueAndClosesIt() = testApplication {
         if (!GitHubClient.isAvailable()) return@testApplication
@@ -228,6 +229,7 @@ class ApplicationTest {
         }
     }
 
+    @Ignore("Avoid repo pollution")
     @Test
     fun testGeneralFeedback_createsDiscussion() = testApplication {
         if (!GitHubClient.isAvailable()) return@testApplication
@@ -457,7 +459,7 @@ class RaceWithFallbackTest {
             )
         }
 
-        assertTrue(exception.message?.contains("No AI provider available") == true)
+        assertEquals(exception.message?.contains("No AI provider available"), true)
     }
 
     @Test

--- a/server/src/test/kotlin/com/slovy/slovymovyapp/ApplicationTest.kt
+++ b/server/src/test/kotlin/com/slovy/slovymovyapp/ApplicationTest.kt
@@ -228,6 +228,61 @@ class ApplicationTest {
         }
     }
 
+    @Test
+    fun testGeneralFeedback_createsDiscussion() = testApplication {
+        if (!GitHubClient.isAvailable()) return@testApplication
+
+        application {
+            module()
+        }
+
+        val response = client.post("/feedback") {
+            contentType(ContentType.Application.Json)
+            setBody("""{"comment":"General app feedback from test"}""")
+        }
+
+        assertEquals(HttpStatusCode.Created, response.status)
+        assertEquals(ContentType.Application.Json, response.contentType()?.withoutParameters())
+
+        val json = Json { ignoreUnknownKeys = true }
+        val responseJson = json.parseToJsonElement(response.bodyAsText()).jsonObject
+        val discussionNumber = responseJson["discussionNumber"]?.jsonPrimitive?.content?.toIntOrNull()
+        assertNotNull(discussionNumber, "Discussion number should be present in response")
+        assertTrue(discussionNumber > 0, "Discussion number should be positive")
+
+        val discussionUrl = responseJson["discussionUrl"]?.jsonPrimitive?.content
+        assertNotNull(discussionUrl, "Discussion URL should be present in response")
+        assertTrue(discussionUrl.contains("github.com"), "URL should be a GitHub URL")
+    }
+
+    @Test
+    fun testGeneralFeedback_returnsBadRequestForEmptyComment() = testApplication {
+        application {
+            module()
+        }
+
+        val response = client.post("/feedback") {
+            contentType(ContentType.Application.Json)
+            setBody("""{"comment":"   "}""")
+        }
+
+        assertEquals(HttpStatusCode.BadRequest, response.status)
+    }
+
+    @Test
+    fun testGeneralFeedback_returnsBadRequestForInvalidBody() = testApplication {
+        application {
+            module()
+        }
+
+        val response = client.post("/feedback") {
+            contentType(ContentType.Application.Json)
+            setBody("""not json""")
+        }
+
+        assertEquals(HttpStatusCode.BadRequest, response.status)
+    }
+
     private fun parseNdjson(body: String, json: Json) =
         body
             .lineSequence()

--- a/server/src/test/kotlin/com/slovy/slovymovyapp/server/github/GitHubClientTest.kt
+++ b/server/src/test/kotlin/com/slovy/slovymovyapp/server/github/GitHubClientTest.kt
@@ -249,6 +249,37 @@ class GitHubClientTest {
     }
 
     @Test
+    fun buildGeneralFeedbackBody_withEmail() {
+        val body = GitHubClient.buildGeneralFeedbackBody("Great app!", "user@example.com")
+        assertTrue(body.contains("Feedback submitted from application."), "Body should contain header")
+        assertTrue(body.contains("Great app!"), "Body should contain comment")
+        assertTrue(body.contains("[feedback]"), "Email should be obfuscated with [feedback]")
+        assertFalse(body.contains("@example"), "Email @ should be replaced")
+    }
+
+    @Test
+    fun buildGeneralFeedbackBody_withoutEmail() {
+        val body = GitHubClient.buildGeneralFeedbackBody("Bug report")
+        assertTrue(body.contains("Bug report"), "Body should contain comment")
+        assertFalse(body.contains("Email"), "Body should not contain Email line")
+    }
+
+    @Test
+    @Ignore("prevent repo pollution")
+    fun createFeedbackDiscussion_createsAndReturns() {
+        if (!GitHubClient.isAvailable()) return
+
+        val discussion = GitHubClient.createFeedbackDiscussion(
+            comment = "Integration test feedback - please ignore",
+            email = null
+        )
+
+        assertTrue(discussion.number > 0, "Discussion number should be positive")
+        assertEquals("App feedback", discussion.title)
+        assertTrue(discussion.url.contains("github.com"), "URL should be a GitHub URL")
+    }
+
+    @Test
     fun fileOperations_throwsForNonExistentFileOnBranch() {
         val testBranch = "test-${UUID.randomUUID()}"
 


### PR DESCRIPTION
…tion.

- Implement `/feedback` endpoint to create GitHub Discussions for app feedback.
- Add `FeedbackDialog` component for submitting and handling feedback.
- Update `SettingsScreen` to integrate feedback submission flow.
- Extend `GitHubClient` with GraphQL mutation for creating feedback discussions.
- Add unit tests for feedback submission scenarios.