### PR TITLE
Polish feedback dialog UI and relocate correction button

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/FeedbackDialog.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/FeedbackDialog.kt
@@ -1,10 +1,14 @@
 package com.slovy.slovymovyapp.ui
 
 import androidx.compose.foundation.layout.*
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.CheckCircle
 import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalUriHandler
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.dp
@@ -12,6 +16,7 @@ import androidx.compose.ui.unit.dp
 @Composable
 fun FeedbackDialog(
     title: String,
+    commentPlaceholder: String,
     comment: String,
     email: String,
     isSending: Boolean,
@@ -26,18 +31,36 @@ fun FeedbackDialog(
         val uriHandler = LocalUriHandler.current
         AlertDialog(
             onDismissRequest = onDismiss,
-            title = { Text("Feedback sent!") },
+            title = {
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(8.dp)
+                ) {
+                    Icon(
+                        imageVector = Icons.Outlined.CheckCircle,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.primary,
+                        modifier = Modifier.size(24.dp)
+                    )
+                    Text(
+                        text = "Feedback sent",
+                        style = MaterialTheme.typography.titleLarge.copy(
+                            fontWeight = FontWeight.SemiBold
+                        )
+                    )
+                }
+            },
             text = {
                 Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
                     Text(
-                        text = "Thank you for your feedback.",
+                        text = "Thank you! We've created a tracking issue for your feedback. You can follow its progress on GitHub.",
                         style = MaterialTheme.typography.bodyMedium
                     )
                     TextButton(
                         onClick = { uriHandler.openUri(resultUrl) },
                         contentPadding = PaddingValues(0.dp)
                     ) {
-                        Text("View on GitHub")
+                        Text("Track on GitHub")
                     }
                 }
             },
@@ -53,9 +76,17 @@ fun FeedbackDialog(
                 if (!isSending) onDismiss()
             },
             title = {
-                Text(title)
+                Text(
+                    text = title,
+                    style = MaterialTheme.typography.titleLarge.copy(
+                        fontWeight = FontWeight.SemiBold
+                    )
+                )
             },
             text = {
+                val fieldColors = OutlinedTextFieldDefaults.colors(
+                    focusedBorderColor = MaterialTheme.colorScheme.onSurfaceVariant
+                )
                 Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
                     OutlinedTextField(
                         value = comment,
@@ -65,7 +96,14 @@ fun FeedbackDialog(
                         maxLines = 6,
                         singleLine = false,
                         enabled = !isSending,
-                        label = { Text("Comment") },
+                        placeholder = {
+                            Text(
+                                text = commentPlaceholder,
+                                style = MaterialTheme.typography.bodyMedium
+                            )
+                        },
+                        shape = MaterialTheme.shapes.small,
+                        colors = fieldColors,
                         isError = error != null
                     )
                     OutlinedTextField(
@@ -74,10 +112,19 @@ fun FeedbackDialog(
                         modifier = Modifier.fillMaxWidth(),
                         singleLine = true,
                         enabled = !isSending,
-                        label = { Text("Email (optional)") },
-                        supportingText = {
-                            Text("May be publicly visible on GitHub")
-                        }
+                        placeholder = {
+                            Text(
+                                text = "Email (optional)",
+                                style = MaterialTheme.typography.bodyMedium
+                            )
+                        },
+                        shape = MaterialTheme.shapes.small,
+                        colors = fieldColors
+                    )
+                    Text(
+                        text = "May be publicly visible on GitHub",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
                     )
                     if (error != null) {
                         Text(
@@ -98,6 +145,8 @@ fun FeedbackDialog(
                             modifier = Modifier.size(16.dp),
                             strokeWidth = 2.dp
                         )
+                        Spacer(modifier = Modifier.width(8.dp))
+                        Text("Sending…")
                     } else {
                         Text("Send")
                     }
@@ -106,7 +155,10 @@ fun FeedbackDialog(
             dismissButton = {
                 TextButton(
                     onClick = onDismiss,
-                    enabled = !isSending
+                    enabled = !isSending,
+                    colors = ButtonDefaults.textButtonColors(
+                        contentColor = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
                 ) {
                     Text("Cancel")
                 }
@@ -123,6 +175,7 @@ private fun FeedbackDialogInputPreview(
     ThemedPreview(darkTheme = isDark) {
         FeedbackDialog(
             title = "App feedback",
+            commentPlaceholder = "Share your thoughts…",
             comment = "",
             email = "",
             isSending = false,
@@ -144,6 +197,7 @@ private fun FeedbackDialogSendingPreview(
     ThemedPreview(darkTheme = isDark) {
         FeedbackDialog(
             title = "App feedback",
+            commentPlaceholder = "Share your thoughts…",
             comment = "Great app!",
             email = "user@example.com",
             isSending = true,
@@ -165,6 +219,7 @@ private fun FeedbackDialogErrorPreview(
     ThemedPreview(darkTheme = isDark) {
         FeedbackDialog(
             title = "App feedback",
+            commentPlaceholder = "Share your thoughts…",
             comment = "",
             email = "",
             isSending = false,
@@ -186,6 +241,7 @@ private fun FeedbackDialogSuccessPreview(
     ThemedPreview(darkTheme = isDark) {
         FeedbackDialog(
             title = "App feedback",
+            commentPlaceholder = "Share your thoughts…",
             comment = "",
             email = "",
             isSending = false,

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/FeedbackDialog.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/FeedbackDialog.kt
@@ -122,12 +122,10 @@ fun FeedbackDialog(
                             )
                         },
                         shape = MaterialTheme.shapes.small,
-                        colors = fieldColors
-                    )
-                    Text(
-                        text = "May be publicly visible on GitHub",
-                        style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                        colors = fieldColors,
+                        supportingText = {
+                            Text("May be publicly visible on GitHub")
+                        }
                     )
                     if (error != null) {
                         Text(

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/FeedbackDialog.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/FeedbackDialog.kt
@@ -85,7 +85,8 @@ fun FeedbackDialog(
             },
             text = {
                 val fieldColors = OutlinedTextFieldDefaults.colors(
-                    focusedBorderColor = MaterialTheme.colorScheme.onSurfaceVariant
+                    focusedBorderColor = MaterialTheme.colorScheme.onSurfaceVariant,
+                    focusedLabelColor = MaterialTheme.colorScheme.onSurfaceVariant
                 )
                 Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
                     OutlinedTextField(
@@ -96,6 +97,7 @@ fun FeedbackDialog(
                         maxLines = 6,
                         singleLine = false,
                         enabled = !isSending,
+                        label = { Text("Comment") },
                         placeholder = {
                             Text(
                                 text = commentPlaceholder,
@@ -112,6 +114,7 @@ fun FeedbackDialog(
                         modifier = Modifier.fillMaxWidth(),
                         singleLine = true,
                         enabled = !isSending,
+                        label = { Text("Email (optional)") },
                         placeholder = {
                             Text(
                                 text = "Email (optional)",

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/SettingsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/SettingsScreen.kt
@@ -1059,6 +1059,7 @@ fun SettingsScreenContent(
         if (state.feedbackDialogVisible) {
             FeedbackDialog(
                 title = "App feedback",
+                commentPlaceholder = "Share your thoughts…",
                 comment = state.feedbackComment,
                 email = state.feedbackEmail,
                 isSending = state.feedbackSubmitting,

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/word/WordDetailsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/word/WordDetailsScreen.kt
@@ -8,7 +8,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.automirrored.filled.VolumeUp
 import androidx.compose.material.icons.filled.StopCircle
-import androidx.compose.material.icons.outlined.Feedback
+import androidx.compose.material.icons.outlined.Flag
 import androidx.compose.material3.*
 import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.runtime.*
@@ -813,17 +813,6 @@ fun WordDetailScreenContent(
                                     )
                                 }
                             }
-                            IconButton(
-                                onClick = onOpenFeedback,
-                                enabled = !state.feedbackSubmitting,
-                                modifier = Modifier.size(36.dp)
-                            ) {
-                                Icon(
-                                    imageVector = Icons.Outlined.Feedback,
-                                    contentDescription = "Send feedback",
-                                    tint = MaterialTheme.colorScheme.primary
-                                )
-                            }
                         }
                     }
                 },
@@ -878,7 +867,8 @@ fun WordDetailScreenContent(
                         isSenseFavorite = isSenseFavorite,
                         onSenseFavoriteToggle = onSenseFavoriteToggle,
                         onWordClick = onWordClick,
-                        favoriteLemmas = favoriteLemmas
+                        favoriteLemmas = favoriteLemmas,
+                        onOpenFeedback = onOpenFeedback
                     )
                 }
 
@@ -912,7 +902,8 @@ fun WordDetailScreenContent(
 
     if (state is WordDetailUiState.Content && state.feedbackDialogVisible) {
         com.slovy.slovymovyapp.ui.FeedbackDialog(
-            title = "Propose correction",
+            title = "Suggest a correction",
+            commentPlaceholder = "What needs correcting?",
             comment = state.feedbackComment,
             email = state.feedbackEmail,
             isSending = state.feedbackSubmitting,
@@ -942,7 +933,8 @@ private fun WordDetailContent(
     isSenseFavorite: (String) -> Boolean = { false },
     onSenseFavoriteToggle: (String) -> Unit = {},
     onWordClick: (String) -> Unit = {},
-    favoriteLemmas: Set<String> = emptySet()
+    favoriteLemmas: Set<String> = emptySet(),
+    onOpenFeedback: () -> Unit = {}
 ) {
     var scrollContainerY by remember { mutableStateOf(0f) }
 
@@ -1018,6 +1010,25 @@ private fun WordDetailContent(
                     favoriteLemmas = favoriteLemmas
                 )
             }
+        }
+
+        TextButton(
+            onClick = onOpenFeedback,
+            modifier = Modifier.align(Alignment.CenterHorizontally),
+            colors = ButtonDefaults.textButtonColors(
+                contentColor = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        ) {
+            Icon(
+                imageVector = Icons.Outlined.Flag,
+                contentDescription = null,
+                modifier = Modifier.size(18.dp)
+            )
+            Spacer(modifier = Modifier.width(6.dp))
+            Text(
+                text = "Suggest a correction",
+                style = MaterialTheme.typography.bodyMedium
+            )
         }
     }
 }


### PR DESCRIPTION
## Summary
- Move the feedback icon out of the word detail top bar into a subtle "Suggest a correction" button at the bottom of word content (Flag icon, centered, muted color)
- Restyle `FeedbackDialog`: smaller title (`titleLarge` + `SemiBold`), rounded text fields (8dp corners), calmer focused borders, context-specific placeholder hints, muted Cancel button, spinner with "Sending…" label
- Success state: checkmark icon, descriptive body text about tracking issue, "Track on GitHub" link
- Align dialog title wording with the button that opens it ("Suggest a correction" for word details, "App feedback" for settings)

## Test plan
- [ ] Open word detail screen, scroll to bottom — verify "Suggest a correction" button appears below the last sense card
- [ ] Tap the button — verify dialog opens with "What needs correcting?" placeholder
- [ ] Check dark theme: focused field border should be subtle, not bright primary
- [ ] Submit feedback — verify spinner shows "Sending…" text alongside it
- [ ] On success — verify checkmark icon, tracking issue text, and "Track on GitHub" link
- [ ] Open Settings > App feedback — verify dialog shows "Share your thoughts…" placeholder
- [ ] Verify top bar only shows word + audio button (no feedback icon)

🤖 Generated with [Claude Code](https://claude.com/claude-code)