### PR TITLE
Search screen: latest favorites, tap-to-focus, and UI polish

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/data/remote/DictionaryRepository.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/data/remote/DictionaryRepository.kt
@@ -747,7 +747,7 @@ class DictionaryRepository(
     ): List<String> = withContext(Dispatchers.IO) {
         (favorites ?: favoritesRepository.getAll())
             .filter { it.language == language }
-            .distinctBy { it.lemma }
+            .distinctBy { it.lemma.lowercase() }
             .take(limit)
             .map { it.lemma }
     }

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/data/remote/DictionaryRepository.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/data/remote/DictionaryRepository.kt
@@ -2,6 +2,7 @@ package com.slovy.slovymovyapp.data.remote
 
 import com.slovy.slovymovyapp.data.Language
 import com.slovy.slovymovyapp.data.dictionary.DictionaryPos
+import com.slovy.slovymovyapp.data.favorites.Favorite
 import com.slovy.slovymovyapp.data.favorites.FavoritesRepository
 import com.slovy.slovymovyapp.data.local.LocalDbManager
 import com.slovy.slovymovyapp.data.util.HtmlTagParser
@@ -722,15 +723,34 @@ class DictionaryRepository(
     }
 
     /**
-     * Gets recent favorite lemmas for the given language, most recent first.
+     * Loads both word suggestions and recent favorite lemmas in a single pass,
+     * fetching favorites from the DB only once.
      */
-    suspend fun getRecentFavoriteLemmas(language: Language, limit: Int = 5): List<String> =
-        withContext(Dispatchers.IO) {
-            favoritesRepository.getAll()
-                .filter { it.language == language }
-                .map { it.lemma }
-                .take(limit)
-        }
+    suspend fun getSearchEmptyStateData(
+        language: Language
+    ): Pair<List<String>, List<String>> {
+        val allFavorites = withContext(Dispatchers.IO) { favoritesRepository.getAll() }
+        val suggestions = getWordSuggestions(language, favorites = allFavorites)
+        val recentFavorites = getRecentFavoriteLemmas(language, favorites = allFavorites)
+        return suggestions to recentFavorites
+    }
+
+    /**
+     * Gets recent favorite lemmas for the given language, most recent first.
+     * Accepts pre-fetched [favorites] to avoid redundant DB reads when the caller
+     * already has the list (e.g. [getSearchEmptyStateData]).
+     */
+    suspend fun getRecentFavoriteLemmas(
+        language: Language,
+        limit: Int = 5,
+        favorites: List<Favorite>? = null
+    ): List<String> = withContext(Dispatchers.IO) {
+        (favorites ?: favoritesRepository.getAll())
+            .filter { it.language == language }
+            .distinctBy { it.lemma }
+            .take(limit)
+            .map { it.lemma }
+    }
 
     /**
      * Gets word suggestions for the empty search state.
@@ -740,7 +760,8 @@ class DictionaryRepository(
     suspend fun getWordSuggestions(
         language: Language,
         count: Int = 5,
-        offset: Int = 2000
+        offset: Int = 2000,
+        favorites: List<Favorite>? = null
     ): List<String> = withContext(Dispatchers.IO) {
         if (!dataDbManager.hasDictionary(language)) {
             return@withContext emptyList()
@@ -750,7 +771,7 @@ class DictionaryRepository(
         val q = db.dictionaryQueries
 
         // Get favorites to exclude (case-insensitive)
-        val favorites = favoritesRepository.getAll()
+        val favoriteLemmas = (favorites ?: favoritesRepository.getAll())
             .filter { it.language == language }
             .map { it.lemma.lowercase() }
             .toSet()
@@ -773,7 +794,7 @@ class DictionaryRepository(
             if (batch.isEmpty()) return@repeat
 
             // Sample non-favorite rows with gaps, then fill remaining from unused candidates.
-            val candidates = batch.filter { it.lemma.lowercase() !in favorites }
+            val candidates = batch.filter { it.lemma.lowercase() !in favoriteLemmas }
             if (candidates.isNotEmpty()) {
                 val startIndex = (0 until candidates.size).random()
                 var index = startIndex

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/data/remote/DictionaryRepository.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/data/remote/DictionaryRepository.kt
@@ -722,6 +722,17 @@ class DictionaryRepository(
     }
 
     /**
+     * Gets recent favorite lemmas for the given language, most recent first.
+     */
+    suspend fun getRecentFavoriteLemmas(language: Language, limit: Int = 5): List<String> =
+        withContext(Dispatchers.IO) {
+            favoritesRepository.getAll()
+                .filter { it.language == language }
+                .map { it.lemma }
+                .take(limit)
+        }
+
+    /**
      * Gets word suggestions for the empty search state.
      * Returns high-frequency words that are not in favorites.
      * Uses a random offset for variety.

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/SearchScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/SearchScreen.kt
@@ -124,8 +124,7 @@ class SearchViewModel(
 
     private suspend fun loadSuggestionsForCurrentLanguage() {
         val language = state.selectedLanguage ?: return
-        val suggestions = repository.getWordSuggestions(language)
-        val favorites = repository.getRecentFavoriteLemmas(language)
+        val (suggestions, favorites) = repository.getSearchEmptyStateData(language)
         state = state.copy(wordSuggestions = suggestions, favoriteLemmas = favorites)
     }
 

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/SearchScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/SearchScreen.kt
@@ -537,21 +537,6 @@ private fun EmptySearchState(
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.spacedBy(24.dp)
     ) {
-        Text(
-            text = "Search your word",
-            style = MaterialTheme.typography.titleMedium,
-            color = MaterialTheme.colorScheme.onSurface
-        )
-
-        if (showPullToRefreshHint) {
-            Spacer(modifier = Modifier.height(12.dp))
-            Text(
-                text = "Pull down to refresh suggestions",
-                style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant
-            )
-        }
-
         if (wordSuggestions.isNotEmpty()) {
             WordChipSection(
                 title = "Explore new words",
@@ -565,6 +550,16 @@ private fun EmptySearchState(
                 title = "Your latest favorites",
                 words = favoriteLemmas,
                 onWordClick = onWordClick
+            )
+        }
+
+        if (showPullToRefreshHint) {
+            Spacer(modifier = Modifier.height(0.dp)) // reset arrangement gap
+            Text(
+                modifier = Modifier.offset(y = (-12).dp),
+                text = "Pull down to refresh suggestions",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
             )
         }
     }

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/SearchScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/SearchScreen.kt
@@ -296,9 +296,9 @@ fun SearchScreenContent(
     Surface(
         modifier = Modifier
             .fillMaxSize()
-            .pointerInput(state.query, isSearchFocused) {
+            .pointerInput(isSearchFocused) {
                 detectTapGestures(onTap = {
-                    if (!isSearchFocused && state.query.isEmpty()) {
+                    if (!isSearchFocused) {
                         searchFocusRequester.requestFocus()
                     } else {
                         focusManager.clearFocus()
@@ -556,7 +556,13 @@ private fun EmptySearchState(
             )
         }
 
-        if (showPullToRefreshHint) {
+        if (wordSuggestions.isEmpty() && favoriteLemmas.isEmpty()) {
+            Text(
+                text = "Start typing to search",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        } else if (showPullToRefreshHint) {
             Spacer(modifier = Modifier.height(0.dp)) // reset arrangement gap
             Text(
                 modifier = Modifier.offset(y = (-12).dp),
@@ -584,7 +590,7 @@ private fun WordChipSection(
             modifier = Modifier.padding(horizontal = 16.dp, vertical = 14.dp),
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
-            Text(
+                Text(
                 text = title,
                 style = MaterialTheme.typography.labelLarge,
                 color = MaterialTheme.colorScheme.onSurfaceVariant

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/SearchScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/SearchScreen.kt
@@ -24,6 +24,9 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.dp
@@ -462,7 +465,8 @@ private fun SearchResultCard(
     OutlinedCard(
         modifier = Modifier
             .fillMaxWidth()
-            .clickable(onClick = onClick),
+            .semantics { role = Role.Button }
+            .clickable(onClickLabel = "Open ${item.display}", onClick = onClick),
         shape = MaterialTheme.shapes.small,
         colors = CardDefaults.outlinedCardColors(containerColor = containerColor),
         border = BorderStroke(0.5.dp, MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f))

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/SearchScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/SearchScreen.kt
@@ -12,7 +12,6 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.DownloadForOffline
 import androidx.compose.material.icons.filled.Favorite
 import androidx.compose.material.icons.filled.Search
-import androidx.compose.material.icons.outlined.Lightbulb
 import androidx.compose.material3.*
 import androidx.compose.material3.ExposedDropdownMenuAnchorType.Companion.PrimaryEditable
 import androidx.compose.material3.pulltorefresh.PullToRefreshBox
@@ -49,9 +48,10 @@ data class SearchUiState(
     val availableLanguages: List<Language> = emptyList(),
     val selectedLanguage: Language? = null,
     val isLanguageDropdownExpanded: Boolean = false,
-    val wordSuggestions: List<String> = emptyList(),
     val isSuggestionsRefreshing: Boolean = false,
-    val showPullToRefreshHint: Boolean = true
+    val showPullToRefreshHint: Boolean = true,
+    val wordSuggestions: List<String> = emptyList(),
+    val favoriteLemmas: List<String> = emptyList()
 )
 
 class SearchViewModel(
@@ -120,7 +120,8 @@ class SearchViewModel(
     private suspend fun loadSuggestionsForCurrentLanguage() {
         val language = state.selectedLanguage ?: return
         val suggestions = repository.getWordSuggestions(language)
-        state = state.copy(wordSuggestions = suggestions)
+        val favorites = repository.getRecentFavoriteLemmas(language)
+        state = state.copy(wordSuggestions = suggestions, favoriteLemmas = favorites)
     }
 
     fun refreshSuggestions() {
@@ -326,7 +327,7 @@ fun SearchScreenContent(
                         query = state.query,
                         onQueryChange = onQueryChange,
                         modifier = Modifier.weight(1f),
-                        placeholder = "Type a word..."
+                        placeholder = "Search your word..."
                     )
 
                     // Language filter dropdown
@@ -407,7 +408,8 @@ fun SearchScreenContent(
                         ) {
                             EmptySearchState(
                                 wordSuggestions = state.wordSuggestions,
-                                onWordClick = onSuggestionSelected,
+                                favoriteLemmas = state.favoriteLemmas,
+                            onWordClick = onSuggestionSelected,
                                 showPullToRefreshHint = state.showPullToRefreshHint && !state.isSuggestionsRefreshing
                             )
                         }
@@ -509,6 +511,7 @@ private fun SearchResultCard(
 @Composable
 private fun EmptySearchState(
     wordSuggestions: List<String>,
+    favoriteLemmas: List<String>,
     onWordClick: (String) -> Unit,
     showPullToRefreshHint: Boolean = true
 ) {
@@ -517,8 +520,9 @@ private fun EmptySearchState(
             .fillMaxSize()
             .verticalScroll(rememberScrollState())
             .padding(horizontal = 24.dp)
-            .padding(top = 48.dp),
-        horizontalAlignment = Alignment.CenterHorizontally
+            .padding(top = 32.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(24.dp)
     ) {
         Text(
             text = "Search your word",
@@ -536,11 +540,42 @@ private fun EmptySearchState(
         }
 
         if (wordSuggestions.isNotEmpty()) {
-            Spacer(modifier = Modifier.height(24.dp))
+            WordChipSection(
+                title = "Explore new words",
+                words = wordSuggestions,
+                onWordClick = onWordClick
+            )
+        }
 
+        if (favoriteLemmas.isNotEmpty()) {
+            WordChipSection(
+                title = "Your latest favorites",
+                words = favoriteLemmas,
+                onWordClick = onWordClick
+            )
+        }
+    }
+}
+
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+private fun WordChipSection(
+    title: String,
+    words: List<String>,
+    onWordClick: (String) -> Unit
+) {
+    Surface(
+        modifier = Modifier.fillMaxWidth(),
+        color = MaterialTheme.colorScheme.surfaceContainerHigh,
+        shape = MaterialTheme.shapes.medium
+    ) {
+        Column(
+            modifier = Modifier.padding(horizontal = 16.dp, vertical = 14.dp),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
             Text(
-                text = "or explore:",
-                style = MaterialTheme.typography.bodyMedium,
+                text = title,
+                style = MaterialTheme.typography.labelLarge,
                 color = MaterialTheme.colorScheme.onSurfaceVariant
             )
 
@@ -551,7 +586,7 @@ private fun EmptySearchState(
                 horizontalArrangement = Arrangement.spacedBy(8.dp, Alignment.CenterHorizontally),
                 verticalArrangement = Arrangement.spacedBy(4.dp)
             ) {
-                wordSuggestions.forEach { word ->
+                words.forEach { word ->
                     SuggestionChip(
                         onClick = { onWordClick(word) },
                         label = {
@@ -573,31 +608,6 @@ private fun EmptySearchState(
                         )
                     )
                 }
-            }
-        }
-
-        Spacer(modifier = Modifier.height(32.dp))
-
-        Surface(
-            color = MaterialTheme.colorScheme.secondaryContainer.copy(alpha = 0.5f),
-            shape = MaterialTheme.shapes.medium
-        ) {
-            Row(
-                modifier = Modifier.padding(horizontal = 14.dp, vertical = 12.dp),
-                horizontalArrangement = Arrangement.spacedBy(10.dp),
-                verticalAlignment = Alignment.CenterVertically
-            ) {
-                Icon(
-                    imageVector = Icons.Outlined.Lightbulb,
-                    contentDescription = null,
-                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
-                    modifier = Modifier.size(18.dp)
-                )
-                Text(
-                    text = "You can search by translations and grammar forms too!",
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSecondaryContainer
-                )
             }
         }
     }
@@ -666,7 +676,8 @@ private fun SearchScreenPreviewEmptyQuery(
                 showNoResults = false,
                 availableLanguages = listOf(Language.ENGLISH, Language.RUSSIAN),
                 selectedLanguage = Language.ENGLISH,
-                wordSuggestions = listOf("the", "be", "to", "of", "and")
+                wordSuggestions = listOf("the", "be", "to", "of", "and"),
+                favoriteLemmas = listOf("world", "time", "love")
             ),
         )
     }

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/SearchScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/SearchScreen.kt
@@ -1,5 +1,7 @@
 package com.slovy.slovymovyapp.ui
 
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
@@ -30,7 +32,6 @@ import androidx.lifecycle.viewModelScope
 import com.slovy.slovymovyapp.data.Language
 import com.slovy.slovymovyapp.data.remote.DictionaryRepository
 import com.slovy.slovymovyapp.data.remote.PartOfSpeech
-import com.slovy.slovymovyapp.ui.components.AppCard
 import com.slovy.slovymovyapp.ui.components.AppSearchBar
 import com.slovy.slovymovyapp.ui.components.EmptyState
 import com.slovy.slovymovyapp.ui.word.Badge
@@ -458,10 +459,13 @@ private fun SearchResultCard(
     onClick: () -> Unit
 ) {
     val containerColor = colorForLemma(item.lemma, MaterialTheme.colorScheme.surface)
-    AppCard(
-        modifier = Modifier.fillMaxWidth(),
-        colors = CardDefaults.cardColors(containerColor = containerColor),
-        onClick = onClick
+    OutlinedCard(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(onClick = onClick),
+        shape = MaterialTheme.shapes.small,
+        colors = CardDefaults.outlinedCardColors(containerColor = containerColor),
+        border = BorderStroke(0.5.dp, MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f))
     ) {
         Row(
             modifier = Modifier

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/SearchScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/SearchScreen.kt
@@ -19,6 +19,7 @@ import androidx.compose.runtime.*
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.tooling.preview.Preview
@@ -287,12 +288,18 @@ fun SearchScreenContent(
     onNavigateToSettings: () -> Unit = {}
 ) {
     val focusManager = LocalFocusManager.current
+    val searchFocusRequester = remember { FocusRequester() }
+    var isSearchFocused by remember { mutableStateOf(false) }
     Surface(
         modifier = Modifier
             .fillMaxSize()
-            .pointerInput(Unit) {
+            .pointerInput(state.query, isSearchFocused) {
                 detectTapGestures(onTap = {
-                    focusManager.clearFocus()
+                    if (!isSearchFocused && state.query.isEmpty()) {
+                        searchFocusRequester.requestFocus()
+                    } else {
+                        focusManager.clearFocus()
+                    }
                 })
             }
     ) {
@@ -327,7 +334,9 @@ fun SearchScreenContent(
                         query = state.query,
                         onQueryChange = onQueryChange,
                         modifier = Modifier.weight(1f),
-                        placeholder = "Search your word..."
+                        placeholder = "Search your word...",
+                        focusRequester = searchFocusRequester,
+                        onFocusChanged = { isSearchFocused = it }
                     )
 
                     // Language filter dropdown

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/components/AppSearchBar.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/components/AppSearchBar.kt
@@ -13,6 +13,9 @@ import androidx.compose.material.icons.filled.Search
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.input.ImeAction
@@ -49,7 +52,9 @@ fun AppSearchBar(
     placeholder: String = "Search...",
     onSearch: (() -> Unit)? = null,
     leadingIcon: @Composable (() -> Unit)? = null,
-    enabled: Boolean = true
+    enabled: Boolean = true,
+    focusRequester: FocusRequester? = null,
+    onFocusChanged: ((Boolean) -> Unit)? = null
 ) {
     val interactionSource = remember { MutableInteractionSource() }
     val isFocused by interactionSource.collectIsFocusedAsState()
@@ -94,7 +99,10 @@ fun AppSearchBar(
                 textFieldValue = newValue
                 onQueryChange(newValue.text)
             },
-            modifier = Modifier.fillMaxWidth(),
+            modifier = Modifier
+                .fillMaxWidth()
+                .then(if (focusRequester != null) Modifier.focusRequester(focusRequester) else Modifier)
+                .then(if (onFocusChanged != null) Modifier.onFocusChanged { onFocusChanged(it.isFocused) } else Modifier),
             placeholder = {
                 Text(
                     text = placeholder,


### PR DESCRIPTION
## Summary
- Add "Your latest favorites" section and "Explore new words" chip section to the search empty state
- Tap empty background to activate the search bar
- Align search result card styling with favorites SenseCard
- Reposition pull-to-refresh hint below chip sections
- Add semantic role and click label to SearchResultCard for accessibility

## Test plan
- [ ] Verify "Explore new words" and "Your latest favorites" chip sections appear when search is empty
- [ ] Tap empty background area and confirm search bar receives focus
- [ ] Verify pull-to-refresh works on the empty search state
- [ ] Check search result card styling matches favorites SenseCard
- [ ] Test with TalkBack/VoiceOver that search result cards announce correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)