### PR TITLE
Add text reader with CEFR word highlighting

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/App.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/App.kt
@@ -17,6 +17,8 @@ import com.slovy.slovymovyapp.data.settings.SettingsRepository
 import com.slovy.slovymovyapp.speech.TextToSpeechManager
 import com.slovy.slovymovyapp.speech.VoiceFilterHelper
 import com.slovy.slovymovyapp.ui.*
+import com.slovy.slovymovyapp.ui.reader.TextReaderScreen
+import com.slovy.slovymovyapp.ui.reader.TextReaderViewModel
 import com.slovy.slovymovyapp.ui.theme.AppTheme
 import com.slovy.slovymovyapp.ui.word.WordDetailScreen
 import com.slovy.slovymovyapp.ui.word.WordDetailViewModel
@@ -65,6 +67,9 @@ private sealed interface AppDestination {
 
     @Serializable
     data object Settings : AppDestination
+
+    @Serializable
+    data class TextReader(val languageCode: String) : AppDestination
 
     @Serializable
     data class Error(val message: String) : AppDestination
@@ -502,6 +507,9 @@ fun App(
                     onNavigateToSettings = {
                         if (!navController.popBackStack(AppDestination.Settings, inclusive = false))
                             navController.navigate(AppDestination.Settings)
+                    },
+                    onNavigateToTextReader = { language ->
+                        navController.navigate(AppDestination.TextReader(language.code))
                     }
                 )
             }
@@ -632,6 +640,33 @@ fun App(
                         )
                         navController.navigate(destination)
                     }
+                )
+            }
+            composable<AppDestination.TextReader> { backStackEntry ->
+                val args = backStackEntry.toRoute<AppDestination.TextReader>()
+                val language = Language.fromCodeOrNull(args.languageCode) ?: run {
+                    LaunchedEffect(Unit) {
+                        navController.navigate(AppDestination.Error("Unknown language: ${args.languageCode}")) {
+                            popUpTo<AppDestination.TextReader> { inclusive = true }
+                        }
+                    }
+                    return@composable
+                }
+                val viewModel = viewModel(viewModelStoreOwner = backStackEntry) {
+                    TextReaderViewModel(dictionaryRepository, language)
+                }
+                TextReaderScreen(
+                    viewModel = viewModel,
+                    onWordClick = { wordLanguage, lemma ->
+                        val translationCodes = nativeLanguages.filter { it != wordLanguage }.map { it.code }
+                        val destination = AppDestination.WordDetail(
+                            dictionaryLanguageCode = wordLanguage.code,
+                            lemma = lemma,
+                            translationLanguageCodes = translationCodes
+                        )
+                        navController.navigate(destination)
+                    },
+                    onBack = { navController.popBackStack() }
                 )
             }
             composable<AppDestination.DataVersionMismatch> { backStackEntry ->

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/data/remote/DictionaryRepository.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/data/remote/DictionaryRepository.kt
@@ -1047,8 +1047,7 @@ class DictionaryRepository(
     data class TokenResult(
         val lemma: String,
         val lemmaId: Uuid,
-        val level: LearnerLevel?,
-        val isFavorite: Boolean
+        val level: LearnerLevel?
     )
 
     /**
@@ -1070,36 +1069,32 @@ class DictionaryRepository(
         if (forms.isEmpty()) return@withContext emptyMap()
 
         val databases = openDictionaryDatabases(language)
-        val allFavorites = favoritesRepository.getAll()
-        val favoriteLemmas = allFavorites
-            .filter { it.language == language }
-            .map { it.lemma.lowercase() }
-            .toSet()
-
         val result = mutableMapOf<String, TokenResult>()
 
         for (db in databases) {
             val q = db.dictionaryQueries
 
-            // Pass 1: form-based lookup (handles inflected forms like "liepen" → "lopen")
+            // Pass 1: form-based lookup (handles inflected forms like "liepen" → "lopen").
+            // Collect per-DB first so that local DB results can override RO DB results.
+            val dbPass1 = mutableMapOf<String, TokenResult>()
             forms.chunked(999).forEach { chunk ->
                 q.selectTokenDataByForms(language.code, chunk)
                     .executeAsList()
                     .forEach { row ->
-                        if (!result.containsKey(row.form_normalized)) {
+                        if (!dbPass1.containsKey(row.form_normalized)) {
                             val level = row.min_level?.let { rawValue ->
                                 com.slovy.slovymovyapp.data.dictionary.LearnerLevel.from(rawValue)
                                     .let { dbLevel -> LearnerLevel.valueOf(dbLevel.name) }
                             }
-                            result[row.form_normalized] = TokenResult(
+                            dbPass1[row.form_normalized] = TokenResult(
                                 lemma = row.lemma,
                                 lemmaId = row.lemma_id,
-                                level = level,
-                                isFavorite = row.lemma.lowercase() in favoriteLemmas
+                                level = level
                             )
                         }
                     }
             }
+            result.putAll(dbPass1)
 
             // Pass 2: direct lemma lookup — overrides pass-1 when the token itself is a lemma.
             // Function words (e.g. "wat") may not have form-table entries and would otherwise
@@ -1117,8 +1112,7 @@ class DictionaryRepository(
                             directResults[row.lemma_normalized] = TokenResult(
                                 lemma = row.lemma,
                                 lemmaId = row.lemma_id,
-                                level = level,
-                                isFavorite = row.lemma.lowercase() in favoriteLemmas
+                                level = level
                             )
                         }
                     }
@@ -1172,5 +1166,5 @@ class DictionaryRepository(
     }
 
     suspend fun getFavoriteLemmasByLang(language: Language): Set<String> =
-        favoritesRepository.getDistinctLemmasByLang(language)
+        favoritesRepository.getDistinctLemmasByLang(language).mapTo(mutableSetOf()) { it.lowercase() }
 }

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/data/remote/DictionaryRepository.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/data/remote/DictionaryRepository.kt
@@ -1044,6 +1044,91 @@ class DictionaryRepository(
         return allRelatedWords
     }
 
+    data class TokenResult(
+        val lemma: String,
+        val lemmaId: Uuid,
+        val level: LearnerLevel?,
+        val isFavorite: Boolean
+    )
+
+    /**
+     * Batch-looks up normalized word forms against the dictionary DB for the given language.
+     * Returns a map of normalizedForm → TokenResult for all matched forms.
+     *
+     * Two-pass strategy:
+     * 1. Form lookup: finds the best lemma for each inflected form.
+     * 2. Direct lemma lookup: overrides pass-1 results when the input form itself is a lemma.
+     *    This fixes cases where a high-frequency word happens to share a form with the target
+     *    lemma (e.g. "wat" being resolved to "wats").
+     *
+     * Favorites are flagged using [FavoritesRepository].
+     */
+    suspend fun lookupTokensBatch(
+        forms: List<String>,
+        language: Language
+    ): Map<String, TokenResult> = withContext(Dispatchers.IO) {
+        if (forms.isEmpty()) return@withContext emptyMap()
+
+        val databases = openDictionaryDatabases(language)
+        val allFavorites = favoritesRepository.getAll()
+        val favoriteLemmas = allFavorites
+            .filter { it.language == language }
+            .map { it.lemma.lowercase() }
+            .toSet()
+
+        val result = mutableMapOf<String, TokenResult>()
+
+        for (db in databases) {
+            val q = db.dictionaryQueries
+
+            // Pass 1: form-based lookup (handles inflected forms like "liepen" → "lopen")
+            forms.chunked(999).forEach { chunk ->
+                q.selectTokenDataByForms(language.code, chunk)
+                    .executeAsList()
+                    .forEach { row ->
+                        if (!result.containsKey(row.form_normalized)) {
+                            val level = row.min_level?.let { rawValue ->
+                                com.slovy.slovymovyapp.data.dictionary.LearnerLevel.from(rawValue)
+                                    .let { dbLevel -> LearnerLevel.valueOf(dbLevel.name) }
+                            }
+                            result[row.form_normalized] = TokenResult(
+                                lemma = row.lemma,
+                                lemmaId = row.lemma_id,
+                                level = level,
+                                isFavorite = row.lemma.lowercase() in favoriteLemmas
+                            )
+                        }
+                    }
+            }
+
+            // Pass 2: direct lemma lookup — overrides pass-1 when the token itself is a lemma.
+            // Function words (e.g. "wat") may not have form-table entries and would otherwise
+            // resolve to a wrong high-frequency word that shares the same inflected form.
+            val directResults = mutableMapOf<String, TokenResult>()
+            forms.chunked(999).forEach { chunk ->
+                q.selectTokenDataByLemmas(language.code, chunk)
+                    .executeAsList()
+                    .forEach { row ->
+                        if (!directResults.containsKey(row.lemma_normalized)) {
+                            val level = row.min_level?.let { rawValue ->
+                                com.slovy.slovymovyapp.data.dictionary.LearnerLevel.from(rawValue)
+                                    .let { dbLevel -> LearnerLevel.valueOf(dbLevel.name) }
+                            }
+                            directResults[row.lemma_normalized] = TokenResult(
+                                lemma = row.lemma,
+                                lemmaId = row.lemma_id,
+                                level = level,
+                                isFavorite = row.lemma.lowercase() in favoriteLemmas
+                            )
+                        }
+                    }
+            }
+            result.putAll(directResults)
+        }
+
+        result
+    }
+
     private suspend fun finalizeSearchResults(
         out: List<SearchItem>,
         maxItems: Int

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/data/remote/DictionaryRepository.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/data/remote/DictionaryRepository.kt
@@ -1170,4 +1170,7 @@ class DictionaryRepository(
             }
         }
     }
+
+    suspend fun getFavoriteLemmasByLang(language: Language): Set<String> =
+        favoritesRepository.getDistinctLemmasByLang(language)
 }

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/SearchScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/SearchScreen.kt
@@ -224,7 +224,8 @@ fun SearchScreen(
     wordDetailLabel: String? = null,
     onNavigateToWordDetail: () -> Unit = {},
     onNavigateToFavorites: () -> Unit = {},
-    onNavigateToSettings: () -> Unit = {}
+    onNavigateToSettings: () -> Unit = {},
+    onNavigateToTextReader: (Language) -> Unit = {}
 ) {
     val focusManager = LocalFocusManager.current
     // restore after process death
@@ -273,7 +274,8 @@ fun SearchScreen(
         wordDetailLabel = wordDetailLabel,
         onNavigateToWordDetail = onNavigateToWordDetail,
         onNavigateToFavorites = onNavigateToFavorites,
-        onNavigateToSettings = onNavigateToSettings
+        onNavigateToSettings = onNavigateToSettings,
+        onNavigateToTextReader = { viewModel.state.selectedLanguage?.let { onNavigateToTextReader(it) } }
     )
 }
 
@@ -290,7 +292,8 @@ fun SearchScreenContent(
     wordDetailLabel: String? = null,
     onNavigateToWordDetail: () -> Unit = {},
     onNavigateToFavorites: () -> Unit = {},
-    onNavigateToSettings: () -> Unit = {}
+    onNavigateToSettings: () -> Unit = {},
+    onNavigateToTextReader: () -> Unit = {}
 ) {
     val focusManager = LocalFocusManager.current
     val searchFocusRequester = remember { FocusRequester() }
@@ -423,8 +426,9 @@ fun SearchScreenContent(
                             EmptySearchState(
                                 wordSuggestions = state.wordSuggestions,
                                 favoriteLemmas = state.favoriteLemmas,
-                            onWordClick = onSuggestionSelected,
-                                showPullToRefreshHint = state.showPullToRefreshHint && !state.isSuggestionsRefreshing
+                                onWordClick = onSuggestionSelected,
+                                showPullToRefreshHint = state.showPullToRefreshHint && !state.isSuggestionsRefreshing,
+                                onNavigateToTextReader = onNavigateToTextReader
                             )
                         }
                     }
@@ -531,7 +535,8 @@ private fun EmptySearchState(
     wordSuggestions: List<String>,
     favoriteLemmas: List<String>,
     onWordClick: (String) -> Unit,
-    showPullToRefreshHint: Boolean = true
+    showPullToRefreshHint: Boolean = true,
+    onNavigateToTextReader: () -> Unit = {}
 ) {
     Column(
         modifier = Modifier
@@ -573,6 +578,12 @@ private fun EmptySearchState(
                 color = MaterialTheme.colorScheme.onSurfaceVariant
             )
         }
+
+        FilledTonalButton(onClick = onNavigateToTextReader) {
+            Text("Paste your text")
+        }
+
+        Spacer(modifier = Modifier.height(8.dp))
     }
 }
 
@@ -705,6 +716,27 @@ private fun SearchScreenPreviewEmptyQuery(
                 wordSuggestions = listOf("the", "be", "to", "of", "and"),
                 favoriteLemmas = listOf("world", "time", "love")
             ),
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun SearchScreenPreviewWithAnalyzeButton(
+    @PreviewParameter(ThemePreviewProvider::class) isDark: Boolean
+) {
+    ThemedPreview(darkTheme = isDark) {
+        SearchScreenContent(
+            state = SearchUiState(
+                query = "",
+                results = emptyList(),
+                showNoResults = false,
+                availableLanguages = listOf(Language.DUTCH),
+                selectedLanguage = Language.DUTCH,
+                wordSuggestions = listOf("lopen", "kijken", "mooi"),
+                favoriteLemmas = listOf("huis", "water")
+            ),
+            onNavigateToTextReader = {}
         )
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/SearchScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/SearchScreen.kt
@@ -580,7 +580,7 @@ private fun EmptySearchState(
         }
 
         FilledTonalButton(onClick = onNavigateToTextReader) {
-            Text("Paste your text")
+            Text("Add your text")
         }
 
         Spacer(modifier = Modifier.height(8.dp))

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/reader/TextReaderScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/reader/TextReaderScreen.kt
@@ -43,7 +43,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import kotlin.uuid.Uuid
 
-private val TOKEN_REGEX = Regex("[\\p{L}\\p{M}\\-']+|[^\\p{L}\\p{M}\\-']+")
+private val TOKEN_REGEX = Regex("[\\p{L}\\p{M}\\-']+|\\s+|[^\\p{L}\\p{M}\\-'\\s]+")
 private val PillShape = RoundedCornerShape(6.dp)
 private val HeartColor = Color(0xFFC46060)
 
@@ -117,6 +117,30 @@ private fun tokenize(text: String): List<TextToken> {
         val value = match.value
         TextToken(text = value, isWord = value.any { it.isLetter() })
     }.toList()
+}
+
+// Groups tokens so that each word stays with its immediately surrounding punctuation,
+// but groups never span more than one word. This prevents long runs of non-whitespace
+// tokens (e.g. URLs) from forming a single oversized FlowRow item.
+private fun groupTokensForRendering(tokens: List<TextToken>): List<List<TextToken>> {
+    val result = mutableListOf<List<TextToken>>()
+    val current = mutableListOf<TextToken>()
+    for (token in tokens) {
+        when {
+            !token.isWord && token.text.all { it.isWhitespace() } -> {
+                if (current.isNotEmpty()) { result.add(current.toList()); current.clear() }
+                result.add(listOf(token))
+            }
+            token.isWord && current.any { it.isWord } -> {
+                // Second word in the same run — flush and start a new group
+                result.add(current.toList()); current.clear()
+                current.add(token)
+            }
+            else -> current.add(token)
+        }
+    }
+    if (current.isNotEmpty()) result.add(current.toList())
+    return result
 }
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -295,63 +319,88 @@ private fun ResultView(
             horizontalArrangement = Arrangement.spacedBy(1.dp),
             verticalArrangement = Arrangement.spacedBy(8.dp)
         ) {
-            state.tokens.forEach { token ->
-                if (token.text.contains('\n')) {
-                    // Force a new row for each newline
-                    repeat(token.text.count { it == '\n' }) {
-                        Spacer(modifier = Modifier.fillMaxWidth())
+            val groups = remember(state.tokens) { groupTokensForRendering(state.tokens) }
+            groups.forEach { group ->
+                val single = group.singleOrNull()
+                if (single != null && !single.isWord && single.text.all { it.isWhitespace() }) {
+                    // Whitespace/newline group
+                    if (single.text.contains('\n')) {
+                        repeat(single.text.count { it == '\n' }) {
+                            Spacer(modifier = Modifier.fillMaxWidth())
+                        }
+                    } else {
+                        Text(
+                            text = single.text,
+                            style = MaterialTheme.typography.bodyLarge,
+                            modifier = Modifier.padding(vertical = 2.dp)
+                        )
                     }
-                } else if (!token.isWord) {
-                    // Spaces, punctuation, numbers — plain text, no pill
-                    // Vertical padding matches pill padding so baselines stay aligned
-                    Text(
-                        text = token.text,
-                        style = MaterialTheme.typography.bodyLarge,
-                        modifier = Modifier.padding(vertical = 2.dp)
-                    )
+                } else if (group.none { it.isWord }) {
+                    // Pure punctuation/number group — render directly as FlowRow items (no Row wrapper)
+                    group.forEach { token ->
+                        Text(
+                            text = token.text,
+                            style = MaterialTheme.typography.bodyLarge,
+                            modifier = Modifier.padding(vertical = 2.dp)
+                        )
+                    }
                 } else {
-                    // Every word token gets a pill
-                    val (bgColor, textColor) = levelColors[token.level] ?: (neutralBg to neutralText)
-                    val lemmaCapture = token.lemma
-                    val isFavorite = lemmaCapture != null &&
-                            state.favoriteLemmas.contains(lemmaCapture.lowercase())
-
-                    val semanticDescription = buildString {
-                        if (isFavorite) append("Saved, ")
-                        append(token.text)
-                        token.level?.let { append(", ${it.name} level") }
-                    }
-                    Box(
-                        modifier = Modifier
-                            .semantics { contentDescription = semanticDescription }
-                            .clip(PillShape)
-                            .background(bgColor)
-                            .then(
-                                if (lemmaCapture != null) Modifier.clickable(
-                                    onClickLabel = "Look up",
-                                    role = Role.Button
-                                ) { onWordClick(language, lemmaCapture) }
-                                else Modifier
-                            )
-                            .padding(horizontal = 4.dp, vertical = 2.dp)
-                    ) {
-                        Row(
-                            horizontalArrangement = Arrangement.spacedBy(3.dp),
-                            verticalAlignment = Alignment.CenterVertically
-                        ) {
-                            if (isFavorite) {
+                    // Word + adjacent punctuation group — wrap in Row so FlowRow never splits them
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        group.forEach { token ->
+                            if (!token.isWord) {
                                 Text(
-                                    text = "\u2665",
-                                    style = MaterialTheme.typography.labelMedium,
-                                    color = HeartColor,
-                                    modifier = Modifier.clearAndSetSemantics {}
+                                    text = token.text,
+                                    style = MaterialTheme.typography.bodyLarge,
+                                    modifier = Modifier.padding(vertical = 2.dp)
                                 )
+                            } else if (token.lemma == null) {
+                                // Word not found in dictionary — plain text, no pill
+                                Text(
+                                    text = token.text,
+                                    style = MaterialTheme.typography.bodyLarge,
+                                    modifier = Modifier.padding(vertical = 2.dp)
+                                )
+                            } else {
+                                val (bgColor, textColor) = levelColors[token.level] ?: (neutralBg to neutralText)
+                                val lemmaCapture = token.lemma
+                                val isFavorite = state.favoriteLemmas.contains(lemmaCapture.lowercase())
+                                val semanticDescription = buildString {
+                                    if (isFavorite) append("Saved, ")
+                                    append(token.text)
+                                    token.level?.let { append(", ${it.name} level") }
+                                }
+                                Box(
+                                    modifier = Modifier
+                                        .semantics { contentDescription = semanticDescription }
+                                        .clip(PillShape)
+                                        .background(bgColor)
+                                        .clickable(
+                                            onClickLabel = "Look up",
+                                            role = Role.Button
+                                        ) { onWordClick(language, lemmaCapture) }
+                                        .padding(horizontal = 4.dp, vertical = 2.dp)
+                                ) {
+                                    Row(
+                                        horizontalArrangement = Arrangement.spacedBy(3.dp),
+                                        verticalAlignment = Alignment.CenterVertically
+                                    ) {
+                                        if (isFavorite) {
+                                            Text(
+                                                text = "\u2665",
+                                                style = MaterialTheme.typography.labelMedium,
+                                                color = HeartColor,
+                                                modifier = Modifier.clearAndSetSemantics {}
+                                            )
+                                        }
+                                        Text(
+                                            text = token.text,
+                                            style = MaterialTheme.typography.bodyLarge,
+                                            color = textColor
+                                        )
+                                    }
+                                }
                             }
-                            Text(
-                                text = token.text,
-                                style = MaterialTheme.typography.bodyLarge,
-                                color = textColor
-                            )
                         }
                     }
                 }

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/reader/TextReaderScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/reader/TextReaderScreen.kt
@@ -1,9 +1,12 @@
 package com.slovy.slovymovyapp.ui.reader
 
 import androidx.compose.foundation.ScrollState
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
@@ -11,24 +14,29 @@ import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalClipboardManager
-import androidx.compose.ui.text.*
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.clearAndSetSemantics
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.compose.LifecycleResumeEffect
 import androidx.lifecycle.viewModelScope
 import com.slovy.slovymovyapp.data.Language
 import com.slovy.slovymovyapp.data.remote.DictionaryRepository
 import com.slovy.slovymovyapp.data.remote.LearnerLevel
+import com.slovy.slovymovyapp.ui.ThemePreviewProvider
 import com.slovy.slovymovyapp.ui.ThemedPreview
 import com.slovy.slovymovyapp.ui.theme.AppSpacing
-import com.slovy.slovymovyapp.util.stripAccents
-import com.slovy.slovymovyapp.ui.ThemePreviewProvider
 import com.slovy.slovymovyapp.ui.word.colorsForLevel
+import com.slovy.slovymovyapp.util.stripAccents
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -36,19 +44,20 @@ import kotlinx.coroutines.withContext
 import kotlin.uuid.Uuid
 
 private val TOKEN_REGEX = Regex("[\\p{L}\\p{M}\\-']+|[^\\p{L}\\p{M}\\-']+")
+private val PillShape = RoundedCornerShape(6.dp)
+private val HeartColor = Color(0xFFC46060)
 
 data class TextToken(
     val text: String,
     val lemma: String? = null,
     val lemmaId: Uuid? = null,
     val level: LearnerLevel? = null,
-    val isFavorite: Boolean = false,
     val isWord: Boolean
 )
 
 data class TextReaderUiState(
-    val inputText: String = "",
     val tokens: List<TextToken> = emptyList(),
+    val favoriteLemmas: Set<String> = emptySet(),
     val isAnalyzing: Boolean = false,
     val error: String? = null
 ) {
@@ -80,12 +89,12 @@ class TextReaderViewModel(
                         token.copy(
                             lemma = result?.lemma,
                             lemmaId = result?.lemmaId,
-                            level = result?.level,
-                            isFavorite = result?.isFavorite ?: false
+                            level = result?.level
                         )
                     }
                 }
-                state = state.copy(inputText = text, tokens = resolvedTokens, isAnalyzing = false)
+                val favoriteLemmas = repository.getFavoriteLemmasByLang(language)
+                state = state.copy(tokens = resolvedTokens, favoriteLemmas = favoriteLemmas, isAnalyzing = false)
             } catch (e: CancellationException) {
                 throw e
             } catch (e: Exception) {
@@ -94,8 +103,12 @@ class TextReaderViewModel(
         }
     }
 
-    fun resetToInput() {
-        state = state.copy(tokens = emptyList(), error = null)
+    fun refreshFavorites() {
+        if (state.tokens.isEmpty()) return
+        viewModelScope.launch {
+            val favoriteLemmas = repository.getFavoriteLemmasByLang(language)
+            state = state.copy(favoriteLemmas = favoriteLemmas)
+        }
     }
 }
 
@@ -113,12 +126,15 @@ fun TextReaderScreen(
     onWordClick: (language: Language, lemma: String) -> Unit,
     onBack: () -> Unit
 ) {
+    LifecycleResumeEffect(Unit) {
+        viewModel.refreshFavorites()
+        onPauseOrDispose {}
+    }
     TextReaderContent(
         state = viewModel.state,
         scrollState = viewModel.scrollState,
         language = viewModel.language,
         onAnalyze = { viewModel.analyzeText(it) },
-        onReset = { viewModel.resetToInput() },
         onWordClick = onWordClick,
         onBack = onBack
     )
@@ -131,7 +147,6 @@ fun TextReaderContent(
     scrollState: ScrollState = rememberScrollState(),
     language: Language = Language.DUTCH,
     onAnalyze: (String) -> Unit = {},
-    onReset: () -> Unit = {},
     onWordClick: (language: Language, lemma: String) -> Unit = { _, _ -> },
     onBack: () -> Unit = {}
 ) {
@@ -142,7 +157,7 @@ fun TextReaderContent(
                 colors = TopAppBarDefaults.topAppBarColors(containerColor = MaterialTheme.colorScheme.background),
                 title = {
                     Text(
-                        "Text reader",
+                        "Text reader · ${language.selfName}",
                         style = MaterialTheme.typography.headlineSmall.copy(fontWeight = FontWeight.SemiBold)
                     )
                 },
@@ -163,7 +178,6 @@ fun TextReaderContent(
                 scrollState = scrollState,
                 language = language,
                 onWordClick = onWordClick,
-                onReset = onReset,
                 modifier = Modifier.padding(innerPadding)
             )
         } else {
@@ -185,6 +199,7 @@ private fun InputView(
     modifier: Modifier = Modifier
 ) {
     val clipboardManager = LocalClipboardManager.current
+    var clipboardEmpty by remember { mutableStateOf(false) }
 
     Box(
         modifier = modifier.fillMaxSize(),
@@ -196,20 +211,45 @@ private fun InputView(
             modifier = Modifier.padding(horizontal = AppSpacing.xxl)
         ) {
             Text(
-                text = "Paste text to analyze word levels",
+                text = "Copy any text to your clipboard and paste it here with the button below",
                 style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                textAlign = TextAlign.Center
+            )
+            Text(
+                text = "Each word is looked up individually — phrases and multi-word expressions are not recognized",
+                style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
                 textAlign = TextAlign.Center
             )
 
             if (isAnalyzing) {
-                CircularProgressIndicator()
+                CircularProgressIndicator(
+                    modifier = Modifier.semantics { contentDescription = "Analyzing text" }
+                )
             } else {
                 FilledTonalButton(
-                    onClick = { onAnalyze(clipboardManager.getText()?.text ?: "") }
+                    onClick = {
+                        val text = clipboardManager.getText()?.text.orEmpty()
+                        if (text.isBlank()) {
+                            clipboardEmpty = true
+                        } else {
+                            clipboardEmpty = false
+                            onAnalyze(text)
+                        }
+                    }
                 ) {
                     Text("Paste")
                 }
+            }
+
+            if (clipboardEmpty) {
+                Text(
+                    text = "Clipboard is empty. Copy something awesome and paste here",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    textAlign = TextAlign.Center
+                )
             }
 
             if (error != null) {
@@ -224,102 +264,148 @@ private fun InputView(
     }
 }
 
+@OptIn(ExperimentalLayoutApi::class)
 @Composable
 private fun ResultView(
     state: TextReaderUiState,
     scrollState: ScrollState,
     language: Language,
     onWordClick: (language: Language, lemma: String) -> Unit,
-    onReset: () -> Unit,
     modifier: Modifier = Modifier
 ) {
-    // Resolve level background colors inside the Composable (theme-aware)
-    val levelBgColors: Map<LearnerLevel, Color> = mapOf(
-        LearnerLevel.A1 to colorsForLevel(LearnerLevel.A1).first,
-        LearnerLevel.A2 to colorsForLevel(LearnerLevel.A2).first,
-        LearnerLevel.B1 to colorsForLevel(LearnerLevel.B1).first,
-        LearnerLevel.B2 to colorsForLevel(LearnerLevel.B2).first,
-        LearnerLevel.C1 to colorsForLevel(LearnerLevel.C1).first,
-        LearnerLevel.C2 to colorsForLevel(LearnerLevel.C2).first
+    // Full (bg, text) color pairs per level — used as solid pill backgrounds
+    val levelColors: Map<LearnerLevel, Pair<Color, Color>> = mapOf(
+        LearnerLevel.A1 to colorsForLevel(LearnerLevel.A1),
+        LearnerLevel.A2 to colorsForLevel(LearnerLevel.A2),
+        LearnerLevel.B1 to colorsForLevel(LearnerLevel.B1),
+        LearnerLevel.B2 to colorsForLevel(LearnerLevel.B2),
+        LearnerLevel.C1 to colorsForLevel(LearnerLevel.C1),
+        LearnerLevel.C2 to colorsForLevel(LearnerLevel.C2),
     )
-    // Color for words found in the DB but not yet enriched with CEFR level data
-    val unenrichedBg = MaterialTheme.colorScheme.surfaceContainerHighest
-    val primaryColor = MaterialTheme.colorScheme.primary
-
-    val annotatedText = buildAnnotatedString {
-        state.tokens.forEach { token ->
-            if (!token.isWord || token.lemma == null || token.lemmaId == null) {
-                append(token.text)
-            } else {
-                // Known word: use level color if available, unenriched color otherwise
-                val bgColor = token.level?.let { levelBgColors[it] } ?: unenrichedBg
-                val spanStyle = if (token.isFavorite) {
-                    SpanStyle(background = bgColor, color = primaryColor, fontWeight = FontWeight.SemiBold)
-                } else {
-                    SpanStyle(background = bgColor)
-                }
-
-                val lemmaCapture = token.lemma
-                val link = LinkAnnotation.Clickable(
-                    tag = "WORD_${token.lemmaId}",
-                    linkInteractionListener = { onWordClick(language, lemmaCapture) }
-                )
-                withLink(link) {
-                    withStyle(spanStyle) { append(token.text) }
-                }
-            }
-        }
-    }
+    // Neutral pill for words not in the DB or without a CEFR level yet
+    val neutralBg = MaterialTheme.colorScheme.surfaceContainerHigh
+    val neutralText = MaterialTheme.colorScheme.onSurfaceVariant
 
     Column(modifier = modifier.fillMaxSize()) {
-        Text(
-            text = annotatedText,
-            style = MaterialTheme.typography.bodyLarge,
-            lineHeight = MaterialTheme.typography.bodyLarge.lineHeight * 1.6f,
+        FlowRow(
             modifier = Modifier
                 .weight(1f)
                 .verticalScroll(scrollState)
-                .padding(horizontal = AppSpacing.lg, vertical = AppSpacing.md)
-        )
+                .padding(horizontal = AppSpacing.lg, vertical = AppSpacing.md),
+            horizontalArrangement = Arrangement.spacedBy(1.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            state.tokens.forEach { token ->
+                if (token.text.contains('\n')) {
+                    // Force a new row for each newline
+                    repeat(token.text.count { it == '\n' }) {
+                        Spacer(modifier = Modifier.fillMaxWidth())
+                    }
+                } else if (!token.isWord) {
+                    // Spaces, punctuation, numbers — plain text, no pill
+                    // Vertical padding matches pill padding so baselines stay aligned
+                    Text(
+                        text = token.text,
+                        style = MaterialTheme.typography.bodyLarge,
+                        modifier = Modifier.padding(vertical = 2.dp)
+                    )
+                } else {
+                    // Every word token gets a pill
+                    val (bgColor, textColor) = levelColors[token.level] ?: (neutralBg to neutralText)
+                    val lemmaCapture = token.lemma
+                    val isFavorite = lemmaCapture != null &&
+                            state.favoriteLemmas.contains(lemmaCapture.lowercase())
+
+                    val semanticDescription = buildString {
+                        if (isFavorite) append("Saved, ")
+                        append(token.text)
+                        token.level?.let { append(", ${it.name} level") }
+                    }
+                    Box(
+                        modifier = Modifier
+                            .semantics { contentDescription = semanticDescription }
+                            .clip(PillShape)
+                            .background(bgColor)
+                            .then(
+                                if (lemmaCapture != null) Modifier.clickable(
+                                    onClickLabel = "Look up",
+                                    role = Role.Button
+                                ) { onWordClick(language, lemmaCapture) }
+                                else Modifier
+                            )
+                            .padding(horizontal = 4.dp, vertical = 2.dp)
+                    ) {
+                        Row(
+                            horizontalArrangement = Arrangement.spacedBy(3.dp),
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            if (isFavorite) {
+                                Text(
+                                    text = "\u2665",
+                                    style = MaterialTheme.typography.labelMedium,
+                                    color = HeartColor,
+                                    modifier = Modifier.clearAndSetSemantics {}
+                                )
+                            }
+                            Text(
+                                text = token.text,
+                                style = MaterialTheme.typography.bodyLarge,
+                                color = textColor
+                            )
+                        }
+                    }
+                }
+            }
+        }
 
         Surface(color = MaterialTheme.colorScheme.surfaceContainer) {
             Row(
                 modifier = Modifier
                     .fillMaxWidth()
                     .horizontalScroll(rememberScrollState())
-                    .padding(horizontal = AppSpacing.lg, vertical = AppSpacing.sm),
+                    .padding(horizontal = AppSpacing.lg, vertical = AppSpacing.md)
+                    .semantics(mergeDescendants = false) {
+                        contentDescription = "Level legend"
+                    },
                 horizontalArrangement = Arrangement.spacedBy(6.dp),
                 verticalAlignment = Alignment.CenterVertically
             ) {
                 LearnerLevel.entries.forEach { level ->
-                    val bg = levelBgColors[level] ?: return@forEach
+                    val (bg, fg) = levelColors[level] ?: return@forEach
                     Surface(
                         color = bg,
-                        shape = MaterialTheme.shapes.extraSmall
+                        shape = MaterialTheme.shapes.extraSmall,
+                        modifier = Modifier.clearAndSetSemantics {}
                     ) {
                         Text(
                             text = level.name,
                             style = MaterialTheme.typography.labelSmall,
+                            color = fg,
                             modifier = Modifier.padding(horizontal = 6.dp, vertical = 2.dp)
                         )
                     }
                 }
                 Surface(
-                    color = unenrichedBg,
-                    shape = MaterialTheme.shapes.extraSmall
+                    color = neutralBg,
+                    shape = MaterialTheme.shapes.extraSmall,
+                    modifier = Modifier.clearAndSetSemantics {}
                 ) {
-                    Text(
-                        text = "?",
-                        style = MaterialTheme.typography.labelSmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        modifier = Modifier.padding(horizontal = 6.dp, vertical = 2.dp)
-                    )
-                }
-
-                Spacer(modifier = Modifier.weight(1f))
-
-                TextButton(onClick = onReset) {
-                    Text("Edit", style = MaterialTheme.typography.labelMedium)
+                    Row(
+                        modifier = Modifier.padding(horizontal = 6.dp, vertical = 2.dp),
+                        horizontalArrangement = Arrangement.spacedBy(3.dp),
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Text(
+                            text = "\u2665",
+                            style = MaterialTheme.typography.labelSmall,
+                            color = HeartColor
+                        )
+                        Text(
+                            text = "Saved",
+                            style = MaterialTheme.typography.labelSmall,
+                            color = neutralText
+                        )
+                    }
                 }
             }
         }
@@ -362,13 +448,12 @@ private fun TextReaderResultPreview(
     ThemedPreview(darkTheme = isDark) {
         TextReaderContent(
             state = TextReaderUiState(
-                inputText = "De kinderen liepen door het park.",
                 tokens = listOf(
                     TextToken("De", lemma = "de", lemmaId = Uuid.parse("00000000-0000-0000-0000-000000000001"), level = LearnerLevel.A1, isWord = true),
                     TextToken(" ", isWord = false),
                     TextToken("kinderen", lemma = "kind", lemmaId = Uuid.parse("00000000-0000-0000-0000-000000000002"), level = LearnerLevel.A1, isWord = true),
                     TextToken(" ", isWord = false),
-                    TextToken("liepen", lemma = "lopen", lemmaId = Uuid.parse("00000000-0000-0000-0000-000000000003"), level = LearnerLevel.A2, isFavorite = true, isWord = true),
+                    TextToken("liepen", lemma = "lopen", lemmaId = Uuid.parse("00000000-0000-0000-0000-000000000003"), level = LearnerLevel.A2, isWord = true),
                     TextToken(" ", isWord = false),
                     TextToken("door", lemma = "door", lemmaId = Uuid.parse("00000000-0000-0000-0000-000000000004"), level = LearnerLevel.A1, isWord = true),
                     TextToken(" ", isWord = false),
@@ -384,7 +469,8 @@ private fun TextReaderResultPreview(
                     TextToken("woorden", lemma = "woord", lemmaId = Uuid.parse("00000000-0000-0000-0000-000000000007"), level = LearnerLevel.C1, isWord = true),
                     TextToken(" ", isWord = false),
                     TextToken("complexe", lemma = "complex", lemmaId = Uuid.parse("00000000-0000-0000-0000-000000000008"), level = LearnerLevel.C2, isWord = true),
-                )
+                ),
+                favoriteLemmas = setOf("lopen")
             ),
             language = Language.DUTCH
         )

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/reader/TextReaderScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/reader/TextReaderScreen.kt
@@ -113,10 +113,25 @@ class TextReaderViewModel(
 }
 
 private fun tokenize(text: String): List<TextToken> {
-    return TOKEN_REGEX.findAll(text).map { match ->
+    val result = mutableListOf<TextToken>()
+    for (match in TOKEN_REGEX.findAll(text)) {
         val value = match.value
-        TextToken(text = value, isWord = value.any { it.isLetter() })
-    }.toList()
+        if (!value.any { it.isLetter() }) {
+            result.add(TextToken(text = value, isWord = false))
+            continue
+        }
+        // Strip leading/trailing hyphens and apostrophes so that bullet-style
+        // "-word" and quoted "'rijk'" are looked up without the surrounding symbol.
+        // Mid-word occurrences (you're, arm-rijk) are preserved unchanged.
+        val trimmedStart = value.trimStart('-', '\'')
+        val leading = value.length - trimmedStart.length
+        val core = trimmedStart.trimEnd('-', '\'')
+        val trailing = trimmedStart.length - core.length
+        if (leading > 0) result.add(TextToken(text = value.take(leading), isWord = false))
+        result.add(TextToken(text = core, isWord = core.any { it.isLetter() }))
+        if (trailing > 0) result.add(TextToken(text = trimmedStart.takeLast(trailing), isWord = false))
+    }
+    return result
 }
 
 // Groups tokens so that each word stays with its immediately surrounding punctuation,

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/reader/TextReaderScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/reader/TextReaderScreen.kt
@@ -1,0 +1,392 @@
+package com.slovy.slovymovyapp.ui.reader
+
+import androidx.compose.foundation.ScrollState
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalClipboardManager
+import androidx.compose.ui.text.*
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewParameter
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.slovy.slovymovyapp.data.Language
+import com.slovy.slovymovyapp.data.remote.DictionaryRepository
+import com.slovy.slovymovyapp.data.remote.LearnerLevel
+import com.slovy.slovymovyapp.ui.ThemedPreview
+import com.slovy.slovymovyapp.ui.theme.AppSpacing
+import com.slovy.slovymovyapp.util.stripAccents
+import com.slovy.slovymovyapp.ui.ThemePreviewProvider
+import com.slovy.slovymovyapp.ui.word.colorsForLevel
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import kotlin.uuid.Uuid
+
+private val TOKEN_REGEX = Regex("[\\p{L}\\p{M}\\-']+|[^\\p{L}\\p{M}\\-']+")
+
+data class TextToken(
+    val text: String,
+    val lemma: String? = null,
+    val lemmaId: Uuid? = null,
+    val level: LearnerLevel? = null,
+    val isFavorite: Boolean = false,
+    val isWord: Boolean
+)
+
+data class TextReaderUiState(
+    val inputText: String = "",
+    val tokens: List<TextToken> = emptyList(),
+    val isAnalyzing: Boolean = false,
+    val error: String? = null
+) {
+    val hasResults: Boolean get() = tokens.isNotEmpty()
+}
+
+class TextReaderViewModel(
+    private val repository: DictionaryRepository,
+    val language: Language
+) : ViewModel() {
+
+    var state by mutableStateOf(TextReaderUiState())
+        private set
+
+    val scrollState = ScrollState(0)
+
+    fun analyzeText(text: String) {
+        if (text.isBlank()) return
+        viewModelScope.launch {
+            state = state.copy(isAnalyzing = true, error = null)
+            try {
+                val tokens = withContext(Dispatchers.Default) { tokenize(text) }
+                val uniqueForms = tokens.filter { it.isWord }.map { stripAccents(it.text) }.distinct()
+                val results = repository.lookupTokensBatch(uniqueForms, language)
+                val resolvedTokens = tokens.map { token ->
+                    if (!token.isWord) token
+                    else {
+                        val result = results[stripAccents(token.text)]
+                        token.copy(
+                            lemma = result?.lemma,
+                            lemmaId = result?.lemmaId,
+                            level = result?.level,
+                            isFavorite = result?.isFavorite ?: false
+                        )
+                    }
+                }
+                state = state.copy(inputText = text, tokens = resolvedTokens, isAnalyzing = false)
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                state = state.copy(isAnalyzing = false, error = e.message ?: "Error analyzing text")
+            }
+        }
+    }
+
+    fun resetToInput() {
+        state = state.copy(tokens = emptyList(), error = null)
+    }
+}
+
+private fun tokenize(text: String): List<TextToken> {
+    return TOKEN_REGEX.findAll(text).map { match ->
+        val value = match.value
+        TextToken(text = value, isWord = value.any { it.isLetter() })
+    }.toList()
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun TextReaderScreen(
+    viewModel: TextReaderViewModel,
+    onWordClick: (language: Language, lemma: String) -> Unit,
+    onBack: () -> Unit
+) {
+    TextReaderContent(
+        state = viewModel.state,
+        scrollState = viewModel.scrollState,
+        language = viewModel.language,
+        onAnalyze = { viewModel.analyzeText(it) },
+        onReset = { viewModel.resetToInput() },
+        onWordClick = onWordClick,
+        onBack = onBack
+    )
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun TextReaderContent(
+    state: TextReaderUiState,
+    scrollState: ScrollState = rememberScrollState(),
+    language: Language = Language.DUTCH,
+    onAnalyze: (String) -> Unit = {},
+    onReset: () -> Unit = {},
+    onWordClick: (language: Language, lemma: String) -> Unit = { _, _ -> },
+    onBack: () -> Unit = {}
+) {
+    Scaffold(
+        containerColor = MaterialTheme.colorScheme.background,
+        topBar = {
+            CenterAlignedTopAppBar(
+                colors = TopAppBarDefaults.topAppBarColors(containerColor = MaterialTheme.colorScheme.background),
+                title = {
+                    Text(
+                        "Text reader",
+                        style = MaterialTheme.typography.headlineSmall.copy(fontWeight = FontWeight.SemiBold)
+                    )
+                },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = "Back"
+                        )
+                    }
+                }
+            )
+        }
+    ) { innerPadding ->
+        if (state.hasResults) {
+            ResultView(
+                state = state,
+                scrollState = scrollState,
+                language = language,
+                onWordClick = onWordClick,
+                onReset = onReset,
+                modifier = Modifier.padding(innerPadding)
+            )
+        } else {
+            InputView(
+                isAnalyzing = state.isAnalyzing,
+                error = state.error,
+                onAnalyze = onAnalyze,
+                modifier = Modifier.padding(innerPadding)
+            )
+        }
+    }
+}
+
+@Composable
+private fun InputView(
+    isAnalyzing: Boolean,
+    error: String?,
+    onAnalyze: (String) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val clipboardManager = LocalClipboardManager.current
+
+    Box(
+        modifier = modifier.fillMaxSize(),
+        contentAlignment = Alignment.Center
+    ) {
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(AppSpacing.lg),
+            modifier = Modifier.padding(horizontal = AppSpacing.xxl)
+        ) {
+            Text(
+                text = "Paste text to analyze word levels",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                textAlign = TextAlign.Center
+            )
+
+            if (isAnalyzing) {
+                CircularProgressIndicator()
+            } else {
+                FilledTonalButton(
+                    onClick = { onAnalyze(clipboardManager.getText()?.text ?: "") }
+                ) {
+                    Text("Paste")
+                }
+            }
+
+            if (error != null) {
+                Text(
+                    text = error,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.error,
+                    textAlign = TextAlign.Center
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun ResultView(
+    state: TextReaderUiState,
+    scrollState: ScrollState,
+    language: Language,
+    onWordClick: (language: Language, lemma: String) -> Unit,
+    onReset: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    // Resolve level background colors inside the Composable (theme-aware)
+    val levelBgColors: Map<LearnerLevel, Color> = mapOf(
+        LearnerLevel.A1 to colorsForLevel(LearnerLevel.A1).first,
+        LearnerLevel.A2 to colorsForLevel(LearnerLevel.A2).first,
+        LearnerLevel.B1 to colorsForLevel(LearnerLevel.B1).first,
+        LearnerLevel.B2 to colorsForLevel(LearnerLevel.B2).first,
+        LearnerLevel.C1 to colorsForLevel(LearnerLevel.C1).first,
+        LearnerLevel.C2 to colorsForLevel(LearnerLevel.C2).first
+    )
+    // Color for words found in the DB but not yet enriched with CEFR level data
+    val unenrichedBg = MaterialTheme.colorScheme.surfaceContainerHighest
+    val primaryColor = MaterialTheme.colorScheme.primary
+
+    val annotatedText = buildAnnotatedString {
+        state.tokens.forEach { token ->
+            if (!token.isWord || token.lemma == null || token.lemmaId == null) {
+                append(token.text)
+            } else {
+                // Known word: use level color if available, unenriched color otherwise
+                val bgColor = token.level?.let { levelBgColors[it] } ?: unenrichedBg
+                val spanStyle = if (token.isFavorite) {
+                    SpanStyle(background = bgColor, color = primaryColor, fontWeight = FontWeight.SemiBold)
+                } else {
+                    SpanStyle(background = bgColor)
+                }
+
+                val lemmaCapture = token.lemma
+                val link = LinkAnnotation.Clickable(
+                    tag = "WORD_${token.lemmaId}",
+                    linkInteractionListener = { onWordClick(language, lemmaCapture) }
+                )
+                withLink(link) {
+                    withStyle(spanStyle) { append(token.text) }
+                }
+            }
+        }
+    }
+
+    Column(modifier = modifier.fillMaxSize()) {
+        Text(
+            text = annotatedText,
+            style = MaterialTheme.typography.bodyLarge,
+            lineHeight = MaterialTheme.typography.bodyLarge.lineHeight * 1.6f,
+            modifier = Modifier
+                .weight(1f)
+                .verticalScroll(scrollState)
+                .padding(horizontal = AppSpacing.lg, vertical = AppSpacing.md)
+        )
+
+        Surface(color = MaterialTheme.colorScheme.surfaceContainer) {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .horizontalScroll(rememberScrollState())
+                    .padding(horizontal = AppSpacing.lg, vertical = AppSpacing.sm),
+                horizontalArrangement = Arrangement.spacedBy(6.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                LearnerLevel.entries.forEach { level ->
+                    val bg = levelBgColors[level] ?: return@forEach
+                    Surface(
+                        color = bg,
+                        shape = MaterialTheme.shapes.extraSmall
+                    ) {
+                        Text(
+                            text = level.name,
+                            style = MaterialTheme.typography.labelSmall,
+                            modifier = Modifier.padding(horizontal = 6.dp, vertical = 2.dp)
+                        )
+                    }
+                }
+                Surface(
+                    color = unenrichedBg,
+                    shape = MaterialTheme.shapes.extraSmall
+                ) {
+                    Text(
+                        text = "?",
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.padding(horizontal = 6.dp, vertical = 2.dp)
+                    )
+                }
+
+                Spacer(modifier = Modifier.weight(1f))
+
+                TextButton(onClick = onReset) {
+                    Text("Edit", style = MaterialTheme.typography.labelMedium)
+                }
+            }
+        }
+    }
+}
+
+// ──────────────────────────────── Previews ────────────────────────────────
+
+@Preview
+@Composable
+private fun TextReaderInputEmptyPreview(
+    @PreviewParameter(ThemePreviewProvider::class) isDark: Boolean
+) {
+    ThemedPreview(darkTheme = isDark) {
+        TextReaderContent(
+            state = TextReaderUiState(),
+            language = Language.DUTCH
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun TextReaderInputAnalyzingPreview(
+    @PreviewParameter(ThemePreviewProvider::class) isDark: Boolean
+) {
+    ThemedPreview(darkTheme = isDark) {
+        TextReaderContent(
+            state = TextReaderUiState(isAnalyzing = true),
+            language = Language.DUTCH
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun TextReaderResultPreview(
+    @PreviewParameter(ThemePreviewProvider::class) isDark: Boolean
+) {
+    ThemedPreview(darkTheme = isDark) {
+        TextReaderContent(
+            state = TextReaderUiState(
+                inputText = "De kinderen liepen door het park.",
+                tokens = listOf(
+                    TextToken("De", lemma = "de", lemmaId = Uuid.parse("00000000-0000-0000-0000-000000000001"), level = LearnerLevel.A1, isWord = true),
+                    TextToken(" ", isWord = false),
+                    TextToken("kinderen", lemma = "kind", lemmaId = Uuid.parse("00000000-0000-0000-0000-000000000002"), level = LearnerLevel.A1, isWord = true),
+                    TextToken(" ", isWord = false),
+                    TextToken("liepen", lemma = "lopen", lemmaId = Uuid.parse("00000000-0000-0000-0000-000000000003"), level = LearnerLevel.A2, isFavorite = true, isWord = true),
+                    TextToken(" ", isWord = false),
+                    TextToken("door", lemma = "door", lemmaId = Uuid.parse("00000000-0000-0000-0000-000000000004"), level = LearnerLevel.A1, isWord = true),
+                    TextToken(" ", isWord = false),
+                    TextToken("het", lemma = "het", lemmaId = Uuid.parse("00000000-0000-0000-0000-000000000005"), level = LearnerLevel.A1, isWord = true),
+                    TextToken(" ", isWord = false),
+                    TextToken("park", lemma = "park", lemmaId = Uuid.parse("00000000-0000-0000-0000-000000000006"), level = LearnerLevel.B1, isWord = true),
+                    TextToken(".", isWord = false),
+                    TextToken("\n\n", isWord = false),
+                    TextToken("onbekend", isWord = true),
+                    TextToken(" ", isWord = false),
+                    TextToken("beleggen", lemma = "beleggen", lemmaId = Uuid.parse("00000000-0000-0000-0000-000000000009"), level = null, isWord = true),
+                    TextToken(" ", isWord = false),
+                    TextToken("woorden", lemma = "woord", lemmaId = Uuid.parse("00000000-0000-0000-0000-000000000007"), level = LearnerLevel.C1, isWord = true),
+                    TextToken(" ", isWord = false),
+                    TextToken("complexe", lemma = "complex", lemmaId = Uuid.parse("00000000-0000-0000-0000-000000000008"), level = LearnerLevel.C2, isWord = true),
+                )
+            ),
+            language = Language.DUTCH
+        )
+    }
+}

--- a/shared/src/commonMain/sqldelight/dictionarydb/com/slovy/slovymovyapp/dictionary/Dictionary.sq
+++ b/shared/src/commonMain/sqldelight/dictionarydb/com/slovy/slovymovyapp/dictionary/Dictionary.sq
@@ -369,3 +369,28 @@ WHERE l.lang_code = ?
   )
 ORDER BY l.zipf_frequency DESC
 LIMIT ? OFFSET ?;
+
+-- Batch lookup of lemma + min learner level by normalized forms (for text reader feature).
+-- Exact lemma matches (form == lemma) are ranked first, then by frequency.
+selectTokenDataByForms:
+SELECT f.form_normalized, l.id AS lemma_id, l.lemma, MIN(CAST(s.learner_level AS INTEGER)) AS min_level
+FROM form f
+JOIN lemma_pos lp ON lp.id = f.lemma_pos_id
+JOIN lemma l ON l.id = lp.lemma_id
+LEFT JOIN sense s ON s.lemma_pos_id = lp.id
+WHERE l.lang_code = ? AND f.form_normalized IN ?
+GROUP BY f.form_normalized, l.id, l.lemma
+ORDER BY (CASE WHEN l.lemma_normalized = f.form_normalized THEN 1 ELSE 0 END) DESC,
+         l.zipf_frequency DESC;
+
+-- Direct lemma batch lookup (text reader: exact lemma match overrides form-based match).
+-- Used as a second pass so that e.g. "wat" resolves to lemma "wat", not a higher-freq word
+-- that happens to have "wat" as an inflected form.
+selectTokenDataByLemmas:
+SELECT l.lemma_normalized, l.id AS lemma_id, l.lemma, MIN(CAST(s.learner_level AS INTEGER)) AS min_level
+FROM lemma l
+JOIN lemma_pos lp ON lp.lemma_id = l.id
+LEFT JOIN sense s ON s.lemma_pos_id = lp.id
+WHERE l.lang_code = ? AND l.lemma_normalized IN ?
+GROUP BY l.lemma_normalized, l.id, l.lemma
+ORDER BY l.zipf_frequency DESC;


### PR DESCRIPTION
## Summary

- New **Text Reader** screen: paste any text and every word is highlighted with a colour-coded pill matching its CEFR level (A1–C2). Unknown words get a neutral grey pill; saved favourites show a ♥ icon.
- Entry point added to the Search screen empty state — **"Add your text"** button.
- Favourites sync on resume: navigating to a word, saving it, and returning back immediately reflects the heart on the pill without re-analysing.

## Changes

- `TextReaderScreen.kt` — `TextReaderViewModel`, `TextReaderUiState`, `TextToken`, `InputView`, `ResultView`, previews
- `Dictionary.sq` — `selectTokenDataByForms` query (form → lemma/level lookup)
- `DictionaryRepository.kt` — `lookupTokensBatch`, `TokenResult`, `getFavoriteLemmasByLang`
- `SearchScreen.kt` — "Add your text" button in empty state
- `App.kt` — `AppDestination.TextReader` route + navigation wiring

## Accessibility

- Word pills: `role = Role.Button`, `onClickLabel = "Look up"`, `contentDescription` with level and saved state
- ♥ heart suppressed from TalkBack (`clearAndSetSemantics`)
- `CircularProgressIndicator` labelled "Analyzing text"
- Legend bar marked as decorative with a single "Level legend" label

## Test plan

- [ ] Paste a text in the target language — words highlighted by level, unknown words in grey
- [ ] Tap a word — navigates to word detail
- [ ] Save a word as favourite, return — pill shows ♥ without re-analysing
- [ ] Paste with empty clipboard — "Clipboard is empty" hint appears
- [ ] Light and dark theme — colours readable in both
- [ ] TalkBack / accessibility scan — pills announced correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)