### PR TITLE
Rework English verb forms display

### DIFF
--- a/composeApp/src/commonTest/kotlin/com/slovy/slovymovyapp/forms/EnConjugationSchemeTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/slovy/slovymovyapp/forms/EnConjugationSchemeTest.kt
@@ -46,10 +46,12 @@ class EnConjugationSchemeTest : BaseTest() {
 
     private val expectedEnVerbTest = mapOf(
         "en_verb:short" to listOf(
-            listOf(null, null, null, null),
-            listOf(null, "test", null, "tests"),
-            listOf(null, "tested", null, "tested"),
-            listOf(null, "testing", null)
+            listOf(null, "test"),    // infinitive
+            listOf(null, "test"),    // present (I)
+            listOf(null, "tests"),   // present (he/she/it)
+            listOf(null, "testing"), // present participle
+            listOf(null, "tested"),  // past simple
+            listOf(null, "tested"),  // past participle
         )
     )
 

--- a/shared/src/commonMain/kotlin/com/slovy/slovymovyapp/data/forms/configs/EnConjugationScheme.kt
+++ b/shared/src/commonMain/kotlin/com/slovy/slovymovyapp/data/forms/configs/EnConjugationScheme.kt
@@ -16,15 +16,34 @@ object EnConjugationScheme : ConjugationSchemeProvider {
                 if (baseWord.isEmpty()) return forms
                 if (forms.isEmpty()) return forms
 
-                val hasInfinitive = forms.any { it.hasTag("infinitive") }
-                if (hasInfinitive) return forms
-
-                val shouldSkipInfinitiveInference = forms.any { form ->
+                val shouldSkipInference = forms.any { form ->
                     form.hasTag("form-of") || form.hasTag("gerund")
                 }
-                if (shouldSkipInfinitiveInference) return forms
+                if (shouldSkipInference) return forms
 
-                return forms + SchemeInputForm(tags = listOf("infinitive"), form = baseWord, FormSource.HEURISTIC)
+                val result = forms.toMutableList()
+
+                val hasInfinitive = forms.any { it.hasTag("infinitive") }
+                if (!hasInfinitive) {
+                    result += SchemeInputForm(tags = listOf("infinitive"), form = baseWord, FormSource.HEURISTIC)
+                }
+
+                val hasFirstPersonPresent = forms.any {
+                    it.hasTag("first-person") && it.hasTag("present") && it.hasTag("singular")
+                }
+                if (!hasFirstPersonPresent) {
+                    val presentSingularNonThird = forms.firstOrNull { form ->
+                        form.hasTag("present") && form.hasTag("singular") && !form.hasTag("third-person")
+                    }
+                    val inferredForm = presentSingularNonThird?.form ?: baseWord
+                    result += SchemeInputForm(
+                        tags = listOf("first-person", "present", "singular"),
+                        form = inferredForm,
+                        FormSource.HEURISTIC
+                    )
+                }
+
+                return result
             }
 
             if (pos != DictionaryPos.NOUN) return forms
@@ -89,27 +108,28 @@ object EnConjugationScheme : ConjugationSchemeProvider {
     ) {
         view("short", "Principal parts") {
             row {
-                colHeader("Category")
-                colHeader("Form")
-                colHeader("Category")
-                colHeader("Form")
-            }
-            row {
                 rowHeader("infinitive")
                 data(VerbForm.INFINITIVE)
-                rowHeader("3rd sg. present")
+            }
+            row {
+                rowHeader("present (I)")
+                data(Person.FIRST, Tense.PRESENT, Num.SG)
+            }
+            row {
+                rowHeader("present (he/she/it)")
                 data(Person.THIRD, Tense.PRESENT, Num.SG)
             }
             row {
-                rowHeader("simple past")
-                data(Tense.PAST, supporting = setOf(VerbForm.FINITE))
-                rowHeader("past participle")
-                data(VerbForm.PARTICIPLE, Tense.PAST)
+                rowHeader("present participle")
+                data(VerbForm.PARTICIPLE, Tense.PRESENT)
             }
             row {
-                rowHeader("pres. participle / gerund")
-                data(VerbForm.PARTICIPLE, Tense.PRESENT)
-                empty(colspan = 2)
+                rowHeader("past simple")
+                data(Tense.PAST, supporting = setOf(VerbForm.FINITE))
+            }
+            row {
+                rowHeader("past participle")
+                data(VerbForm.PARTICIPLE, Tense.PAST)
             }
         }
     }


### PR DESCRIPTION
## Summary
- Single-column layout for the English verb table (was two-column)
- Rename labels: "3rd sg. present" → "present (he/she/it)", "simple past" → "past simple", "pres. participle / gerund" → "present participle"
- Add "present (I)" row (first-person singular present)
- Add heuristic to infer first-person present singular when not explicitly stored in DB: uses an existing `present + singular` non-third-person form if available, otherwise falls back to the base word

## Test plan
- [ ] `EnConjugationSchemeTest` snapshot updated and passing (`./gradlew :composeApp:desktopTest`)
- [ ] Verify verb table renders correctly for regular verbs (test, broadcast), irregular verbs (stand, must)

🤖 Generated with [Claude Code](https://claude.com/claude-code)