### PR TITLE
Fix NL adjective base form for invariable adjectives (houten, gouden)

### DIFF
--- a/composeApp/src/commonTest/kotlin/com/slovy/slovymovyapp/forms/NlConjugationSchemeTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/slovy/slovymovyapp/forms/NlConjugationSchemeTest.kt
@@ -49,6 +49,31 @@ class NlConjugationSchemeTest : BaseTest() {
     }
 
     @Test
+    fun preprocessForms_orphanClosingParen_droppedBalancedRetained() {
+        val resolver = NlConjugationScheme.NL_ADJECTIVE.tagResolver
+
+        // "attributief)" is the orphaned second half of a split "(alleen attributief)"
+        // DB entry. It has no opening '(' so it must be dropped entirely.
+        val orphan = SchemeInputForm(
+            tags = listOf("positive", "uninflected"),
+            form = "attributief)",
+            source = FormSource.NATIVE,
+        )
+        val orphanResult = resolver.preprocessForms(listOf(orphan), null)
+        assertTrue(orphanResult.isEmpty(), "Orphaned closing-paren form must be filtered out")
+
+        // "iets (formeel)" has balanced parentheses and must survive.
+        val balanced = SchemeInputForm(
+            tags = listOf("positive", "uninflected"),
+            form = "iets (formeel)",
+            source = FormSource.NATIVE,
+        )
+        val balancedResult = resolver.preprocessForms(listOf(balanced), null)
+        assertEquals(1, balancedResult.size, "Balanced parenthetical form must be retained")
+        assertEquals("iets (formeel)", balancedResult.first().form)
+    }
+
+    @Test
     fun dutchSnapshots_matchExpectedTables() = runBlocking {
         val (mgr, repo) = createSnapshotRepository()
         try {

--- a/shared/src/commonMain/kotlin/com/slovy/slovymovyapp/data/forms/configs/NlConjugationScheme.kt
+++ b/shared/src/commonMain/kotlin/com/slovy/slovymovyapp/data/forms/configs/NlConjugationScheme.kt
@@ -23,7 +23,13 @@ object NlConjugationScheme : ConjugationSchemeProvider {
                         form.copy(form = form.form.trim())
                 }
                 .filter { form ->
-                    form.form.isNotEmpty() && !form.form.startsWith('(') && !form.form.endsWith(',')
+                    // Also drop forms that end with ')' but have no '(': they are the orphaned
+                    // second half of a split parenthetical annotation (e.g. "attributief)" from
+                    // a DB entry that stored "(alleen attributief)" as two broken rows).
+                    form.form.isNotEmpty()
+                        && !form.form.startsWith('(')
+                        && !form.form.endsWith(',')
+                        && (!form.form.endsWith(')') || '(' in form.form)
                 }
 
             // Canonicalize diminutive number tags using Dutch morphology (-je = singular, -jes = plural).


### PR DESCRIPTION
## Summary

- Drop orphaned closing-paren forms in Dutch preprocessing: some DB entries store `(alleen attributief)` as two broken rows — `(alleen` and `attributief)`. The existing `startsWith('(')` filter already drops the first half; this adds a matching rule to drop forms ending with `)` that contain no `(`, preventing `attributief)` from appearing as the Positive (Base) form for invariable adjectives like _houten_ and _gouden_.
- Adds `preprocessForms_orphanClosingParen_droppedBalancedRetained` unit test to pin the new filter and verify balanced forms like `iets (formeel)` are unaffected.

## Test plan

- [x] `./gradlew :composeApp:desktopTest --tests "*.NlConjugationSchemeTest"` passes
- [ ] Verify in app: _houten_ and _gouden_ now show the correct form in the Positive (Base) cell instead of `attributief)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)