### PR TITLE
Adaptive column widths in forms table

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/word/EntryCard.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/word/EntryCard.kt
@@ -159,10 +159,11 @@ internal data class ColumnWidthInput(
  * Computes per-column pixel widths from measured cell intrinsic widths.
  *
  * Pass 1 – single-column cells: each column is at least as wide as its widest cell.
- * Pass 2 – multi-column spans: if the span's intrinsic width exceeds the sum of its
- *   columns' current widths, the deficit is distributed evenly across columns that still
- *   have room below [maxColWidthPx]. When a column is capped, its overflow is
- *   redistributed to the remaining uncapped columns rather than being dropped.
+ * Pass 2 – multi-column spans: spans are processed in canonical order (shorter before
+ *   longer, ties broken left-to-right by anchorColumn) so results are independent of
+ *   declaration order in the grid. Within each span, deficit is distributed evenly
+ *   across columns with room; when a column hits [maxColWidthPx] its overflow is
+ *   redistributed to remaining uncapped columns rather than being dropped.
  */
 internal fun computeColumnWidths(
     maxColumns: Int,
@@ -182,9 +183,11 @@ internal fun computeColumnWidths(
         }
     }
 
-    // Pass 2: multi-column spans with iterative deficit redistribution
-    for (input in inputs) {
-        if (input.colspan > 1) {
+    // Pass 2: multi-column spans — canonical order removes declaration-order dependence.
+    // Shorter spans run before longer ones; equal-length spans run left-to-right.
+    val spans = inputs.filter { it.colspan > 1 }
+        .sortedWith(compareBy({ it.colspan }, { it.anchorColumn }))
+    for (input in spans) {
             val spanCols = input.anchorColumn until input.anchorColumn + input.colspan
             var remaining = input.intrinsicWidthPx - spanCols.sumOf { colWidths[it] }
             if (remaining > 0) {
@@ -209,7 +212,6 @@ internal fun computeColumnWidths(
                     remaining = overflow
                 }
             }
-        }
     }
 
     return colWidths
@@ -234,12 +236,15 @@ private fun SpannedFormsGrid(
     val maxColumns = matrix.maxOfOrNull { it.size } ?: 0
 
     // Cache column widths so the layout hot-path skips intrinsic measurement on every pass.
-    // A new stamp object is allocated only when inputs that affect column widths change
-    // (different word, different dp bounds, or density/font-scale change). During
-    // AnimatedVisibility expand/collapse the height constraint changes each frame but these
-    // inputs don't, so the layout lambda just reads the cached IntArray.
+    // A new stamp object is allocated only when inputs that affect column widths change.
+    // LocalDensity covers system font-scale changes; typography styles cover any runtime
+    // theme or ProvideTextStyle changes that alter header/data text metrics.
     val colWidthsCache = remember { ColWidthsCache() }
-    val colWidthsStamp = remember(formsView, minColWidth, maxColWidth, LocalDensity.current) { Any() }
+    val headerStyle = MaterialTheme.typography.labelSmall
+    val dataStyle = MaterialTheme.typography.bodySmall
+    val colWidthsStamp = remember(
+        formsView, minColWidth, maxColWidth, LocalDensity.current, headerStyle, dataStyle
+    ) { Any() }
 
     val anchors = buildList {
         matrix.forEachIndexed { rowIndex, row ->

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/word/EntryCard.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/word/EntryCard.kt
@@ -9,6 +9,7 @@ import androidx.compose.material.icons.automirrored.outlined.LibraryBooks
 import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -214,6 +215,12 @@ internal fun computeColumnWidths(
     return colWidths
 }
 
+/** Non-observable holder so that writing from the layout lambda doesn't trigger recomposition. */
+private class ColWidthsCache {
+    var stamp: Any? = null
+    var widths: IntArray? = null
+}
+
 @Composable
 private fun SpannedFormsGrid(
     formsView: FormsSchemeView,
@@ -225,6 +232,14 @@ private fun SpannedFormsGrid(
     val rowCount = matrix.size
     if (rowCount == 0) return
     val maxColumns = matrix.maxOfOrNull { it.size } ?: 0
+
+    // Cache column widths so the layout hot-path skips intrinsic measurement on every pass.
+    // A new stamp object is allocated only when inputs that affect column widths change
+    // (different word, different dp bounds, or density/font-scale change). During
+    // AnimatedVisibility expand/collapse the height constraint changes each frame but these
+    // inputs don't, so the layout lambda just reads the cached IntArray.
+    val colWidthsCache = remember { ColWidthsCache() }
+    val colWidthsStamp = remember(formsView, minColWidth, maxColWidth, LocalDensity.current) { Any() }
 
     val anchors = buildList {
         matrix.forEachIndexed { rowIndex, row ->
@@ -250,17 +265,25 @@ private fun SpannedFormsGrid(
             return@Layout layout(0, 0) {}
         }
 
-        // Header cells use maxIntrinsicWidth (label on one line); data cells use
-        // minIntrinsicWidth (wide enough for the longest word, multi-word forms can wrap).
-        val inputs = anchors.mapIndexed { index, placed ->
-            val intrinsic = if (placed.cell is GridCell.Data) {
-                measurables[index].minIntrinsicWidth(Constraints.Infinity)
-            } else {
-                measurables[index].maxIntrinsicWidth(Constraints.Infinity)
+        // Column widths are derived from intrinsic text measurements and cached: recomputed only
+        // when formsView/bounds/density change, not on every layout pass during animation.
+        val colWidths = if (colWidthsCache.stamp === colWidthsStamp) {
+            colWidthsCache.widths!!
+        } else {
+            // Header cells: maxIntrinsicWidth so labels fit on one line.
+            // Data cells: minIntrinsicWidth so individual words never break, but multi-word
+            // forms (e.g. "zou uitgewrongen hebben") can wrap at spaces.
+            val inputs = anchors.mapIndexed { index, placed ->
+                val intrinsic = if (placed.cell is GridCell.Data) {
+                    measurables[index].minIntrinsicWidth(Constraints.Infinity)
+                } else {
+                    measurables[index].maxIntrinsicWidth(Constraints.Infinity)
+                }
+                ColumnWidthInput(placed.anchorColumn, placed.cell.colspan, intrinsic)
             }
-            ColumnWidthInput(placed.anchorColumn, placed.cell.colspan, intrinsic)
+            computeColumnWidths(maxColumns, minColWidth.roundToPx(), maxColWidth.roundToPx(), inputs)
+                .also { colWidthsCache.stamp = colWidthsStamp; colWidthsCache.widths = it }
         }
-        val colWidths = computeColumnWidths(maxColumns, minColWidth.roundToPx(), maxColWidth.roundToPx(), inputs)
 
         val colOffsets = IntArray(maxColumns + 1)
         for (col in 0 until maxColumns) colOffsets[col + 1] = colOffsets[col] + colWidths[col]

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/word/EntryCard.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/word/EntryCard.kt
@@ -148,15 +148,83 @@ private fun FormsGridCell(cell: GridCell, value: String?) {
     }
 }
 
+internal data class ColumnWidthInput(
+    val anchorColumn: Int,
+    val colspan: Int,
+    val intrinsicWidthPx: Int,
+)
+
+/**
+ * Computes per-column pixel widths from measured cell intrinsic widths.
+ *
+ * Pass 1 – single-column cells: each column is at least as wide as its widest cell.
+ * Pass 2 – multi-column spans: if the span's intrinsic width exceeds the sum of its
+ *   columns' current widths, the deficit is distributed evenly across columns that still
+ *   have room below [maxColWidthPx]. When a column is capped, its overflow is
+ *   redistributed to the remaining uncapped columns rather than being dropped.
+ */
+internal fun computeColumnWidths(
+    maxColumns: Int,
+    minColWidthPx: Int,
+    maxColWidthPx: Int,
+    inputs: List<ColumnWidthInput>,
+): IntArray {
+    val colWidths = IntArray(maxColumns) { minColWidthPx }
+
+    // Pass 1: single-column cells
+    for (input in inputs) {
+        if (input.colspan == 1) {
+            colWidths[input.anchorColumn] = minOf(
+                maxColWidthPx,
+                maxOf(colWidths[input.anchorColumn], input.intrinsicWidthPx)
+            )
+        }
+    }
+
+    // Pass 2: multi-column spans with iterative deficit redistribution
+    for (input in inputs) {
+        if (input.colspan > 1) {
+            val spanCols = input.anchorColumn until input.anchorColumn + input.colspan
+            var remaining = input.intrinsicWidthPx - spanCols.sumOf { colWidths[it] }
+            if (remaining > 0) {
+                val growable = spanCols.toMutableList()
+                while (remaining > 0 && growable.isNotEmpty()) {
+                    val share = remaining / growable.size
+                    var leftover = remaining % growable.size
+                    var overflow = 0
+                    val iter = growable.iterator()
+                    while (iter.hasNext()) {
+                        val col = iter.next()
+                        val add = share + if (leftover > 0) { leftover--; 1 } else 0
+                        val proposed = colWidths[col] + add
+                        if (proposed >= maxColWidthPx) {
+                            overflow += proposed - maxColWidthPx
+                            colWidths[col] = maxColWidthPx
+                            iter.remove()
+                        } else {
+                            colWidths[col] = proposed
+                        }
+                    }
+                    remaining = overflow
+                }
+            }
+        }
+    }
+
+    return colWidths
+}
+
 @Composable
 private fun SpannedFormsGrid(
     formsView: FormsSchemeView,
     matrix: List<List<PlacedGridCell?>>,
-    cellWidth: androidx.compose.ui.unit.Dp,
+    minColWidth: androidx.compose.ui.unit.Dp,
+    maxColWidth: androidx.compose.ui.unit.Dp,
     minCellHeight: androidx.compose.ui.unit.Dp,
 ) {
     val rowCount = matrix.size
     if (rowCount == 0) return
+    val maxColumns = matrix.maxOfOrNull { it.size } ?: 0
 
     val anchors = buildList {
         matrix.forEachIndexed { rowIndex, row ->
@@ -182,15 +250,29 @@ private fun SpannedFormsGrid(
             return@Layout layout(0, 0) {}
         }
 
-        val maxColumns = matrix.maxOfOrNull { it.size } ?: 0
-        val colWidthPx = cellWidth.roundToPx()
+        // Header cells use maxIntrinsicWidth (label on one line); data cells use
+        // minIntrinsicWidth (wide enough for the longest word, multi-word forms can wrap).
+        val inputs = anchors.mapIndexed { index, placed ->
+            val intrinsic = if (placed.cell is GridCell.Data) {
+                measurables[index].minIntrinsicWidth(Constraints.Infinity)
+            } else {
+                measurables[index].maxIntrinsicWidth(Constraints.Infinity)
+            }
+            ColumnWidthInput(placed.anchorColumn, placed.cell.colspan, intrinsic)
+        }
+        val colWidths = computeColumnWidths(maxColumns, minColWidth.roundToPx(), maxColWidth.roundToPx(), inputs)
+
+        val colOffsets = IntArray(maxColumns + 1)
+        for (col in 0 until maxColumns) colOffsets[col + 1] = colOffsets[col] + colWidths[col]
+
         val minRowHeightPx = minCellHeight.roundToPx()
         val rowHeights = IntArray(rowCount) { minRowHeightPx }
         val preferredHeights = IntArray(measurables.size)
 
         measurables.forEachIndexed { index, measurable ->
             val placed = anchors[index]
-            val widthPx = colWidthPx * placed.cell.colspan
+            val widthPx = (placed.anchorColumn until placed.anchorColumn + placed.cell.colspan)
+                .sumOf { colWidths[it] }
             val preferredHeight = measurable.maxIntrinsicHeight(widthPx)
             preferredHeights[index] = max(minRowHeightPx, preferredHeight)
         }
@@ -229,21 +311,17 @@ private fun SpannedFormsGrid(
 
         val placeables = measurables.mapIndexed { index, measurable ->
             val placed = anchors[index]
-            val widthPx = colWidthPx * placed.cell.colspan
+            val widthPx = (placed.anchorColumn until placed.anchorColumn + placed.cell.colspan)
+                .sumOf { colWidths[it] }
             val endRowExclusive = min(rowCount, placed.anchorRow + placed.cell.rowspan)
             val heightPx = rowOffsets[endRowExclusive] - rowOffsets[placed.anchorRow]
             measurable.measure(Constraints.fixed(widthPx, heightPx))
         }
 
-        val tableWidthPx = colWidthPx * maxColumns
-        val tableHeightPx = rowOffsets[rowCount]
-
-        layout(tableWidthPx, tableHeightPx) {
+        layout(colOffsets[maxColumns], rowOffsets[rowCount]) {
             placeables.forEachIndexed { index, placeable ->
                 val placed = anchors[index]
-                val x = placed.anchorColumn * colWidthPx
-                val y = rowOffsets[placed.anchorRow]
-                placeable.placeRelative(x, y)
+                placeable.placeRelative(colOffsets[placed.anchorColumn], rowOffsets[placed.anchorRow])
             }
         }
     }
@@ -279,12 +357,8 @@ private fun FormsModeSelector(
 @Composable
 private fun FormsGrid(formsView: FormsSchemeView) {
     val matrix = remember(formsView) { buildPlacedGrid(formsView) }
-    val maxColumns = matrix.maxOfOrNull { it.size } ?: 0
-    if (maxColumns == 0) return
+    if (matrix.maxOfOrNull { it.size } == 0) return
 
-    val cellWidth = 88.dp
-    val minCellHeight = 28.dp
-    val tableWidth = cellWidth * maxColumns
     val tableShape = RoundedCornerShape(10.dp)
     val dividerColor = MaterialTheme.colorScheme.outlineVariant
     val horizontalScrollState = rememberScrollState()
@@ -296,15 +370,15 @@ private fun FormsGrid(formsView: FormsSchemeView) {
     ) {
         Box(
             modifier = Modifier
-                .requiredWidth(tableWidth)
                 .clip(tableShape)
                 .border(1.dp, dividerColor, tableShape)
         ) {
             SpannedFormsGrid(
                 formsView = formsView,
                 matrix = matrix,
-                cellWidth = cellWidth,
-                minCellHeight = minCellHeight,
+                minColWidth = 16.dp,  // just the horizontal padding — content drives width
+                maxColWidth = 240.dp, // guard against pathological single-line text
+                minCellHeight = 28.dp,
             )
         }
     }

--- a/composeApp/src/commonTest/kotlin/com/slovy/slovymovyapp/ui/word/ColumnWidthsTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/slovy/slovymovyapp/ui/word/ColumnWidthsTest.kt
@@ -110,24 +110,27 @@ class ColumnWidthsTest {
     }
 
     @Test
-    fun spanDeficit_overlappingSpans_laterSpanSeesEarlierResult() {
-        // Span 0-1 (intrinsic=100) is processed first: col0 and col1 each grow to 50.
-        // Span 1-2 (intrinsic=200) then sees col1=50 (already widened), col2=10 (min).
+    fun spanDeficit_overlappingSpans_canonicalOrderShortBeforeLong() {
+        // Both spans have colspan=2; canonical order is by anchorColumn: span 0-1 before span 1-2.
+        // Span 0-1 (intrinsic=100) runs first: col0 and col1 each grow to 50.
+        // Span 1-2 (intrinsic=200) then sees col1=50, col2=10 (min).
         //   deficit=140; round1: col1→120 capped to 100 (overflow=20), col2→80
         //   round2: remaining=20 → col2→100.
         // Final: col0=50, col1=100, col2=100.
-        // This test documents the order-dependent behavior so that future refactors
-        // don't silently change it.
-        val result = computeColumnWidths(
+        // Declaring the spans in reverse order in `inputs` must produce the same result
+        // because computeColumnWidths sorts spans canonically before processing.
+        val forwardResult = computeColumnWidths(
             maxColumns = 3, minColWidthPx = 10, maxColWidthPx = 100,
-            inputs = listOf(
-                col(0, colspan = 2, width = 100),
-                col(1, colspan = 2, width = 200),
-            )
+            inputs = listOf(col(0, colspan = 2, width = 100), col(1, colspan = 2, width = 200)),
         )
-        assertEquals(50,  result[0], "col 0 set only by span 0-1")
-        assertEquals(100, result[1], "col 1 widened first by span 0-1, then by span 1-2")
-        assertEquals(100, result[2], "col 2 widened by span 1-2 with redistributed overflow")
+        val reverseResult = computeColumnWidths(
+            maxColumns = 3, minColWidthPx = 10, maxColWidthPx = 100,
+            inputs = listOf(col(1, colspan = 2, width = 200), col(0, colspan = 2, width = 100)),
+        )
+        assertEquals(50,  forwardResult[0], "col 0 set only by span 0-1")
+        assertEquals(100, forwardResult[1], "col 1 widened first by span 0-1, then by span 1-2")
+        assertEquals(100, forwardResult[2], "col 2 widened by span 1-2 with redistributed overflow")
+        assertTrue(forwardResult.contentEquals(reverseResult), "declaration order must not affect result")
     }
 
     @Test

--- a/composeApp/src/commonTest/kotlin/com/slovy/slovymovyapp/ui/word/ColumnWidthsTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/slovy/slovymovyapp/ui/word/ColumnWidthsTest.kt
@@ -1,0 +1,126 @@
+package com.slovy.slovymovyapp.ui.word
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class ColumnWidthsTest {
+
+    private fun col(anchorColumn: Int, colspan: Int = 1, width: Int) =
+        ColumnWidthInput(anchorColumn = anchorColumn, colspan = colspan, intrinsicWidthPx = width)
+
+    // ── Pass 1: single-column cells ──────────────────────────────────────────
+
+    @Test
+    fun singleColumn_usesWidestCell() {
+        val result = computeColumnWidths(
+            maxColumns = 2, minColWidthPx = 10, maxColWidthPx = 300,
+            inputs = listOf(col(0, width = 80), col(0, width = 50), col(1, width = 120))
+        )
+        assertEquals(80, result[0], "col 0 should be max of its cells")
+        assertEquals(120, result[1], "col 1 should be max of its cells")
+    }
+
+    @Test
+    fun singleColumn_respectsMin() {
+        val result = computeColumnWidths(
+            maxColumns = 2, minColWidthPx = 40, maxColWidthPx = 300,
+            inputs = listOf(col(0, width = 10), col(1, width = 5))
+        )
+        assertEquals(40, result[0], "col 0 below min should be lifted to min")
+        assertEquals(40, result[1], "col 1 below min should be lifted to min")
+    }
+
+    @Test
+    fun singleColumn_cappedAtMax() {
+        val result = computeColumnWidths(
+            maxColumns = 1, minColWidthPx = 10, maxColWidthPx = 100,
+            inputs = listOf(col(0, width = 200))
+        )
+        assertEquals(100, result[0], "col 0 should be capped at max")
+    }
+
+    // ── Pass 2: multi-column span redistribution ─────────────────────────────
+
+    @Test
+    fun spanDeficit_evenlyDistributedWhenAllHaveRoom() {
+        // Span over 2 fresh columns, each at min=10, intrinsic=100 → each gets 50.
+        val result = computeColumnWidths(
+            maxColumns = 2, minColWidthPx = 10, maxColWidthPx = 300,
+            inputs = listOf(col(0, colspan = 2, width = 100))
+        )
+        assertEquals(50, result[0])
+        assertEquals(50, result[1])
+    }
+
+    @Test
+    fun spanDeficit_noOpWhenColumnsAlreadySufficient() {
+        // Single-column cells already cover the span's intrinsic width — span pass is a no-op.
+        val result = computeColumnWidths(
+            maxColumns = 2, minColWidthPx = 10, maxColWidthPx = 300,
+            inputs = listOf(
+                col(0, width = 80),
+                col(1, width = 80),
+                col(0, colspan = 2, width = 100), // 80+80 = 160 >= 100
+            )
+        )
+        assertEquals(80, result[0])
+        assertEquals(80, result[1])
+    }
+
+    @Test
+    fun spanDeficit_redistributedToUncappedColumnsWhenOneCapped() {
+        // col0=90 (10 below max), col1=50. Span needs 200 total (currently 140, deficit=60).
+        // Round 1: share=30 each.
+        //   col0: 90+30=120 > max=100 → col0=100, overflow=20
+        //   col1: 50+30=80 → col1=80
+        // Round 2: remaining=20 redistributed to col1 only.
+        //   col1: 80+20=100 → col1=100
+        // Result: col0=100, col1=100 (total=200 == intrinsic).
+        val result = computeColumnWidths(
+            maxColumns = 2, minColWidthPx = 10, maxColWidthPx = 100,
+            inputs = listOf(
+                col(0, width = 90),
+                col(1, width = 50),
+                col(0, colspan = 2, width = 200),
+            )
+        )
+        assertEquals(100, result[0], "col 0 should reach max")
+        assertEquals(100, result[1], "col 1 should absorb redistributed overflow from col 0")
+        assertEquals(200, result[0] + result[1], "total must equal span intrinsic width")
+    }
+
+    @Test
+    fun spanDeficit_redistributedAcrossMultipleCappedColumns() {
+        // 3 columns: col0=90, col1=90, col2=50. Span needs 300 (currently 230, deficit=70).
+        // Iterative redistribution fills col0 and col1 to 100 each and gives col2 the rest.
+        val result = computeColumnWidths(
+            maxColumns = 3, minColWidthPx = 10, maxColWidthPx = 100,
+            inputs = listOf(
+                col(0, width = 90),
+                col(1, width = 90),
+                col(2, width = 50),
+                col(0, colspan = 3, width = 300),
+            )
+        )
+        assertEquals(100, result[0])
+        assertEquals(100, result[1])
+        assertEquals(100, result[2])
+        assertEquals(300, result.sum())
+    }
+
+    @Test
+    fun spanDeficit_droppedOnlyWhenAllColumnsAtMax() {
+        // All columns already at max — deficit cannot be absorbed anywhere.
+        val result = computeColumnWidths(
+            maxColumns = 2, minColWidthPx = 10, maxColWidthPx = 100,
+            inputs = listOf(
+                col(0, width = 100),
+                col(1, width = 100),
+                col(0, colspan = 2, width = 300),
+            )
+        )
+        assertTrue(result[0] <= 100, "col 0 must not exceed max")
+        assertTrue(result[1] <= 100, "col 1 must not exceed max")
+    }
+}

--- a/composeApp/src/commonTest/kotlin/com/slovy/slovymovyapp/ui/word/ColumnWidthsTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/slovy/slovymovyapp/ui/word/ColumnWidthsTest.kt
@@ -110,6 +110,27 @@ class ColumnWidthsTest {
     }
 
     @Test
+    fun spanDeficit_overlappingSpans_laterSpanSeesEarlierResult() {
+        // Span 0-1 (intrinsic=100) is processed first: col0 and col1 each grow to 50.
+        // Span 1-2 (intrinsic=200) then sees col1=50 (already widened), col2=10 (min).
+        //   deficit=140; round1: col1→120 capped to 100 (overflow=20), col2→80
+        //   round2: remaining=20 → col2→100.
+        // Final: col0=50, col1=100, col2=100.
+        // This test documents the order-dependent behavior so that future refactors
+        // don't silently change it.
+        val result = computeColumnWidths(
+            maxColumns = 3, minColWidthPx = 10, maxColWidthPx = 100,
+            inputs = listOf(
+                col(0, colspan = 2, width = 100),
+                col(1, colspan = 2, width = 200),
+            )
+        )
+        assertEquals(50,  result[0], "col 0 set only by span 0-1")
+        assertEquals(100, result[1], "col 1 widened first by span 0-1, then by span 1-2")
+        assertEquals(100, result[2], "col 2 widened by span 1-2 with redistributed overflow")
+    }
+
+    @Test
     fun spanDeficit_droppedOnlyWhenAllColumnsAtMax() {
         // All columns already at max — deficit cannot be absorbed anywhere.
         val result = computeColumnWidths(


### PR DESCRIPTION
## Summary

- Replace fixed 88dp cell width with content-driven per-column sizing using Compose intrinsic measurements
- Header cells (`RowHeader`/`ColHeader`) use `maxIntrinsicWidth` so labels like "Conditional perfect" always fit on one line
- Data cells use `minIntrinsicWidth` so individual words never break mid-character, while multi-word forms (e.g. "zou uitgewrongen hebben") can still wrap at spaces
- Multi-column span deficit is redistributed iteratively: when a column hits `maxColWidth`, its overflow is passed to uncapped siblings rather than silently dropped

## Test plan

- [ ] Open a Dutch verb (e.g. "zeggen", "uitwringen") — full table row headers ("Conditional", "Present perfect") render on one line
- [ ] Open a long Dutch adjective (e.g. "indrukwekkend") — positive/comparative/superlative forms are not broken mid-word
- [ ] Multi-word verb forms (e.g. "zou uitgewrongen hebben") wrap at spaces, not mid-character
- [ ] Compact 2-column views are not excessively wide/sparse
- [ ] `ColumnWidthsTest` passes: single-column min/max clamping, span even distribution, span deficit redistribution across capped columns

🤖 Generated with [Claude Code](https://claude.com/claude-code)