### PR TITLE
feat(ru): restructure verb tables, add adjective essentials view, add RU_ADVERB scheme

### DIFF
--- a/composeApp/src/commonTest/kotlin/com/slovy/slovymovyapp/forms/RuConjugationSchemeTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/slovy/slovymovyapp/forms/RuConjugationSchemeTest.kt
@@ -2,11 +2,15 @@ package com.slovy.slovymovyapp.forms
 
 import com.slovy.slovymovyapp.data.Language
 import com.slovy.slovymovyapp.data.dictionary.DictionaryPos
+import com.slovy.slovymovyapp.data.dictionary.FormSource
+import com.slovy.slovymovyapp.data.forms.SchemeInputForm
+import com.slovy.slovymovyapp.data.forms.configs.RuConjugationScheme
 import com.slovy.slovymovyapp.test.BaseTest
 import com.slovy.slovymovyapp.test.IgnoreIos
 import kotlinx.coroutines.runBlocking
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNull
 
 @IgnoreIos
 class RuConjugationSchemeTest : BaseTest() {
@@ -37,6 +41,18 @@ class RuConjugationSchemeTest : BaseTest() {
                 resolveFormsSnapshot(repo, Language.RUSSIAN, "красивый", DictionaryPos.ADJECTIVE),
                 "Resolved RU adjective views for 'красивый' changed"
             )
+            assertEquals(
+                expectedRuAdverbBystro,
+                resolveFormsSnapshot(repo, Language.RUSSIAN, "быстро", DictionaryPos.ADVERB),
+                "Resolved RU adverb views for 'быстро' changed"
+            )
+            assertNull(
+                RuConjugationScheme.schemeFor(
+                    DictionaryPos.ADVERB,
+                    listOf(SchemeInputForm(listOf("canonical"), "абсолю́тно", FormSource.NATIVE))
+                ),
+                "Non-gradable RU adverb with no comparative tag should produce no scheme"
+            )
         } finally {
             mgr.deleteDictionary(Language.RUSSIAN)
         }
@@ -56,60 +72,72 @@ class RuConjugationSchemeTest : BaseTest() {
 
     private val expectedRuVerbCitat = mapOf(
         "ru_verb_imperfective:full" to listOf(
-            listOf(null, "чита́ть"),
-            listOf(null, null, null),
-            listOf(null, "чита́ющий", "чита́вший"),
-            listOf(null, "чита́емый", "чи́танный"),
-            listOf(null, "чита́я", "чита́в"),
-            listOf(null, null, null),
-            listOf(null, "чита́ю", "бу́ду чита́ть"),
-            listOf(null, "чита́ешь", "бу́дешь чита́ть"),
-            listOf(null, "чита́ет", "бу́дет чита́ть"),
-            listOf(null, "чита́ем", "бу́дем чита́ть"),
-            listOf(null, "чита́ете", "бу́дете чита́ть"),
-            listOf(null, "чита́ют", "бу́дут чита́ть"),
-            listOf(null, null, null),
-            listOf(null, "чита́й", "чита́йте"),
-            listOf(null, null, null),
-            listOf(null, "чита́л", "чита́ли"),
-            listOf(null, "чита́ла"),
-            listOf(null, "чита́ло")
+            listOf(null, "чита́ть"),                              // infinitive
+            listOf(null, null, null),                              // col headers: singular | plural
+            listOf(null),                                          // present tense
+            listOf(null, "чита́ю", "чита́ем"),                    // 1st person
+            listOf(null, "чита́ешь", "чита́ете"),                  // 2nd person
+            listOf(null, "чита́ет", "чита́ют"),                    // 3rd person
+            listOf(null),                                          // past tense
+            listOf(null, "чита́л", "чита́ли"),                    // masculine (plural rowspan)
+            listOf(null, "чита́ла"),                               // feminine
+            listOf(null, "чита́ло"),                               // neuter
+            listOf(null),                                          // future tense
+            listOf(null, "бу́ду чита́ть", "бу́дем чита́ть"),      // 1st person
+            listOf(null, "бу́дешь чита́ть", "бу́дете чита́ть"),   // 2nd person
+            listOf(null, "бу́дет чита́ть", "бу́дут чита́ть"),     // 3rd person
+            listOf(null),                                          // imperative
+            listOf(null, "чита́й", "чита́йте"),                   // 2nd person
+            listOf(null, null, null),                              // col headers: present | past
+            listOf(null, "чита́ющий", "чита́вший"),               // active participle
+            listOf(null, "чита́емый", "чи́танный"),               // passive participle
+            listOf(null, "чита́я", "чита́в")                      // adverbial participle
         ),
     )
 
     private val expectedRuVerbSkazat = mapOf(
         "ru_verb_perfective:full" to listOf(
-            listOf(null, "сказа́ть"),
-            listOf(null, null, null),
-            listOf(null, "сказа́вший", "ска́занный"),
-            listOf(null, "сказа́в"),
-            listOf(null),
-            listOf(null, "скажу́"),
-            listOf(null, "ска́жешь"),
-            listOf(null, "ска́жет"),
-            listOf(null, "ска́жем"),
-            listOf(null, "ска́жете"),
-            listOf(null, "ска́жут"),
-            listOf(null, null, null),
-            listOf(null, "скажи́", "скажи́те"),
-            listOf(null, null, null),
-            listOf(null, "сказа́л", "сказа́ли"),
-            listOf(null, "сказа́ла"),
-            listOf(null, "сказа́ло")
+            listOf(null, "сказа́ть"),                             // infinitive
+            listOf(null, null, null),                              // col headers: singular | plural
+            listOf(null),                                          // future tense
+            listOf(null, "скажу́", "ска́жем"),                    // 1st person
+            listOf(null, "ска́жешь", "ска́жете"),                 // 2nd person
+            listOf(null, "ска́жет", "ска́жут"),                   // 3rd person
+            listOf(null),                                          // past tense
+            listOf(null, "сказа́л", "сказа́ли"),                  // masculine (plural rowspan)
+            listOf(null, "сказа́ла"),                              // feminine
+            listOf(null, "сказа́ло"),                              // neuter
+            listOf(null),                                          // imperative
+            listOf(null, "скажи́", "скажи́те"),                   // 2nd person
+            listOf(null, null, null),                              // col headers: active | passive
+            listOf(null, "сказа́вший", "ска́занный"),             // past participle
+            listOf(null, "сказа́в")                               // adverbial participle (colspan=2)
+        )
+    )
+
+    private val expectedRuAdverbBystro = mapOf(
+        "ru_adverb:short" to listOf(
+            listOf(null, "(по)быстре́е") // comparative
         )
     )
 
     private val expectedRuAdjectiveKrasivyj = mapOf(
+        "ru_adjective:essentials" to listOf(
+            listOf(null, "краси́вый"),  // masculine
+            listOf(null, "краси́вая"),  // feminine
+            listOf(null, "краси́вое"),  // neuter
+            listOf(null, "краси́вые")   // plural
+        ),
         "ru_adjective:full" to listOf(
-            listOf(null, null, null, null, null),
-            listOf(null, "краси́вый", "краси́вое", "краси́вая", "краси́вые"),
-            listOf(null, "краси́вого", "краси́вого", "краси́вой", "краси́вых"),
-            listOf(null, "краси́вому", "краси́вой", "краси́вым"),
-            listOf(null, null, "краси́вого", "краси́вое", "краси́вую", "краси́вых"),
-            listOf(null, "краси́вый", "краси́вые"),
-            listOf(null, "краси́вым", "краси́вым", "краси́вой", "краси́выми"),
-            listOf(null, "краси́вом", "краси́вой", "краси́вых"),
-            listOf(null, "краси́в", "краси́во", "краси́ва", "краси́вы")
+            listOf(null, null, null, null, null),                                    // col headers: masculine | feminine | neuter | plural
+            listOf(null, "краси́вый", "краси́вая", "краси́вое", "краси́вые"),        // nominative
+            listOf(null, "краси́вого", "краси́вой", "краси́вого", "краси́вых"),      // genitive (neuter rowspan=2)
+            listOf(null, "краси́вому", "краси́вой", "краси́вым"),                    // dative (neuter covered)
+            listOf(null, null, "краси́вого", "краси́вую", "краси́вое", "краси́вых"), // accusative animate (fem+neuter rowspan=2)
+            listOf(null, "краси́вый", "краси́вые"),                                  // accusative inanimate (fem+neuter covered)
+            listOf(null, "краси́вым", "краси́вой", "краси́вым", "краси́выми"),       // instrumental (neuter rowspan=2)
+            listOf(null, "краси́вом", "краси́вой", "краси́вых"),                     // prepositional (neuter covered)
+            listOf(null, "краси́в", "краси́ва", "краси́во", "краси́вы")              // short form
         )
     )
 }

--- a/shared/src/commonMain/kotlin/com/slovy/slovymovyapp/data/forms/configs/RuConjugationScheme.kt
+++ b/shared/src/commonMain/kotlin/com/slovy/slovymovyapp/data/forms/configs/RuConjugationScheme.kt
@@ -133,11 +133,78 @@ object RuConjugationScheme : ConjugationSchemeProvider {
                     data(VerbForm.INFINITIVE, supporting = setOf(Aspect.IMPERFECTIVE), colspan = 2)
                 }
 
-                // Participles header block
+                // Shared col headers for all tense/mood sections
                 row {
                     empty()
-                    colHeader("present tense")
-                    colHeader("past tense")
+                    colHeader("singular")
+                    colHeader("plural")
+                }
+
+                // ── Present tense ─────────────────────────────────────────
+                row { rowHeader("present tense", colspan = 3) }
+                row {
+                    rowHeader("1st person")
+                    data(Tense.PRESENT, Person.FIRST, Num.SG, supporting = setOf(VerbForm.FINITE))
+                    data(Tense.PRESENT, Person.FIRST, Num.PL, supporting = setOf(VerbForm.FINITE))
+                }
+                row {
+                    rowHeader("2nd person")
+                    data(Tense.PRESENT, Person.SECOND, Num.SG, supporting = setOf(VerbForm.FINITE))
+                    data(Tense.PRESENT, Person.SECOND, Num.PL, supporting = setOf(VerbForm.FINITE))
+                }
+                row {
+                    rowHeader("3rd person")
+                    data(Tense.PRESENT, Person.THIRD, Num.SG, supporting = setOf(VerbForm.FINITE))
+                    data(Tense.PRESENT, Person.THIRD, Num.PL, supporting = setOf(VerbForm.FINITE))
+                }
+
+                // ── Past tense (gendered; no person inflection in Russian) ─
+                row { rowHeader("past tense", colspan = 3) }
+                row {
+                    rowHeader("masculine")
+                    data(Tense.PAST, Gender.MASC, supporting = setOf(VerbForm.FINITE, Num.SG))
+                    data(Tense.PAST, Num.PL, rowspan = 3, supporting = setOf(VerbForm.FINITE))
+                }
+                row {
+                    rowHeader("feminine")
+                    data(Tense.PAST, Gender.FEM, supporting = setOf(VerbForm.FINITE, Num.SG))
+                }
+                row {
+                    rowHeader("neuter")
+                    data(Tense.PAST, Gender.NEUT, supporting = setOf(VerbForm.FINITE, Num.SG))
+                }
+
+                // ── Future tense (analytic: буду + infinitive) ────────────
+                row { rowHeader("future tense", colspan = 3) }
+                row {
+                    rowHeader("1st person")
+                    data(Tense.FUTURE, Person.FIRST, Num.SG, supporting = setOf(VerbForm.FINITE))
+                    data(Tense.FUTURE, Person.FIRST, Num.PL, supporting = setOf(VerbForm.FINITE))
+                }
+                row {
+                    rowHeader("2nd person")
+                    data(Tense.FUTURE, Person.SECOND, Num.SG, supporting = setOf(VerbForm.FINITE))
+                    data(Tense.FUTURE, Person.SECOND, Num.PL, supporting = setOf(VerbForm.FINITE))
+                }
+                row {
+                    rowHeader("3rd person")
+                    data(Tense.FUTURE, Person.THIRD, Num.SG, supporting = setOf(VerbForm.FINITE))
+                    data(Tense.FUTURE, Person.THIRD, Num.PL, supporting = setOf(VerbForm.FINITE))
+                }
+
+                // ── Imperative ────────────────────────────────────────────
+                row { rowHeader("imperative", colspan = 3) }
+                row {
+                    rowHeader("2nd person")
+                    data(Mood.IMPERATIVE, Num.SG, supporting = setOf(VerbForm.FINITE, Person.SECOND))
+                    data(Mood.IMPERATIVE, Num.PL, supporting = setOf(VerbForm.FINITE, Person.SECOND))
+                }
+
+                // ── Participles ───────────────────────────────────────────
+                row {
+                    empty()
+                    colHeader("present")
+                    colHeader("past")
                 }
                 row {
                     rowHeader("active participle")
@@ -153,75 +220,6 @@ object RuConjugationScheme : ConjugationSchemeProvider {
                     rowHeader("adverbial participle")
                     data(VerbForm.ADVERBIAL, Tense.PRESENT)
                     data(VerbForm.ADVERBIAL, Tense.PAST)
-                }
-
-                // Finite forms header
-                row {
-                    empty()
-                    colHeader("present tense")
-                    colHeader("future tense")
-                }
-                row {
-                    rowHeader("1st singular (я)")
-                    data(Tense.PRESENT, Person.FIRST, Num.SG, supporting = setOf(VerbForm.FINITE))
-                    data(Tense.FUTURE, Person.FIRST, Num.SG, supporting = setOf(VerbForm.FINITE))
-                }
-                row {
-                    rowHeader("2nd singular (ты)")
-                    data(Tense.PRESENT, Person.SECOND, Num.SG, supporting = setOf(VerbForm.FINITE))
-                    data(Tense.FUTURE, Person.SECOND, Num.SG, supporting = setOf(VerbForm.FINITE))
-                }
-                row {
-                    rowHeader("3rd singular (он/она/оно)")
-                    data(Tense.PRESENT, Person.THIRD, Num.SG, supporting = setOf(VerbForm.FINITE))
-                    data(Tense.FUTURE, Person.THIRD, Num.SG, supporting = setOf(VerbForm.FINITE))
-                }
-                row {
-                    rowHeader("1st plural (мы)")
-                    data(Tense.PRESENT, Person.FIRST, Num.PL, supporting = setOf(VerbForm.FINITE))
-                    data(Tense.FUTURE, Person.FIRST, Num.PL, supporting = setOf(VerbForm.FINITE))
-                }
-                row {
-                    rowHeader("2nd plural (вы)")
-                    data(Tense.PRESENT, Person.SECOND, Num.PL, supporting = setOf(VerbForm.FINITE))
-                    data(Tense.FUTURE, Person.SECOND, Num.PL, supporting = setOf(VerbForm.FINITE))
-                }
-                row {
-                    rowHeader("3rd plural (они)")
-                    data(Tense.PRESENT, Person.THIRD, Num.PL, supporting = setOf(VerbForm.FINITE))
-                    data(Tense.FUTURE, Person.THIRD, Num.PL, supporting = setOf(VerbForm.FINITE))
-                }
-
-                // Imperative
-                row {
-                    rowHeader("imperative")
-                    colHeader("singular")
-                    colHeader("plural")
-                }
-                row {
-                    rowHeader("2nd (ты / вы)")
-                    data(Mood.IMPERATIVE, Num.SG, supporting = setOf(VerbForm.FINITE, Person.SECOND))
-                    data(Mood.IMPERATIVE, Num.PL, supporting = setOf(VerbForm.FINITE, Person.SECOND))
-                }
-
-                // Past tense — gendered
-                row {
-                    rowHeader("past tense")
-                    colHeader("singular")
-                    colHeader("plural (мы/вы/они)")
-                }
-                row {
-                    rowHeader("masculine (я/ты/он)")
-                    data(Tense.PAST, Gender.MASC, supporting = setOf(VerbForm.FINITE, Num.SG))
-                    data(Tense.PAST, Num.PL, rowspan = 3, supporting = setOf(VerbForm.FINITE))
-                }
-                row {
-                    rowHeader("feminine (я/ты/она)")
-                    data(Tense.PAST, Gender.FEM, supporting = setOf(VerbForm.FINITE, Num.SG))
-                }
-                row {
-                    rowHeader("neuter (оно)")
-                    data(Tense.PAST, Gender.NEUT, supporting = setOf(VerbForm.FINITE, Num.SG))
                 }
             }
         }
@@ -245,7 +243,56 @@ object RuConjugationScheme : ConjugationSchemeProvider {
                     data(VerbForm.INFINITIVE, Aspect.PERFECTIVE, colspan = 2)
                 }
 
-                // Participles — perfective has no present active/passive participles
+                // Shared col headers for all tense/mood sections
+                row {
+                    empty()
+                    colHeader("singular")
+                    colHeader("plural")
+                }
+
+                // ── Future tense (synthetic: perfective present = simple future) ─
+                row { rowHeader("future tense", colspan = 3) }
+                row {
+                    rowHeader("1st person")
+                    data(Tense.FUTURE, Person.FIRST, Num.SG, supporting = setOf(VerbForm.FINITE))
+                    data(Tense.FUTURE, Person.FIRST, Num.PL, supporting = setOf(VerbForm.FINITE))
+                }
+                row {
+                    rowHeader("2nd person")
+                    data(Tense.FUTURE, Person.SECOND, Num.SG, supporting = setOf(VerbForm.FINITE))
+                    data(Tense.FUTURE, Person.SECOND, Num.PL, supporting = setOf(VerbForm.FINITE))
+                }
+                row {
+                    rowHeader("3rd person")
+                    data(Tense.FUTURE, Person.THIRD, Num.SG, supporting = setOf(VerbForm.FINITE))
+                    data(Tense.FUTURE, Person.THIRD, Num.PL, supporting = setOf(VerbForm.FINITE))
+                }
+
+                // ── Past tense (gendered; no person inflection in Russian) ─
+                row { rowHeader("past tense", colspan = 3) }
+                row {
+                    rowHeader("masculine")
+                    data(Tense.PAST, Gender.MASC, supporting = setOf(VerbForm.FINITE, Num.SG))
+                    data(Tense.PAST, Num.PL, rowspan = 3, supporting = setOf(VerbForm.FINITE))
+                }
+                row {
+                    rowHeader("feminine")
+                    data(Tense.PAST, Gender.FEM, supporting = setOf(VerbForm.FINITE, Num.SG))
+                }
+                row {
+                    rowHeader("neuter")
+                    data(Tense.PAST, Gender.NEUT, supporting = setOf(VerbForm.FINITE, Num.SG))
+                }
+
+                // ── Imperative ────────────────────────────────────────────
+                row { rowHeader("imperative", colspan = 3) }
+                row {
+                    rowHeader("2nd person")
+                    data(Mood.IMPERATIVE, Num.SG, supporting = setOf(VerbForm.FINITE))
+                    data(Mood.IMPERATIVE, Num.PL, supporting = setOf(VerbForm.FINITE))
+                }
+
+                // ── Participles (perfective: past only) ──────────────────
                 row {
                     empty()
                     colHeader("active")
@@ -260,74 +307,14 @@ object RuConjugationScheme : ConjugationSchemeProvider {
                     rowHeader("adverbial participle")
                     data(VerbForm.ADVERBIAL, Tense.PAST, colspan = 2)
                 }
-
-                // Future tense (perfective present = simple future)
-                row {
-                    rowHeader("future tense", colspan = 2)
-                }
-                row {
-                    rowHeader("1st singular (я)")
-                    data(Tense.FUTURE, Person.FIRST, Num.SG, supporting = setOf(VerbForm.FINITE))
-                }
-                row {
-                    rowHeader("2nd singular (ты)")
-                    data(Tense.FUTURE, Person.SECOND, Num.SG, supporting = setOf(VerbForm.FINITE))
-                }
-                row {
-                    rowHeader("3rd singular (он/она/оно)")
-                    data(Tense.FUTURE, Person.THIRD, Num.SG, supporting = setOf(VerbForm.FINITE))
-                }
-                row {
-                    rowHeader("1st plural (мы)")
-                    data(Tense.FUTURE, Person.FIRST, Num.PL, supporting = setOf(VerbForm.FINITE))
-                }
-                row {
-                    rowHeader("2nd plural (вы)")
-                    data(Tense.FUTURE, Person.SECOND, Num.PL, supporting = setOf(VerbForm.FINITE))
-                }
-                row {
-                    rowHeader("3rd plural (они)")
-                    data(Tense.FUTURE, Person.THIRD, Num.PL, supporting = setOf(VerbForm.FINITE))
-                }
-
-                // Imperative
-                row {
-                    rowHeader("imperative")
-                    colHeader("singular")
-                    colHeader("plural")
-                }
-                row {
-                    rowHeader("2nd (ты / вы)")
-                    data(Mood.IMPERATIVE, Num.SG, supporting = setOf(VerbForm.FINITE))
-                    data(Mood.IMPERATIVE, Num.PL, supporting = setOf(VerbForm.FINITE))
-                }
-
-                // Past tense
-                row {
-                    rowHeader("past tense")
-                    colHeader("singular")
-                    colHeader("plural")
-                }
-                row {
-                    rowHeader("masculine (я/ты/он)")
-                    data(Tense.PAST, Gender.MASC, supporting = setOf(VerbForm.FINITE, Num.SG))
-                    data(Tense.PAST, Num.PL, rowspan = 3, supporting = setOf(VerbForm.FINITE))
-                }
-                row {
-                    rowHeader("feminine (я/ты/она)")
-                    data(Tense.PAST, Gender.FEM, supporting = setOf(VerbForm.FINITE, Num.SG))
-                }
-                row {
-                    rowHeader("neuter (оно)")
-                    data(Tense.PAST, Gender.NEUT, supporting = setOf(VerbForm.FINITE, Num.SG))
-                }
             }
         }
 
     /**
      * Russian adjective declension.
      *
-     * Four gender/number columns × six cases + short forms.
+     * Essentials: nominative forms for all four genders/number.
+     * Full: six cases × (masculine, feminine, neuter, plural) + short forms.
      * Accusative is split into animate and inanimate sub-rows.
      * Matches the en.wiktionary table for красивый.
      */
@@ -337,33 +324,51 @@ object RuConjugationScheme : ConjugationSchemeProvider {
         DictionaryPos.ADJECTIVE,
         tagResolver = russianTagResolver(DictionaryPos.ADJECTIVE)
     ) {
-        view("full", "Declension") {
+        view("essentials", "Essentials") {
+            row {
+                rowHeader("masculine")
+                data(Case.NOMINATIVE, Gender.MASC)
+            }
+            row {
+                rowHeader("feminine")
+                data(Case.NOMINATIVE, Gender.FEM)
+            }
+            row {
+                rowHeader("neuter")
+                data(Case.NOMINATIVE, Gender.NEUT)
+            }
+            row {
+                rowHeader("plural")
+                data(Case.NOMINATIVE, Num.PL)
+            }
+        }
+        view("full", "Full table") {
             row {
                 empty(colspan = 2)
                 colHeader("masculine")
-                colHeader("neuter")
                 colHeader("feminine")
+                colHeader("neuter")
                 colHeader("plural")
             }
             row {
                 rowHeader("nominative", colspan = 2)
                 data(Case.NOMINATIVE, Gender.MASC)
-                data(Case.NOMINATIVE, Gender.NEUT)
                 data(Case.NOMINATIVE, Gender.FEM)
+                data(Case.NOMINATIVE, Gender.NEUT)
                 data(Case.NOMINATIVE, Num.PL)
             }
             row {
                 rowHeader("genitive", colspan = 2)
                 data(Case.GENITIVE, Gender.MASC)
-                data(Case.GENITIVE, Gender.NEUT, rowspan = 2)
                 data(Case.GENITIVE, Gender.FEM)
+                data(Case.GENITIVE, Gender.NEUT, rowspan = 2)
                 data(Case.GENITIVE, Num.PL)
             }
             row {
                 rowHeader("dative", colspan = 2)
                 data(Case.DATIVE, Gender.MASC)
-                // neuter cell already covered by rowspan above
                 data(Case.DATIVE, Gender.FEM)
+                // neuter cell already covered by rowspan above
                 data(Case.DATIVE, Num.PL)
             }
             // Accusative: two sub-rows for animate / inanimate
@@ -371,41 +376,62 @@ object RuConjugationScheme : ConjugationSchemeProvider {
                 rowHeader("accusative", rowspan = 2)
                 rowHeader("animate")
                 data(Case.ACCUSATIVE, Animacy.ANIM, Gender.MASC)
-                data(Case.ACCUSATIVE, Gender.NEUT, rowspan = 2)
                 data(Case.ACCUSATIVE, Animacy.ANIM, Gender.FEM, rowspan = 2)
+                data(Case.ACCUSATIVE, Gender.NEUT, rowspan = 2)
                 data(Case.ACCUSATIVE, Animacy.ANIM, Num.PL)
             }
             row {
                 rowHeader("inanimate")
                 data(Case.ACCUSATIVE, Animacy.INANIM, Gender.MASC)
+                // fem and neuter covered by rowspan above
                 data(Case.ACCUSATIVE, Animacy.INANIM, Num.PL)
             }
             row {
                 rowHeader("instrumental", colspan = 2)
                 data(Case.INSTRUMENTAL, Gender.MASC)
-                data(Case.INSTRUMENTAL, Gender.NEUT, rowspan = 2)
                 data(Case.INSTRUMENTAL, Gender.FEM)
+                data(Case.INSTRUMENTAL, Gender.NEUT, rowspan = 2)
                 data(Case.INSTRUMENTAL, Num.PL)
             }
             row {
                 rowHeader("prepositional", colspan = 2)
                 data(Case.PREPOSITIONAL, Gender.MASC)
-                // neuter covered by rowspan
                 data(Case.PREPOSITIONAL, Gender.FEM)
+                // neuter covered by rowspan
                 data(Case.PREPOSITIONAL, Num.PL)
             }
             row {
                 rowHeader("short form", colspan = 2)
                 data(VerbForm.SHORT, Gender.MASC)
-                data(VerbForm.SHORT, Gender.NEUT)
                 data(VerbForm.SHORT, Gender.FEM)
+                data(VerbForm.SHORT, Gender.NEUT)
                 data(VerbForm.SHORT, Num.PL)
             }
         }
     }
 
+    /**
+     * Russian adverb paradigm.
+     *
+     * Gradable adverbs form a comparative degree. Only shown when comparative
+     * forms are present in the data (most adverbs are non-gradable).
+     */
+    val RU_ADVERB: ConjugationScheme = conjugationScheme(
+        "ru_adverb",
+        Language.RUSSIAN,
+        DictionaryPos.ADVERB,
+        tagResolver = russianTagResolver(DictionaryPos.ADVERB)
+    ) {
+        view("short", "Degrees of comparison") {
+            row {
+                rowHeader("comparative")
+                data(Degree.COMPARATIVE)
+            }
+        }
+    }
+
     /** All Russian schemes for easy lookup. */
-    val ALL: List<ConjugationScheme> = listOf(RU_NOUN, RU_VERB_IMPERFECTIVE, RU_VERB_PERFECTIVE, RU_ADJECTIVE)
+    val ALL: List<ConjugationScheme> = listOf(RU_NOUN, RU_VERB_IMPERFECTIVE, RU_VERB_PERFECTIVE, RU_ADJECTIVE, RU_ADVERB)
 
     /**
      * Selects the applicable schemes for [pos] given the word's raw input [forms].
@@ -417,6 +443,10 @@ object RuConjugationScheme : ConjugationSchemeProvider {
      * - Both or neither → [RU_VERB_IMPERFECTIVE] by predefined default order
      */
     override fun schemeFor(pos: DictionaryPos, forms: List<SchemeInputForm>): ConjugationScheme? {
+        if (pos == DictionaryPos.ADVERB) {
+            val hasComparative = forms.any { "comparative" in it.tags }
+            return if (hasComparative) RU_ADVERB else null
+        }
         val byPos = ALL.firstOrNull { it.pos == pos }
         if (pos != DictionaryPos.VERB) return byPos
         val hasPerfective = forms.any { "perfective" in it.tags && "canonical" in it.tags }


### PR DESCRIPTION
## Summary

- **Verbs**: `RU_VERB_IMPERFECTIVE` and `RU_VERB_PERFECTIVE` restructured to use tense sections with singular/plural columns and person/gender rows (matching Polish verb table style)
- **Adjectives**: added `essentials` view (nominative forms as rows: masc/fem/neuter/plural), reordered full-table columns to masc → fem → neuter, renamed tabs to *Essentials* / *Full table*
- **Adverbs**: new `RU_ADVERB` scheme with a comparative row; `schemeFor` guard ensures non-gradable adverbs (no comparative tag) get no table

## Test plan

- [ ] `RuConjugationSchemeTest` snapshots updated for all restructured views (читать, сказать, красивый)
- [ ] New adverb snapshot: быстро (gradable)
- [ ] New non-gradable adverb path: `schemeFor` returns `null` for canonical-only forms (абсолютно)
- [ ] Run `./gradlew :composeApp:desktopTest --tests "com.slovy.slovymovyapp.forms.RuConjugationSchemeTest"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)