### PR TITLE
fix(nl): correct present/future/conditional perfect rows in Dutch verb table

### DIFF
--- a/composeApp/src/commonTest/kotlin/com/slovy/slovymovyapp/forms/NlConjugationSchemeTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/slovy/slovymovyapp/forms/NlConjugationSchemeTest.kt
@@ -95,6 +95,14 @@ class NlConjugationSchemeTest : BaseTest() {
                 resolveFormsSnapshot(repo, Language.DUTCH, "kwartier", DictionaryPos.NOUN),
                 "Resolved NL noun views for 'kwartier' changed"
             )
+            // Pure zijn-verb (only zijn-auxiliary compound perfect forms in Wiktionary).
+            // The dutchAuxiliaryPriority tiebreaker must prefer "bent" (priority 1) over
+            // "is" (priority 2) for the 2nd-person present-perfect cell.
+            assertEquals(
+                expectedNlVerbOnderstromen,
+                resolveFormsSnapshot(repo, Language.DUTCH, "onderstromen", DictionaryPos.VERB),
+                "Resolved NL verb views for 'onderstromen' changed"
+            )
             // Archaic gij collision (non-separable): wrongt uit finite-token "wrongt" ends in -t,
             // must lose to wrong uit (modern).
             assertEquals(
@@ -130,13 +138,12 @@ class NlConjugationSchemeTest : BaseTest() {
             listOf(null, null, null, null, null),
             listOf(null, "zeg", "zegt", "zegt", "zeggen"),
             listOf(null, "zegde\nzei", "zegde\nzei", "zegde\nzei", "zegden\nzeiden"),
-            listOf(null, "zou zeggen", "zou zeggen", "zou zeggen", "zouden zeggen"),
             listOf(null, "zal zeggen", "zal zeggen", "zal zeggen", "zullen zeggen"),
+            listOf(null, "zou zeggen", "zou zeggen", "zou zeggen", "zouden zeggen"),
             listOf(null, "zeg", null),
-            listOf(null, null, null, null, null),
-            listOf(null, "ben gezegd", "bent gezegd", "hebben gezegd", null),
-            listOf(null, "zou gezegd hebben", "zou gezegd hebben", "zou gezegd hebben", null),
-            listOf(null, "zal gezegd hebben", "zal gezegd hebben", "zal gezegd hebben", null)
+            listOf(null, "heb gezegd", "hebt gezegd", "heeft gezegd", null),
+            listOf(null, "zal gezegd hebben", "zal gezegd hebben", "zal gezegd hebben", null),
+            listOf(null, "zou gezegd hebben", "zou gezegd hebben", "zou gezegd hebben", null)
         )
     )
 
@@ -164,7 +171,7 @@ class NlConjugationSchemeTest : BaseTest() {
 
     // uitwringen has "wrongt uit" (archaic 2nd-sg-past, ends in -t) alongside "wrong uit" (modern).
     // The gij heuristic must inject "gij" into the archaic form so it loses to the modern one.
-    // The conditional perfect must show active voice (zou uitgewrongen hebben) not passive (zou uitgewrongen zijn).
+    // Present/conditional/future perfect must show active hebben-auxiliary forms, not zijn-based ones.
     private val expectedNlVerbUitwringen = mapOf(
         "nl_verb:category_summary" to listOf(
             listOf(null, null),
@@ -180,13 +187,12 @@ class NlConjugationSchemeTest : BaseTest() {
             listOf(null, null, null, null, null),
             listOf(null, "wring uit", "wringt uit", "wringt uit", "wringen uit"),
             listOf(null, "wrong uit", "wrong uit", "wrong uit", "wrongen uit"),
-            listOf(null, "zou uitwringen", "zou uitwringen", "zou uitwringen", "zouden uitwringen"),
             listOf(null, "zal uitwringen", "zal uitwringen", "zal uitwringen", "zullen uitwringen"),
+            listOf(null, "zou uitwringen", "zou uitwringen", "zou uitwringen", "zouden uitwringen"),
             listOf(null, "wring uit", null),
-            listOf(null, null, null, null, null),
-            listOf(null, "ben uitgewrongen", "bent uitgewrongen", "hebben uitgewrongen", null),
-            listOf(null, "zou uitgewrongen hebben", "zou uitgewrongen hebben", "zou uitgewrongen hebben", null),
-            listOf(null, "zal uitgewrongen hebben", "zal uitgewrongen hebben", "zal uitgewrongen hebben", null)
+            listOf(null, "heb uitgewrongen", "hebt uitgewrongen", "heeft uitgewrongen", null),
+            listOf(null, "zal uitgewrongen hebben", "zal uitgewrongen hebben", "zal uitgewrongen hebben", null),
+            listOf(null, "zou uitgewrongen hebben", "zou uitgewrongen hebben", "zou uitgewrongen hebben", null)
         )
     )
 
@@ -209,13 +215,12 @@ class NlConjugationSchemeTest : BaseTest() {
             listOf(null, null, null, null, null),
             listOf(null, "spreek af", "spreekt af", "spreekt af", "spreken af"),
             listOf(null, "sprak af", "sprak af", "sprak af", "spraken af"),
-            listOf(null, "zou afspreken", "zou afspreken", "zou afspreken", "zouden afspreken"),
             listOf(null, "zal afspreken", "zal afspreken", "zal afspreken", "zullen afspreken"),
+            listOf(null, "zou afspreken", "zou afspreken", "zou afspreken", "zouden afspreken"),
             listOf(null, "spreek af", null),
-            listOf(null, null, null, null, null),
-            listOf(null, "ben afgesproken", "bent afgesproken", "hebben afgesproken", null),
-            listOf(null, "zou afgesproken hebben", "zou afgesproken hebben", "zou afgesproken hebben", null),
-            listOf(null, "zal afgesproken hebben", "zal afgesproken hebben", "zal afgesproken hebben", null)
+            listOf(null, "heb afgesproken", "hebt afgesproken", "heeft afgesproken", null),
+            listOf(null, "zal afgesproken hebben", "zal afgesproken hebben", "zal afgesproken hebben", null),
+            listOf(null, "zou afgesproken hebben", "zou afgesproken hebben", "zou afgesproken hebben", null)
         )
     )
 
@@ -225,6 +230,35 @@ class NlConjugationSchemeTest : BaseTest() {
             listOf(null, "kwartieren"),
             listOf(null, "kwartiertje"),
             listOf(null, "kwartiertjes")
+        )
+    )
+
+    // onderstromen is a pure zijn-verb: Wiktionary lists only zijn-auxiliary compound perfect
+    // forms (no "heb/hebt/heeft" counterpart). The zijn-passive heuristic therefore does NOT
+    // fire, and the dutchAuxiliaryPriority tiebreaker must pick "bent" (priority 1) over
+    // "is" (priority 2) for the 2nd-person present-perfect cell.
+    private val expectedNlVerbOnderstromen = mapOf(
+        "nl_verb:category_summary" to listOf(
+            listOf(null, null),
+            listOf(null, "onder te stromen"),  // infinitive (long-form te-infinitive wins)
+            listOf(null, "stroom onder"),      // present (ik) — main-clause form
+            listOf(null, "stroomt onder"),     // present (jij/hij/u)
+            listOf(null, "stroomde onder"),    // past singular
+            listOf(null, "stroomden onder"),   // past plural
+            listOf(null, "ondergestroomd"),    // past participle
+            listOf(null, "onderstromend")      // present participle
+        ),
+        "nl_verb:full" to listOf(
+            listOf(null, null, null, null, null),
+            listOf(null, "stroom onder", "stroomt onder", "stroomt onder", "stromen onder"),
+            listOf(null, "stroomde onder", "stroomde onder", "stroomde onder", "stroomden onder"),
+            listOf(null, "zal onderstromen", "zal onderstromen", "zal onderstromen", "zullen onderstromen"),
+            listOf(null, "zou onderstromen", "zou onderstromen", "zou onderstromen", "zouden onderstromen"),
+            listOf(null, "onderstroom", null),
+            // zijn-verb: heuristic does not fire; dutchAuxiliaryPriority selects ben/bent/is
+            listOf(null, "ben ondergestroomd", "bent ondergestroomd", "is ondergestroomd", null),
+            listOf(null, "zal ondergestroomd zijn", "zal ondergestroomd zijn", "zal ondergestroomd zijn", null),
+            listOf(null, "zou ondergestroomd zijn", "zou ondergestroomd zijn", "zou ondergestroomd zijn", null)
         )
     )
 

--- a/shared/src/commonMain/kotlin/com/slovy/slovymovyapp/data/forms/Tags.kt
+++ b/shared/src/commonMain/kotlin/com/slovy/slovymovyapp/data/forms/Tags.kt
@@ -257,7 +257,9 @@ object TagMapping {
         "noun" to PossessiveType.INDEPENDENT,           // theirs = "noun possessive"
 
         // Unmapped (documented here for reference):
-        // "perfect"       — nl compound past (hebben/zijn + past participle); no enum yet
+        // "perfect"       — nl compound past (hebben/zijn + past participle); mapped to "perfective"
+        //                   in NlConjugationScheme.preprocessForms so Aspect.PERFECTIVE can be used
+        //                   to select compound-tense cells; intentionally absent from this global map.
         // "inflected" / "uninflected" — nl adjective; no enum yet
         // "pluperfect", "anterior", "potential" — pl rare tenses; no enum yet
         // "adjectival"    — pl participial; overlaps with VerbForm.PARTICIPLE contextually

--- a/shared/src/commonMain/kotlin/com/slovy/slovymovyapp/data/forms/configs/NlConjugationScheme.kt
+++ b/shared/src/commonMain/kotlin/com/slovy/slovymovyapp/data/forms/configs/NlConjugationScheme.kt
@@ -32,10 +32,20 @@ object NlConjugationScheme : ConjugationSchemeProvider {
                         && (!form.form.endsWith(')') || '(' in form.form)
                 }
 
+            // Map "perfect" → "perfective" so compound tense forms (hebben/zijn + past participle)
+            // expose Aspect.PERFECTIVE to scheme cells. This lets present/conditional/future
+            // perfect cells *require* PERFECTIVE rather than merely *forbidding* indicative,
+            // which is more robust when forms lack the "indicative" tag in the source data.
+            val perfectedForms = cleanForms.map { form ->
+                if ("perfect" in form.tags && "perfective" !in form.tags)
+                    form.copy(tags = form.tags + "perfective")
+                else form
+            }
+
             // Canonicalize diminutive number tags using Dutch morphology (-je = singular, -jes = plural).
             // Always strip both number tags first and re-add the canonical one, so conflicting
             // combinations (e.g. -je + plural, or -jes + singular + plural) are fully corrected.
-            val correctedForms = cleanForms.map { form ->
+            val correctedForms = perfectedForms.map { form ->
                 val tags = form.tags
                 when {
                     "diminutive" in tags && form.form.endsWith("jes") ->
@@ -84,6 +94,36 @@ object NlConjugationScheme : ConjugationSchemeProvider {
                 }
             }
 
+            // Inject "passive" into zijn-auxiliary compound present-perfect forms when the same
+            // participle also has hebben-auxiliary forms. Dutch Wiktionary lists archaic/literary
+            // zijn-based compound forms alongside the standard hebben-based active forms for many
+            // hebben-verbs (e.g. "ben gedacht" alongside "heb gedacht" for "denken"). When both
+            // auxiliaries appear for the same participle, the zijn forms are lower-register and
+            // should lose to the standard hebben forms in scheme cells that forbid passive voice.
+            // Note: for pure zijn-verbs (gaan, komen) only zijn auxiliaries exist, so the
+            // heuristic never fires and "ben gegaan" is correctly left unmarked.
+            val zijnAuxiliaries = setOf("ben", "bent", "is", "zijn", "zijt")
+            val hebbenAuxiliaries = setOf("heb", "hebt", "heeft", "hebben")
+            val presentPerfectForms = markedForms.filter { form ->
+                "perfect" in form.tags && "present" in form.tags && ' ' in form.form
+            }
+            val participlesWithHebben = presentPerfectForms
+                .filter { it.form.substringBefore(' ') in hebbenAuxiliaries }
+                .map { it.form.substringAfter(' ') }
+                .toSet()
+            val archaicZijnForms = presentPerfectForms.filter { form ->
+                form.form.substringBefore(' ') in zijnAuxiliaries &&
+                    form.form.substringAfter(' ') in participlesWithHebben &&
+                    "passive" !in form.tags
+            }.toSet()
+            val finalForms = if (archaicZijnForms.isEmpty()) markedForms else {
+                markedForms.map { form ->
+                    if (form in archaicZijnForms)
+                        form.copy(tags = form.tags + "passive", source = FormSource.HEURISTIC)
+                    else form
+                }
+            }
+
             // Build extras from correctedForms (before imperfect stripping) so that the
             // imperfect-based heuristics below can still detect the original tag on
             // non-finite and conditional forms.
@@ -114,15 +154,29 @@ object NlConjugationScheme : ConjugationSchemeProvider {
 
                 result
             }
-            return if (extras.isEmpty()) markedForms else markedForms + extras
+            return if (extras.isEmpty()) finalForms else finalForms + extras
         }
 
         override fun selectCandidate(candidates: List<SchemeCellCandidate>): SchemeCellCandidate? {
             return candidates.minWithOrNull(
                 compareBy<SchemeCellCandidate> { -it.matchedPreferredTags }
                     .thenBy { it.extraKnownTags }
+                    // For compound perfect forms, prefer the person-specific auxiliary over
+                    // generic plural forms. Priority: 1st-sg (heb/ben) < 2nd-sg (hebt/bent) <
+                    // 3rd-sg (heeft/is) < plural/unknown (hebben/zijn/other). This makes "bent"
+                    // beat "is" for 2nd-person cells of zijn-verbs, and "hebt"/"heeft" beat
+                    // "hebben" for hebben-verbs. Single-word forms are unaffected (they resolve
+                    // to the same unknown bucket and fall through to the alphabetical tiebreaker).
+                    .thenBy { dutchAuxiliaryPriority(it.form.substringBefore(' ')) }
                     .thenBy { it.form }
             )
+        }
+
+        private fun dutchAuxiliaryPriority(auxiliary: String): Int = when (auxiliary) {
+            "heb", "ben" -> 0
+            "hebt", "bent", "zijt" -> 1
+            "heeft", "is" -> 2
+            else -> 3  // hebben, zijn, or any non-auxiliary (single-word forms)
         }
 
     }
@@ -195,13 +249,6 @@ object NlConjugationScheme : ConjugationSchemeProvider {
                 data(Tense.PAST, Num.PL, supporting = setOf(Mood.INDICATIVE))
             }
             row {
-                rowHeader("Conditional")
-                data(Mood.CONDITIONAL, Aspect.IMPERFECTIVE, Person.FIRST, Num.SG, supporting = setOf(Mood.INDICATIVE))
-                data(Mood.CONDITIONAL, Aspect.IMPERFECTIVE, Person.SECOND, Num.SG, supporting = setOf(Mood.INDICATIVE))
-                data(Mood.CONDITIONAL, Aspect.IMPERFECTIVE, Person.THIRD, Num.SG, supporting = setOf(Mood.INDICATIVE))
-                data(Mood.CONDITIONAL, Aspect.IMPERFECTIVE, Num.PL, supporting = setOf(Mood.INDICATIVE))
-            }
-            row {
                 rowHeader("Future")
                 data(Tense.FUTURE, Person.FIRST, Num.SG, supporting = setOf(Mood.INDICATIVE))
                 data(Tense.FUTURE, Person.SECOND, Num.SG, supporting = setOf(Mood.INDICATIVE))
@@ -209,36 +256,41 @@ object NlConjugationScheme : ConjugationSchemeProvider {
                 data(Tense.FUTURE, Num.PL, supporting = setOf(Mood.INDICATIVE))
             }
             row {
+                rowHeader("Conditional")
+                data(Mood.CONDITIONAL, Aspect.IMPERFECTIVE, Person.FIRST, Num.SG, supporting = setOf(Mood.INDICATIVE))
+                data(Mood.CONDITIONAL, Aspect.IMPERFECTIVE, Person.SECOND, Num.SG, supporting = setOf(Mood.INDICATIVE))
+                data(Mood.CONDITIONAL, Aspect.IMPERFECTIVE, Person.THIRD, Num.SG, supporting = setOf(Mood.INDICATIVE))
+                data(Mood.CONDITIONAL, Aspect.IMPERFECTIVE, Num.PL, supporting = setOf(Mood.INDICATIVE))
+            }
+            row {
                 rowHeader("Imperative")
                 data(Mood.IMPERATIVE, supporting = setOf(Num.SG))
                 empty(colspan = 3)
             }
             row {
-                empty()
-                colHeader("1st person")
-                colHeader("2nd person")
-                colHeader("3rd person")
-                empty()
-            }
-            row {
                 rowHeader("Present perfect")
-                data(Tense.PRESENT, Person.FIRST)
-                data(Tense.PRESENT, Person.SECOND)
-                data(Tense.PRESENT, Person.THIRD)
-                empty()
-            }
-            row {
-                rowHeader("Conditional perfect")
-                data(Mood.CONDITIONAL, Person.FIRST)
-                data(Mood.CONDITIONAL, Person.SECOND)
-                data(Mood.CONDITIONAL, Person.THIRD)
+                // Require PERFECTIVE (mapped from "perfect" in preprocessing) so only compound
+                // tense forms match; simple present forms lack "perfect" and are excluded even
+                // when "indicative" is absent from the DB data (e.g. verspringen).
+                // Forbid passive to exclude zijn-auxiliary forms that the preprocessing heuristic
+                // marks passive for hebben-verbs (e.g. "ben gedacht" for denken).
+                data(Tense.PRESENT, Person.FIRST, Aspect.PERFECTIVE, forbidden = setOf(Voice.PASSIVE))
+                data(Tense.PRESENT, Person.SECOND, Aspect.PERFECTIVE, forbidden = setOf(Voice.PASSIVE))
+                data(Tense.PRESENT, Person.THIRD, Aspect.PERFECTIVE, forbidden = setOf(Voice.PASSIVE))
                 empty()
             }
             row {
                 rowHeader("Future perfect")
-                data(Tense.FUTURE, Person.FIRST)
-                data(Tense.FUTURE, Person.SECOND)
-                data(Tense.FUTURE, Person.THIRD)
+                data(Tense.FUTURE, Aspect.PERFECTIVE, Person.FIRST, forbidden = setOf(Voice.PASSIVE))
+                data(Tense.FUTURE, Aspect.PERFECTIVE, Person.SECOND, forbidden = setOf(Voice.PASSIVE))
+                data(Tense.FUTURE, Aspect.PERFECTIVE, Person.THIRD, forbidden = setOf(Voice.PASSIVE))
+                empty()
+            }
+            row {
+                rowHeader("Conditional perfect")
+                data(Mood.CONDITIONAL, Aspect.PERFECTIVE, Person.FIRST, forbidden = setOf(Voice.PASSIVE))
+                data(Mood.CONDITIONAL, Aspect.PERFECTIVE, Person.SECOND, forbidden = setOf(Voice.PASSIVE))
+                data(Mood.CONDITIONAL, Aspect.PERFECTIVE, Person.THIRD, forbidden = setOf(Voice.PASSIVE))
                 empty()
             }
         }


### PR DESCRIPTION
## Summary

- **Wrong form in perfect cells** (verspringen, doorstromen): simple present forms leaked into present-perfect cells because the `"perfect"` DB tag was unmapped. Fixed by mapping `"perfect"` → `"perfective"` in `preprocessForms` so perfect cells can *require* `Aspect.PERFECTIVE`, positively selecting only compound tense forms.
- **Wrong auxiliary for 2nd/3rd person** (nemen, zeggen): `"hebben"` was shown instead of `"hebt"`/`"heeft"`. Fixed by a `dutchAuxiliaryPriority` tiebreaker in `selectCandidate` that ranks `heb/ben < hebt/bent/zijt < heeft/is < plural/other`.
- **zijn-auxiliary forms for hebben-verbs** (denken): archaic `"ben gedacht"` was beating `"heb gedacht"` for 1st person. Fixed by injecting `"passive"` into zijn-auxiliary present-perfect forms when a hebben-auxiliary form for the same participle also exists; perfect cells now forbid passive.
- **Row order**: swap Conditional/Future rows (Future before Conditional is the standard order).
- **Remove redundant header row** between simple and perfect tense blocks.

## Test plan

- [ ] Snapshot tests for `zeggen`, `uitwringen`, `afspreken` updated and passing — verify hebben-verb perfect rows show `heb/hebt/heeft`
- [ ] New snapshot for `onderstromen` (pure zijn-verb) — verify `dutchAuxiliaryPriority` selects `"bent"` over `"is"` for 2nd-person present perfect
- [ ] Run `./gradlew :composeApp:desktopTest --tests "*.NlConjugationSchemeTest"`
- [ ] Manually check Dutch verbs in the app: verspringen, doorstromen, denken, nemen, beginnen, sterven

🤖 Generated with [Claude Code](https://claude.com/claude-code)