### PR TITLE
fix(ios): prevent cursor jump and dropped characters in text fields

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/FeedbackDialog.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/FeedbackDialog.kt
@@ -145,7 +145,7 @@ fun FeedbackDialog(
             confirmButton = {
                 TextButton(
                     onClick = onSend,
-                    enabled = !isSending && comment.isNotBlank()
+                    enabled = !isSending && commentValue.text.isNotBlank()
                 ) {
                     if (isSending) {
                         CircularProgressIndicator(

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/FeedbackDialog.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/FeedbackDialog.kt
@@ -4,11 +4,12 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.CheckCircle
 import androidx.compose.material3.*
-import androidx.compose.runtime.Composable
+import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.dp
@@ -88,10 +89,15 @@ fun FeedbackDialog(
                     focusedBorderColor = MaterialTheme.colorScheme.onSurfaceVariant,
                     focusedLabelColor = MaterialTheme.colorScheme.onSurfaceVariant
                 )
+                // Local TextFieldValue state preserves cursor position across recompositions.
+                // Plain String → TextField causes cursor jumps on iOS due to the UIKit bridge
+                // recreating cursor state on every recomposition triggered by ViewModel updates.
+                var commentValue by remember { mutableStateOf(TextFieldValue(comment)) }
+                var emailValue by remember { mutableStateOf(TextFieldValue(email)) }
                 Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
                     OutlinedTextField(
-                        value = comment,
-                        onValueChange = onCommentChange,
+                        value = commentValue,
+                        onValueChange = { commentValue = it; onCommentChange(it.text) },
                         modifier = Modifier.fillMaxWidth(),
                         minLines = 3,
                         maxLines = 6,
@@ -109,8 +115,8 @@ fun FeedbackDialog(
                         isError = error != null
                     )
                     OutlinedTextField(
-                        value = email,
-                        onValueChange = onEmailChange,
+                        value = emailValue,
+                        onValueChange = { emailValue = it; onEmailChange(it.text) },
                         modifier = Modifier.fillMaxWidth(),
                         singleLine = true,
                         enabled = !isSending,

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/FeedbackDialog.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/FeedbackDialog.kt
@@ -72,6 +72,12 @@ fun FeedbackDialog(
             }
         )
     } else {
+        // Local TextFieldValue state preserves cursor position across recompositions.
+        // Plain String → TextField causes cursor jumps on iOS due to the UIKit bridge
+        // recreating cursor state on every recomposition triggered by ViewModel updates.
+        // Hoisted outside AlertDialog so confirmButton can read commentValue.text.
+        var commentValue by remember { mutableStateOf(TextFieldValue(comment)) }
+        var emailValue by remember { mutableStateOf(TextFieldValue(email)) }
         AlertDialog(
             onDismissRequest = {
                 if (!isSending) onDismiss()
@@ -89,11 +95,6 @@ fun FeedbackDialog(
                     focusedBorderColor = MaterialTheme.colorScheme.onSurfaceVariant,
                     focusedLabelColor = MaterialTheme.colorScheme.onSurfaceVariant
                 )
-                // Local TextFieldValue state preserves cursor position across recompositions.
-                // Plain String → TextField causes cursor jumps on iOS due to the UIKit bridge
-                // recreating cursor state on every recomposition triggered by ViewModel updates.
-                var commentValue by remember { mutableStateOf(TextFieldValue(comment)) }
-                var emailValue by remember { mutableStateOf(TextFieldValue(email)) }
                 Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
                     OutlinedTextField(
                         value = commentValue,

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/components/AppSearchBar.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/components/AppSearchBar.kt
@@ -133,6 +133,7 @@ fun AppSearchBar(
                 {
                     IconButton(onClick = {
                         textFieldValue = TextFieldValue("", TextRange(0))
+                        lastSentQuery.value = ""
                         onQueryChange("")
                     }) {
                         Icon(

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/components/AppSearchBar.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/components/AppSearchBar.kt
@@ -72,12 +72,20 @@ fun AppSearchBar(
         label = "searchBarElevation"
     )
 
-    // Use TextFieldValue to control cursor position
     var textFieldValue by remember { mutableStateOf(TextFieldValue(query, TextRange(query.length))) }
+    // Plain (non-observable) ref updated synchronously in onValueChange before onQueryChange
+    // is called. LaunchedEffect reads it on the main thread after the event fires, so it
+    // always sees the up-to-date value. Using a non-State holder avoids the extra
+    // recomposition that a mutableStateOf write would trigger, which on iOS caused
+    // the UIKit text bridge to drop characters mid-keystroke.
+    val lastSentQuery = remember { object { var value = query } }
 
-    // Sync external query changes and place cursor at end
     LaunchedEffect(query) {
-        if (textFieldValue.text != query) {
+        // Only sync when query was changed from outside (not as a round-trip echo of our
+        // own onValueChange call). This preserves cursor position during normal typing
+        // while still handling external resets such as restore-after-process-death.
+        if (query != lastSentQuery.value) {
+            lastSentQuery.value = query
             textFieldValue = TextFieldValue(query, TextRange(query.length))
         }
     }
@@ -97,6 +105,7 @@ fun AppSearchBar(
             value = textFieldValue,
             onValueChange = { newValue ->
                 textFieldValue = newValue
+                lastSentQuery.value = newValue.text
                 onQueryChange(newValue.text)
             },
             modifier = Modifier


### PR DESCRIPTION
Fixes #409

Real devs were right, the issue is not related to the number of favs.

## Summary

- **AppSearchBar**: `lastSentQuery` non-observable ref (plain object, not `mutableStateOf`) updated synchronously in `onValueChange` before `onQueryChange` is called. `LaunchedEffect(query)` skips the cursor reset when `query` is just echoing the user's own keystroke back; only syncs for genuine external changes (restore-after-process-death, programmatic clear). Using a non-State holder avoids the extra recomposition that previously caused the iOS UIKit bridge to drop characters mid-keystroke.
- **FeedbackDialog**: local `TextFieldValue` state for comment and email fields so cursor position survives ViewModel-driven recompositions on iOS. Affects both the settings and word-card feedback entry points.

## Test plan

- [ ] Favourites search — type quickly (e.g. "bardzo"), no characters dropped, cursor stays in place
- [ ] Feedback dialog (from settings and from a word card) — type in the middle of text, cursor holds position

🤖 Generated with [Claude Code](https://claude.com/claude-code)