### PR TITLE
UI: improve copy and styling for Data and error screens

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/App.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/App.kt
@@ -642,7 +642,7 @@ fun App(
                 val viewModel = viewModel(
                     viewModelStoreOwner = backStackEntry
                 ) {
-                    ErrorViewModel("Data format has been updated. Your downloaded dictionaries will be deleted and need to be re-downloaded.")
+                    ErrorViewModel("We've updated the dictionary format. You'll need to re-download your dictionaries — your saved words are safe.")
                 }
 
                 ErrorScreen(

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/AppDataSection.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/AppDataSection.kt
@@ -37,7 +37,7 @@ fun AppDataSection(
                 style = MaterialTheme.typography.titleMedium
             )
             Text(
-                text = "Exports your saved words to an archive. Useful for keeping a copy or moving to a new device.",
+                text = "Exports your saved words and app settings to an archive. Useful for keeping a copy or moving to a new device.",
                 style = MaterialTheme.typography.bodyMedium,
                 color = MaterialTheme.colorScheme.onSurfaceVariant
             )

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/AppDataSection.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/AppDataSection.kt
@@ -10,12 +10,10 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.dp
-import com.slovy.slovymovyapp.data.remote.standardAppDataDatabaseFileNames
 import com.slovy.slovymovyapp.ui.theme.AppSpacing
 
 @Composable
 fun AppDataSection(
-    destinationDescription: String,
     isExporting: Boolean,
     onExport: () -> Unit,
     modifier: Modifier = Modifier
@@ -35,17 +33,15 @@ fun AppDataSection(
             verticalArrangement = Arrangement.spacedBy(AppSpacing.md)
         ) {
             Text(
-                text = "Export app databases",
+                text = "Back up your saved words",
                 style = MaterialTheme.typography.titleMedium
             )
             Text(
-                text = "Creates a tar archive with ${
-                    standardAppDataDatabaseFileNames.joinToString()
-                } in $destinationDescription.",
+                text = "Exports your saved words to an archive. Useful for keeping a copy or moving to a new device.",
                 style = MaterialTheme.typography.bodyMedium,
                 color = MaterialTheme.colorScheme.onSurfaceVariant
             )
-            Button(
+            FilledTonalButton(
                 onClick = onExport,
                 enabled = !isExporting
             ) {
@@ -78,7 +74,6 @@ private fun AppDataSectionPreview(
 ) {
     ThemedPreview(darkTheme = isDark) {
         AppDataSection(
-            destinationDescription = "Downloads/SlovyMovy",
             isExporting = false,
             onExport = {}
         )
@@ -92,7 +87,6 @@ private fun AppDataSectionExportingPreview(
 ) {
     ThemedPreview(darkTheme = isDark) {
         AppDataSection(
-            destinationDescription = "Downloads/SlovyMovy",
             isExporting = true,
             onExport = {}
         )

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/ErrorScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/ErrorScreen.kt
@@ -2,15 +2,22 @@ package com.slovy.slovymovyapp.ui
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Info
 import androidx.compose.material3.Button
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.ViewModel
 
@@ -34,16 +41,26 @@ fun ErrorScreenContent(
 ) {
     Scaffold(containerColor = MaterialTheme.colorScheme.background) { innerPadding ->
         Column(
-            modifier = Modifier.fillMaxSize().padding(innerPadding).padding(24.dp),
-            verticalArrangement = Arrangement.spacedBy(16.dp, Alignment.CenterVertically),
+            modifier = Modifier.fillMaxSize().padding(innerPadding).padding(32.dp),
+            verticalArrangement = Arrangement.Center,
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
+            Icon(
+                imageVector = Icons.Outlined.Info,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.primary,
+                modifier = Modifier.size(48.dp)
+            )
+            Spacer(modifier = Modifier.height(24.dp))
             Text(
                 text = state.message,
-                style = MaterialTheme.typography.bodyLarge
+                style = MaterialTheme.typography.bodyLarge,
+                textAlign = TextAlign.Center,
+                color = MaterialTheme.colorScheme.onSurface
             )
+            Spacer(modifier = Modifier.height(32.dp))
             Button(onClick = onOkay) {
-                Text("Okay")
+                Text("Got it")
             }
         }
     }
@@ -68,6 +85,20 @@ private fun ErrorScreenPreviewLongMessage(
         ErrorScreenContent(
             state = ErrorViewModel(
                 "We couldn't complete the download. Please check your connection and try again."
+            )
+        )
+    }
+}
+
+@androidx.compose.ui.tooling.preview.Preview
+@Composable
+private fun ErrorScreenPreviewDataVersionMismatch(
+    @androidx.compose.ui.tooling.preview.PreviewParameter(ThemePreviewProvider::class) isDark: Boolean
+) {
+    ThemedPreview(darkTheme = isDark) {
+        ErrorScreenContent(
+            state = ErrorViewModel(
+                "We've updated the dictionary format. You'll need to re-download your dictionaries — your saved words are safe."
             )
         )
     }

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/ErrorScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/ErrorScreen.kt
@@ -7,6 +7,8 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Info
 import androidx.compose.material3.Button
@@ -41,7 +43,11 @@ fun ErrorScreenContent(
 ) {
     Scaffold(containerColor = MaterialTheme.colorScheme.background) { innerPadding ->
         Column(
-            modifier = Modifier.fillMaxSize().padding(innerPadding).padding(32.dp),
+            modifier = Modifier
+                .fillMaxSize()
+                .verticalScroll(rememberScrollState())
+                .padding(innerPadding)
+                .padding(32.dp),
             verticalArrangement = Arrangement.Center,
             horizontalAlignment = Alignment.CenterHorizontally
         ) {

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/SettingsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/SettingsScreen.kt
@@ -70,7 +70,6 @@ data class SettingsUiState(
 
     // Data export
     val isAppDataExportSupported: Boolean = false,
-    val appDataExportDestinationDescription: String = "",
     val isExportingAppData: Boolean = false,
 
     // About
@@ -107,8 +106,7 @@ class SettingsViewModel(
     var state by mutableStateOf(
         SettingsUiState(
             buildConfig = buildConfig,
-            isAppDataExportSupported = appDataExporter.isSupported,
-            appDataExportDestinationDescription = appDataExporter.destinationDescription
+            isAppDataExportSupported = appDataExporter.isSupported
         )
     )
         private set
@@ -1377,7 +1375,6 @@ private fun SettingsScreenPreviewWithMixedStates(
                     "trans_en_pl" to DownloadProgress(2 * 1024 * 1024, 7 * 1024 * 1024)
                 ),
                 isAppDataExportSupported = true,
-                appDataExportDestinationDescription = "Downloads/SlovyMovy"
             )
         )
     }

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/SettingsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/SettingsScreen.kt
@@ -1041,14 +1041,13 @@ fun SettingsScreenContent(
                             if (state.isAppDataExportSupported) {
                                 item {
                                     SectionHeader(
-                                        title = "Data",
+                                        title = "Your data",
                                         modifier = Modifier.padding(top = AppSpacing.sm)
                                     )
                                 }
 
                                 item {
                                     AppDataSection(
-                                        destinationDescription = state.appDataExportDestinationDescription,
                                         isExporting = state.isExportingAppData,
                                         onExport = onExportAppData
                                     )


### PR DESCRIPTION
## Summary

- **Settings > Your data section**: renamed from "Data", card title changed to "Back up your saved words", description rewritten in plain language (no more tar/db file references), `Button` → `FilledTonalButton`
- **Data version mismatch screen**: less alarming message ("We've updated the dictionary format…your saved words are safe"), added `Info` icon, centered layout, button renamed to "Got it"

## Test plan
- [ ] Open Settings, verify Data section shows updated title, description, and tonal button style
- [ ] Trigger a data version mismatch (or check preview) to verify new message and icon
- [ ] Verify export still works on Android and iOS

🤖 Generated with [Claude Code](https://claude.com/claude-code)