### PR TITLE
feat(tts): voice setup prompt for low-quality voices

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/speech/VoiceFilterHelper.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/speech/VoiceFilterHelper.kt
@@ -5,10 +5,10 @@ import com.slovy.slovymovyapp.data.settings.SettingsRepository
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.IO
 import kotlinx.coroutines.withContext
+import com.slovy.slovymovyapp.data.Language
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
-import kotlinx.serialization.json.booleanOrNull
 import kotlinx.serialization.json.contentOrNull
 
 /**
@@ -70,15 +70,23 @@ class VoiceFilterHelper(private val settingsRepo: SettingsRepository?) {
         localVoices
     }
 
-    suspend fun isVoiceSetupShown(): Boolean = withContext(Dispatchers.IO) {
+    suspend fun isVoiceSetupShown(language: Language): Boolean = withContext(Dispatchers.IO) {
         val repo = settingsRepo ?: return@withContext true
         val setting = repo.getById(Setting.Name.VOICE_SETUP_SHOWN) ?: return@withContext false
-        (setting.value as? JsonPrimitive)?.booleanOrNull == true
+        val shownCodes = (setting.value as? JsonArray)
+            ?.mapNotNull { (it as? JsonPrimitive)?.contentOrNull }
+            ?.toSet() ?: emptySet()
+        language.code in shownCodes
     }
 
-    suspend fun markVoiceSetupShown() = withContext(Dispatchers.IO) {
+    suspend fun markVoiceSetupShown(language: Language) = withContext(Dispatchers.IO) {
         val repo = settingsRepo ?: return@withContext
-        repo.insert(Setting(Setting.Name.VOICE_SETUP_SHOWN, JsonPrimitive(true)))
+        val existing = repo.getById(Setting.Name.VOICE_SETUP_SHOWN)
+        val currentCodes = (existing?.value as? JsonArray)
+            ?.mapNotNull { (it as? JsonPrimitive)?.contentOrNull }
+            ?.toMutableSet() ?: mutableSetOf()
+        currentCodes.add(language.code)
+        repo.insert(Setting(Setting.Name.VOICE_SETUP_SHOWN, JsonArray(currentCodes.map { JsonPrimitive(it) })))
     }
 
     suspend fun filterVoicesByEnabled(

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/speech/VoiceFilterHelper.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/speech/VoiceFilterHelper.kt
@@ -1,11 +1,11 @@
 package com.slovy.slovymovyapp.speech
 
+import com.slovy.slovymovyapp.data.Language
 import com.slovy.slovymovyapp.data.settings.Setting
 import com.slovy.slovymovyapp.data.settings.SettingsRepository
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.IO
 import kotlinx.coroutines.withContext
-import com.slovy.slovymovyapp.data.Language
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/speech/VoiceFilterHelper.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/speech/VoiceFilterHelper.kt
@@ -8,6 +8,7 @@ import kotlinx.coroutines.withContext
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.booleanOrNull
 import kotlinx.serialization.json.contentOrNull
 
 /**
@@ -67,6 +68,17 @@ class VoiceFilterHelper(private val settingsRepo: SettingsRepository?) {
             setEnabledVoices(language, localVoices)
         }
         localVoices
+    }
+
+    suspend fun isVoiceSetupShown(): Boolean = withContext(Dispatchers.IO) {
+        val repo = settingsRepo ?: return@withContext true
+        val setting = repo.getById(Setting.Name.VOICE_SETUP_SHOWN) ?: return@withContext false
+        (setting.value as? JsonPrimitive)?.booleanOrNull == true
+    }
+
+    suspend fun markVoiceSetupShown() = withContext(Dispatchers.IO) {
+        val repo = settingsRepo ?: return@withContext
+        repo.insert(Setting(Setting.Name.VOICE_SETUP_SHOWN, JsonPrimitive(true)))
     }
 
     suspend fun filterVoicesByEnabled(

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/VoiceSection.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/VoiceSection.kt
@@ -192,8 +192,7 @@ fun DownloadMoreVoicesCard(onOpenSettings: () -> Unit) {
                 Spacer(modifier = Modifier.width(AppSpacing.md))
                 Text(
                     text = "Download more voices",
-                    style = MaterialTheme.typography.titleMedium,
-                    modifier = Modifier.weight(1f)
+                    style = MaterialTheme.typography.titleMedium
                 )
             }
 

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/VoiceSection.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/VoiceSection.kt
@@ -156,59 +156,58 @@ fun VoiceSectionItem(
     }
 }
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun DownloadMoreVoicesCard(onOpenSettings: () -> Unit) {
+    val platform = getPlatform().name
+    val isIos = platform.contains("iOS", ignoreCase = true)
+    val isAndroid = platform.contains("Android", ignoreCase = true)
+
+    val step1Instruction = when {
+        isAndroid -> "Open your phone's text-to-speech settings and download a high-quality voice."
+        isIos -> "Go to your iPhone Settings → Accessibility → Read & Speak → Voices and download a high-quality voice."
+        else -> "Download a high-quality voice from your system settings."
+    }
+
     ElevatedCard(
         modifier = Modifier.fillMaxWidth(),
         shape = MaterialTheme.shapes.extraLarge,
         colors = CardDefaults.elevatedCardColors(
             containerColor = MaterialTheme.colorScheme.surfaceContainer
         ),
-        elevation = CardDefaults.elevatedCardElevation(defaultElevation = 0.dp),
-        onClick = onOpenSettings
+        elevation = CardDefaults.elevatedCardElevation(defaultElevation = 0.dp)
     ) {
-        Row(
+        Column(
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(AppSpacing.lg),
-            verticalAlignment = Alignment.CenterVertically
+            verticalArrangement = Arrangement.spacedBy(AppSpacing.md)
         ) {
-            Icon(
-                imageVector = Icons.Default.Download,
-                contentDescription = null,
-                tint = MaterialTheme.colorScheme.primary,
-                modifier = Modifier.size(24.dp)
-            )
-
-            Spacer(modifier = Modifier.width(AppSpacing.md))
-
-            Column(modifier = Modifier.weight(1f)) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Icon(
+                    imageVector = Icons.Default.Download,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.primary,
+                    modifier = Modifier.size(24.dp)
+                )
+                Spacer(modifier = Modifier.width(AppSpacing.md))
                 Text(
                     text = "Download more voices",
                     style = MaterialTheme.typography.titleMedium,
+                    modifier = Modifier.weight(1f)
                 )
-                val platform = getPlatform().name
-                val voicesText = when {
-                    platform.contains("Android", ignoreCase = true) -> "Open system settings"
-                    platform.contains("iOS", ignoreCase = true) -> "Accessibility → Spoken Content → Voices"
-                    else -> ""
-                }
-
-                if (voicesText.isNotEmpty()) {
-                    Text(
-                        text = voicesText,
-                        style = MaterialTheme.typography.bodyMedium,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant
-                    )
-                }
             }
 
-            Icon(
-                imageVector = Icons.AutoMirrored.Filled.KeyboardArrowRight,
-                contentDescription = null,
-                tint = MaterialTheme.colorScheme.onSurfaceVariant
-            )
+            StepRow(number = 1, text = step1Instruction)
+            StepRow(number = 2, text = "Come back to Open Words Settings → Voice and enable the new voice.")
+
+            if (isAndroid || isIos) {
+                FilledTonalButton(
+                    onClick = onOpenSettings,
+                    modifier = Modifier.fillMaxWidth()
+                ) {
+                    Text("Open System Settings")
+                }
+            }
         }
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/VoiceSetupBottomSheet.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/VoiceSetupBottomSheet.kt
@@ -20,13 +20,14 @@ import com.slovy.slovymovyapp.ui.theme.AppSpacing
 fun VoiceSetupBottomSheet(
     language: Language,
     onOpenSettings: () -> Unit,
-    onDismiss: () -> Unit
+    onDismiss: () -> Unit,
+    onLater: () -> Unit
 ) {
     ModalBottomSheet(onDismissRequest = onDismiss) {
         VoiceSetupBottomSheetContent(
             language = language,
             onOpenSettings = onOpenSettings,
-            onDismiss = onDismiss
+            onLater = onLater
         )
     }
 }
@@ -35,7 +36,7 @@ fun VoiceSetupBottomSheet(
 fun VoiceSetupBottomSheetContent(
     language: Language,
     onOpenSettings: () -> Unit,
-    onDismiss: () -> Unit
+    onLater: () -> Unit
 ) {
     val platform = getPlatform().name
     val isIos = platform.contains("iOS", ignoreCase = true)
@@ -93,7 +94,7 @@ fun VoiceSetupBottomSheetContent(
         }
 
         TextButton(
-            onClick = onDismiss,
+            onClick = onLater,
             modifier = Modifier.fillMaxWidth()
         ) {
             Text("Later")
@@ -138,7 +139,7 @@ private fun VoiceSetupBottomSheetPreview(
             VoiceSetupBottomSheetContent(
                 language = Language.DUTCH,
                 onOpenSettings = {},
-                onDismiss = {}
+                onLater = {}
             )
         }
     }

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/VoiceSetupBottomSheet.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/VoiceSetupBottomSheet.kt
@@ -42,8 +42,8 @@ fun VoiceSetupBottomSheetContent(
     val isAndroid = platform.contains("Android", ignoreCase = true)
 
     val step1Instruction = when {
-        isAndroid -> "Open TTS settings and download a high-quality voice for ${language.selfName}."
-        isIos -> "Go to Settings → Accessibility → Spoken Content → Voices and download a voice for ${language.selfName}."
+        isAndroid -> "Open your phone's text-to-speech settings and download a high-quality voice for ${language.selfName}."
+        isIos -> "Go to your iPhone Settings → Accessibility → Read & Speak → Voices and download a voice for ${language.selfName}."
         else -> "Download a high-quality voice for ${language.selfName} from your system settings."
     }
 
@@ -79,7 +79,7 @@ fun VoiceSetupBottomSheetContent(
         Spacer(modifier = Modifier.height(AppSpacing.sm))
 
         StepRow(number = 1, text = step1Instruction)
-        StepRow(number = 2, text = "Come back to Settings → Voices and enable the new voice.")
+        StepRow(number = 2, text = "Come back to Open Words Settings → Voices and enable the new voice.")
 
         Spacer(modifier = Modifier.height(AppSpacing.sm))
 
@@ -88,7 +88,7 @@ fun VoiceSetupBottomSheetContent(
                 onClick = onOpenSettings,
                 modifier = Modifier.fillMaxWidth()
             ) {
-                Text("Open Settings")
+                Text("Open System Settings")
             }
         }
 
@@ -102,7 +102,7 @@ fun VoiceSetupBottomSheetContent(
 }
 
 @Composable
-private fun StepRow(number: Int, text: String) {
+internal fun StepRow(number: Int, text: String) {
     Row(
         horizontalArrangement = Arrangement.spacedBy(AppSpacing.md),
         modifier = Modifier.fillMaxWidth()

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/VoiceSetupBottomSheet.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/VoiceSetupBottomSheet.kt
@@ -1,0 +1,145 @@
+package com.slovy.slovymovyapp.ui
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.outlined.VolumeUp
+import androidx.compose.material3.*
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewParameter
+import androidx.compose.ui.unit.dp
+import com.slovy.slovymovyapp.data.Language
+import com.slovy.slovymovyapp.getPlatform
+import com.slovy.slovymovyapp.ui.theme.AppSpacing
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun VoiceSetupBottomSheet(
+    language: Language,
+    onOpenSettings: () -> Unit,
+    onDismiss: () -> Unit
+) {
+    ModalBottomSheet(onDismissRequest = onDismiss) {
+        VoiceSetupBottomSheetContent(
+            language = language,
+            onOpenSettings = onOpenSettings,
+            onDismiss = onDismiss
+        )
+    }
+}
+
+@Composable
+fun VoiceSetupBottomSheetContent(
+    language: Language,
+    onOpenSettings: () -> Unit,
+    onDismiss: () -> Unit
+) {
+    val platform = getPlatform().name
+    val isIos = platform.contains("iOS", ignoreCase = true)
+    val isAndroid = platform.contains("Android", ignoreCase = true)
+
+    val step1Instruction = when {
+        isAndroid -> "Open TTS settings and download a high-quality voice for ${language.selfName}."
+        isIos -> "Go to Settings → Accessibility → Spoken Content → Voices and download a voice for ${language.selfName}."
+        else -> "Download a high-quality voice for ${language.selfName} from your system settings."
+    }
+
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = AppSpacing.xl)
+            .padding(bottom = AppSpacing.xl),
+        verticalArrangement = Arrangement.spacedBy(AppSpacing.md)
+    ) {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(AppSpacing.sm)
+        ) {
+            Icon(
+                imageVector = Icons.AutoMirrored.Outlined.VolumeUp,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.primary,
+                modifier = Modifier.size(24.dp)
+            )
+            Text(
+                text = "Get better pronunciation",
+                style = MaterialTheme.typography.titleLarge.copy(fontWeight = FontWeight.SemiBold)
+            )
+        }
+
+        Text(
+            text = "The default voice may sound robotic. Here's how to get a better one:",
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+
+        Spacer(modifier = Modifier.height(AppSpacing.sm))
+
+        StepRow(number = 1, text = step1Instruction)
+        StepRow(number = 2, text = "Come back to Settings → Voices and enable the new voice.")
+
+        Spacer(modifier = Modifier.height(AppSpacing.sm))
+
+        if (isAndroid || isIos) {
+            Button(
+                onClick = onOpenSettings,
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                Text("Open Settings")
+            }
+        }
+
+        TextButton(
+            onClick = onDismiss,
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            Text("Later")
+        }
+    }
+}
+
+@Composable
+private fun StepRow(number: Int, text: String) {
+    Row(
+        horizontalArrangement = Arrangement.spacedBy(AppSpacing.md),
+        modifier = Modifier.fillMaxWidth()
+    ) {
+        Surface(
+            shape = MaterialTheme.shapes.small,
+            color = MaterialTheme.colorScheme.primaryContainer,
+            modifier = Modifier.size(24.dp)
+        ) {
+            Box(contentAlignment = Alignment.Center) {
+                Text(
+                    text = number.toString(),
+                    style = MaterialTheme.typography.labelMedium.copy(fontWeight = FontWeight.SemiBold),
+                    color = MaterialTheme.colorScheme.onPrimaryContainer
+                )
+            }
+        }
+        Text(
+            text = text,
+            style = MaterialTheme.typography.bodyMedium,
+            modifier = Modifier.weight(1f)
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun VoiceSetupBottomSheetPreview(
+    @PreviewParameter(ThemePreviewProvider::class) isDark: Boolean
+) {
+    ThemedPreview(darkTheme = isDark) {
+        Surface {
+            VoiceSetupBottomSheetContent(
+                language = Language.DUTCH,
+                onOpenSettings = {},
+                onDismiss = {}
+            )
+        }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/VoiceSetupBottomSheet.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/VoiceSetupBottomSheet.kt
@@ -84,7 +84,7 @@ fun VoiceSetupBottomSheetContent(
         Spacer(modifier = Modifier.height(AppSpacing.sm))
 
         if (isAndroid || isIos) {
-            Button(
+            FilledTonalButton(
                 onClick = onOpenSettings,
                 modifier = Modifier.fillMaxWidth()
             ) {

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/word/WordDetailsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/word/WordDetailsScreen.kt
@@ -34,6 +34,7 @@ import com.slovy.slovymovyapp.speech.VoiceFilterHelper
 import com.slovy.slovymovyapp.speech.VoiceQuality
 import com.slovy.slovymovyapp.ui.AppNavigationBar
 import com.slovy.slovymovyapp.ui.AppScreen
+import com.slovy.slovymovyapp.ui.VoiceSetupBottomSheet
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.onCompletion
@@ -506,6 +507,7 @@ class WordDetailViewModel(
     fun dismissVoiceSetup() {
         viewModelScope.launch { voiceFilterHelper.markVoiceSetupShown(dictionaryLanguage) }
         showVoiceSetupSheet = false
+        doPlayWord()
     }
 
     fun openVoiceSettings() {

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/word/WordDetailsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/word/WordDetailsScreen.kt
@@ -507,6 +507,10 @@ class WordDetailViewModel(
     fun dismissVoiceSetup() {
         viewModelScope.launch { voiceFilterHelper.markVoiceSetupShown(dictionaryLanguage) }
         showVoiceSetupSheet = false
+    }
+
+    fun dismissVoiceSetupAndPlay() {
+        dismissVoiceSetup()
         doPlayWord()
     }
 
@@ -776,6 +780,7 @@ fun WordDetailScreen(
         showVoiceSetupSheet = viewModel.showVoiceSetupSheet,
         onOpenVoiceSettings = { viewModel.openVoiceSettings() },
         onDismissVoiceSetup = { viewModel.dismissVoiceSetup() },
+        onLaterVoiceSetup = { viewModel.dismissVoiceSetupAndPlay() },
         onOpenFeedback = { viewModel.openFeedbackDialog() },
         onDismissFeedback = { viewModel.dismissFeedbackDialog() },
         onFeedbackCommentChange = { viewModel.updateFeedbackComment(it) },
@@ -817,6 +822,7 @@ fun WordDetailScreenContent(
     showVoiceSetupSheet: Boolean = false,
     onOpenVoiceSettings: () -> Unit = {},
     onDismissVoiceSetup: () -> Unit = {},
+    onLaterVoiceSetup: () -> Unit = {},
     onOpenFeedback: () -> Unit = {},
     onDismissFeedback: () -> Unit = {},
     onFeedbackCommentChange: (String) -> Unit = {},
@@ -978,7 +984,8 @@ fun WordDetailScreenContent(
         VoiceSetupBottomSheet(
             language = dictionaryLanguage,
             onOpenSettings = onOpenVoiceSettings,
-            onDismiss = onDismissVoiceSetup
+            onDismiss = onDismissVoiceSetup,
+            onLater = onLaterVoiceSetup
         )
     }
 

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/word/WordDetailsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/word/WordDetailsScreen.kt
@@ -31,6 +31,7 @@ import com.slovy.slovymovyapp.speech.TTSStatus
 import com.slovy.slovymovyapp.speech.Text2SpeechVoice
 import com.slovy.slovymovyapp.speech.TextToSpeechManager
 import com.slovy.slovymovyapp.speech.VoiceFilterHelper
+import com.slovy.slovymovyapp.speech.VoiceQuality
 import com.slovy.slovymovyapp.ui.AppNavigationBar
 import com.slovy.slovymovyapp.ui.AppScreen
 import kotlinx.coroutines.cancel
@@ -289,6 +290,9 @@ class WordDetailViewModel(
     var availableVoices by mutableStateOf<List<Text2SpeechVoice>>(emptyList())
         private set
 
+    var showVoiceSetupSheet by mutableStateOf(false)
+        private set
+
     val snackbarHostState = SnackbarHostState()
 
     var pendingIssueUrl by mutableStateOf<String?>(null)
@@ -490,6 +494,13 @@ class WordDetailViewModel(
                     if (availableVoices.isNotEmpty()) {
                         currentVoiceIndex = availableVoices.indices.random()
                     }
+
+                    // Show voice setup sheet once if no good/best quality voice is available
+                    // TODO: restore isVoiceSetupShown() check before release
+                    val hasHighQualityVoice = availableVoices.any { it.quality != VoiceQuality.MEDIUM }
+                    if (!hasHighQualityVoice) {
+                        showVoiceSetupSheet = true
+                    }
                 }
             } catch (_: Exception) {
                 // Failed to load voices, button will be disabled
@@ -497,6 +508,13 @@ class WordDetailViewModel(
             }
         }
     }
+
+    fun dismissVoiceSetup() {
+        viewModelScope.launch { voiceFilterHelper.markVoiceSetupShown() }
+        showVoiceSetupSheet = false
+    }
+
+    fun openVoiceSettings() = ttsManager.openSettings()
 
     fun isSenseFavorite(senseId: String): Boolean {
         return senseId in favoriteSenses
@@ -738,6 +756,10 @@ fun WordDetailScreen(
         onNavigateToSettings = onNavigateToSettings,
         onPlayWord = { viewModel.playWord() },
         onStopWord = { viewModel.stopPlayback() },
+        dictionaryLanguage = viewModel.dictionaryLanguage,
+        showVoiceSetupSheet = viewModel.showVoiceSetupSheet,
+        onOpenVoiceSettings = { viewModel.openVoiceSettings() },
+        onDismissVoiceSetup = { viewModel.dismissVoiceSetup() },
         onOpenFeedback = { viewModel.openFeedbackDialog() },
         onDismissFeedback = { viewModel.dismissFeedbackDialog() },
         onFeedbackCommentChange = { viewModel.updateFeedbackComment(it) },
@@ -775,6 +797,10 @@ fun WordDetailScreenContent(
     onNavigateToSettings: () -> Unit = {},
     onPlayWord: () -> Unit = {},
     onStopWord: () -> Unit = {},
+    dictionaryLanguage: Language = Language.ENGLISH,
+    showVoiceSetupSheet: Boolean = false,
+    onOpenVoiceSettings: () -> Unit = {},
+    onDismissVoiceSetup: () -> Unit = {},
     onOpenFeedback: () -> Unit = {},
     onDismissFeedback: () -> Unit = {},
     onFeedbackCommentChange: (String) -> Unit = {},
@@ -930,6 +956,14 @@ fun WordDetailScreenContent(
                 }
             }
         }
+    }
+
+    if (showVoiceSetupSheet) {
+        com.slovy.slovymovyapp.ui.VoiceSetupBottomSheet(
+            language = dictionaryLanguage,
+            onOpenSettings = onOpenVoiceSettings,
+            onDismiss = onDismissVoiceSetup
+        )
     }
 
     if (state is WordDetailUiState.Content && state.feedbackDialogVisible) {

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/word/WordDetailsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/word/WordDetailsScreen.kt
@@ -495,12 +495,6 @@ class WordDetailViewModel(
                         currentVoiceIndex = availableVoices.indices.random()
                     }
 
-                    // Show voice setup sheet once if no good/best quality voice is available
-                    // TODO: restore isVoiceSetupShown() check before release
-                    val hasHighQualityVoice = availableVoices.any { it.quality != VoiceQuality.MEDIUM }
-                    if (!hasHighQualityVoice) {
-                        showVoiceSetupSheet = true
-                    }
                 }
             } catch (_: Exception) {
                 // Failed to load voices, button will be disabled
@@ -510,7 +504,7 @@ class WordDetailViewModel(
     }
 
     fun dismissVoiceSetup() {
-        viewModelScope.launch { voiceFilterHelper.markVoiceSetupShown() }
+        viewModelScope.launch { voiceFilterHelper.markVoiceSetupShown(dictionaryLanguage) }
         showVoiceSetupSheet = false
     }
 
@@ -666,6 +660,22 @@ class WordDetailViewModel(
     fun playWord() {
         if (availableVoices.isEmpty()) return
 
+        val hasHighQualityVoice = availableVoices.any { it.quality != VoiceQuality.MEDIUM }
+        if (!hasHighQualityVoice) {
+            viewModelScope.launch {
+                if (!voiceFilterHelper.isVoiceSetupShown(dictionaryLanguage)) {
+                    showVoiceSetupSheet = true
+                    return@launch
+                }
+                doPlayWord()
+            }
+            return
+        }
+
+        doPlayWord()
+    }
+
+    private fun doPlayWord() {
         try {
             // Rotate to the next voice
             currentVoiceIndex = (currentVoiceIndex + 1) % availableVoices.size

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/word/WordDetailsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/word/WordDetailsScreen.kt
@@ -508,7 +508,11 @@ class WordDetailViewModel(
         showVoiceSetupSheet = false
     }
 
-    fun openVoiceSettings() = ttsManager.openSettings()
+    fun openVoiceSettings() {
+        viewModelScope.launch { voiceFilterHelper.markVoiceSetupShown(dictionaryLanguage) }
+        showVoiceSetupSheet = false
+        ttsManager.openSettings()
+    }
 
     fun isSenseFavorite(senseId: String): Boolean {
         return senseId in favoriteSenses
@@ -969,7 +973,7 @@ fun WordDetailScreenContent(
     }
 
     if (showVoiceSetupSheet) {
-        com.slovy.slovymovyapp.ui.VoiceSetupBottomSheet(
+        VoiceSetupBottomSheet(
             language = dictionaryLanguage,
             onOpenSettings = onOpenVoiceSettings,
             onDismiss = onDismissVoiceSetup

--- a/composeApp/src/commonTest/kotlin/com/slovy/slovymovyapp/speech/VoiceFilterHelperTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/slovy/slovymovyapp/speech/VoiceFilterHelperTest.kt
@@ -46,7 +46,9 @@ open class VoiceFilterHelperTest : BaseTest() {
     @BeforeTest
     fun before() {
         runBlocking {
-            settingsRepository().deleteById(Setting.Name.ENABLED_VOICES)
+            val repo = settingsRepository()
+            repo.deleteById(Setting.Name.ENABLED_VOICES)
+            repo.deleteById(Setting.Name.VOICE_SETUP_SHOWN)
         }
     }
 
@@ -201,6 +203,47 @@ open class VoiceFilterHelperTest : BaseTest() {
 
         val result = helper.getEnabledVoices(testLanguage)
         assertTrue(result.isEmpty())
+    }
+
+    @Test
+    fun isVoiceSetupShown_returns_false_when_no_setting() = runBlocking {
+        val helper = VoiceFilterHelper(settingsRepository())
+
+        assertFalse(helper.isVoiceSetupShown(Language.ENGLISH))
+    }
+
+    @Test
+    fun markVoiceSetupShown_marks_language_as_shown() = runBlocking {
+        val helper = VoiceFilterHelper(settingsRepository())
+
+        helper.markVoiceSetupShown(Language.ENGLISH)
+
+        assertTrue(helper.isVoiceSetupShown(Language.ENGLISH))
+    }
+
+    @Test
+    fun markVoiceSetupShown_does_not_affect_other_languages() = runBlocking {
+        val helper = VoiceFilterHelper(settingsRepository())
+
+        helper.markVoiceSetupShown(Language.ENGLISH)
+
+        assertFalse(helper.isVoiceSetupShown(Language.DUTCH))
+    }
+
+    @Test
+    fun isVoiceSetupShown_returns_true_when_no_repository() = runBlocking {
+        val helper = VoiceFilterHelper(null)
+
+        assertTrue(helper.isVoiceSetupShown(Language.ENGLISH))
+    }
+
+    @Test
+    fun markVoiceSetupShown_does_nothing_when_no_repository() = runBlocking {
+        val helper = VoiceFilterHelper(null)
+
+        helper.markVoiceSetupShown(Language.ENGLISH)
+
+        assertTrue(helper.isVoiceSetupShown(Language.ENGLISH))
     }
 
     @Test

--- a/shared/src/commonMain/kotlin/com/slovy/slovymovyapp/data/settings/Setting.kt
+++ b/shared/src/commonMain/kotlin/com/slovy/slovymovyapp/data/settings/Setting.kt
@@ -16,6 +16,7 @@ data class Setting(
         LANGUAGE,
         DICTIONARY,
         DATA_VERSION,
-        ENABLED_VOICES
+        ENABLED_VOICES,
+        VOICE_SETUP_SHOWN
     }
 }


### PR DESCRIPTION
## Summary

- Shows a bottom sheet on first speaker tap when no high-quality voice is available for the current language, guiding the user to download a better TTS voice
- Tracks shown state per language (stored as a JSON array of language codes) so each language gets prompted independently
- Adds the same 2-step setup instructions to the Download More Voices card in Settings
- Passive sheet dismiss (swipe/tap outside) closes without playing; "Later" closes and resumes playback; "Open System Settings" marks shown and opens system TTS settings

## Test plan

- [ ] Tap speaker on a word with only medium-quality voices → sheet appears on first tap, plays on second
- [ ] Tap "Later" → sheet closes and word plays
- [ ] Swipe sheet down → sheet closes, word does not play
- [ ] Tap "Open System Settings" → settings open, sheet does not reappear on next tap
- [ ] Two languages installed, only one has medium voices → sheet appears only for that language
- [ ] Settings → Voice section shows Download More Voices card with step instructions and FilledTonalButton
- [ ] `./gradlew :composeApp:desktopTest --tests com.slovy.slovymovyapp.speech.VoiceFilterHelperTest` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)