### PR TITLE
feat(word): show sense clarifications when translations are exactly identical within a PoS

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/word/EntryCard.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/word/EntryCard.kt
@@ -548,6 +548,14 @@ internal fun EntryCard(
                 }
 
                 // Senses - edge-to-edge (no horizontal padding)
+                val ambiguousTranslations = remember(entry.senses) {
+                    val counts = mutableMapOf<String, Int>()
+                    entry.senses.forEach { sense ->
+                        sense.translations.values.flatten()
+                            .forEach { counts[it.targetLangWord] = (counts[it.targetLangWord] ?: 0) + 1 }
+                    }
+                    counts.filterValues { it > 1 }.keys
+                }
                 entry.senses.forEach { sense ->
                     val senseState = entryState.senses.find { it.senseId == sense.senseId }
                         ?: throw IllegalStateException("Sense state not found for sense ${sense.senseId}")
@@ -559,7 +567,8 @@ internal fun EntryCard(
                             sense = sense,
                             pos = entry.pos,
                             translationLoading = translationLoading || senseState.translationLoading,
-                            translationError = translationError ?: senseState.translationError
+                            translationError = translationError ?: senseState.translationError,
+                            ambiguousTranslations = ambiguousTranslations
                         ),
                         state = senseState,
                         onToggle = { onSenseToggle(sense.senseId) },

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/word/EntryCard.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/word/EntryCard.kt
@@ -550,26 +550,7 @@ internal fun EntryCard(
 
                 // Senses - edge-to-edge (no horizontal padding)
                 val ambiguousTranslations = remember(entry.senses) {
-                    val fingerprint = { sense: LanguageCardResponseSense ->
-                        sense.translations.entries
-                            .flatMap { (lang, translations) -> translations.map { "${lang}:${it.targetLangWord}" } }
-                            .sorted()
-                            .joinToString(",")
-                    }
-                    val counts = mutableMapOf<String, Int>()
-                    entry.senses.forEach { sense ->
-                        val fp = fingerprint(sense)
-                        if (fp.isNotEmpty()) counts[fp] = (counts[fp] ?: 0) + 1
-                    }
-                    val duplicated = counts.filterValues { it > 1 }.keys
-                    entry.senses
-                        .filter { fingerprint(it) in duplicated }
-                        .flatMap { sense ->
-                            sense.translations.values.flatten()
-                                .filter { !it.targetLangWord.contains(' ') }
-                                .map { it.targetLangWord }
-                        }
-                        .toSet()
+                    computeAmbiguousTranslations(entry.senses)
                 }
                 entry.senses.forEach { sense ->
                     val senseState = entryState.senses.find { it.senseId == sense.senseId }
@@ -597,6 +578,29 @@ internal fun EntryCard(
             }
         }
     }
+}
+
+internal fun computeAmbiguousTranslations(senses: List<LanguageCardResponseSense>): Set<String> {
+    val fingerprint = { sense: LanguageCardResponseSense ->
+        sense.translations.entries
+            .flatMap { (lang, translations) -> translations.map { "${lang}:${it.targetLangWord}" } }
+            .sorted()
+            .joinToString(",")
+    }
+    val counts = mutableMapOf<String, Int>()
+    senses.forEach { sense ->
+        val fp = fingerprint(sense)
+        if (fp.isNotEmpty()) counts[fp] = (counts[fp] ?: 0) + 1
+    }
+    val duplicated = counts.filterValues { it > 1 }.keys
+    return senses
+        .filter { fingerprint(it) in duplicated }
+        .flatMap { sense ->
+            sense.translations.values.flatten()
+                .filter { !it.targetLangWord.contains(' ') }
+                .map { it.targetLangWord }
+        }
+        .toSet()
 }
 
 fun pluralEnding(count: Int): String = if (count == 1) "" else "s"

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/word/EntryCard.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/word/EntryCard.kt
@@ -549,7 +549,7 @@ internal fun EntryCard(
                 }
 
                 // Senses - edge-to-edge (no horizontal padding)
-                val ambiguousTranslations = remember(entry.senses) {
+                val ambiguousTranslationsBySense = remember(entry.senses) {
                     computeAmbiguousTranslations(entry.senses)
                 }
                 entry.senses.forEach { sense ->
@@ -564,7 +564,7 @@ internal fun EntryCard(
                             pos = entry.pos,
                             translationLoading = translationLoading || senseState.translationLoading,
                             translationError = translationError ?: senseState.translationError,
-                            ambiguousTranslations = ambiguousTranslations
+                            ambiguousTranslations = ambiguousTranslationsBySense[sense.senseId] ?: emptySet()
                         ),
                         state = senseState,
                         onToggle = { onSenseToggle(sense.senseId) },
@@ -580,10 +580,10 @@ internal fun EntryCard(
     }
 }
 
-internal fun computeAmbiguousTranslations(senses: List<LanguageCardResponseSense>): Set<String> {
+internal fun computeAmbiguousTranslations(senses: List<LanguageCardResponseSense>): Map<String, Set<String>> {
     val fingerprint = { sense: LanguageCardResponseSense ->
         sense.translations.entries
-            .flatMap { (lang, translations) -> translations.map { "${lang}:${it.targetLangWord}" } }
+            .flatMap { (lang, translations) -> translations.map { it.targetLangWord }.distinct().map { "$lang:$it" } }
             .sorted()
             .joinToString(",")
     }
@@ -595,12 +595,12 @@ internal fun computeAmbiguousTranslations(senses: List<LanguageCardResponseSense
     val duplicated = counts.filterValues { it > 1 }.keys
     return senses
         .filter { fingerprint(it) in duplicated }
-        .flatMap { sense ->
-            sense.translations.values.flatten()
+        .associate { sense ->
+            sense.senseId to sense.translations.values.flatten()
                 .filter { !it.targetLangWord.contains(' ') }
                 .map { it.targetLangWord }
+                .toSet()
         }
-        .toSet()
 }
 
 fun pluralEnding(count: Int): String = if (count == 1) "" else "s"

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/word/EntryCard.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/word/EntryCard.kt
@@ -551,8 +551,8 @@ internal fun EntryCard(
                 // Senses - edge-to-edge (no horizontal padding)
                 val ambiguousTranslations = remember(entry.senses) {
                     val fingerprint = { sense: LanguageCardResponseSense ->
-                        sense.translations.values.flatten()
-                            .map { it.targetLangWord }
+                        sense.translations.entries
+                            .flatMap { (lang, translations) -> translations.map { "${lang}:${it.targetLangWord}" } }
                             .sorted()
                             .joinToString(",")
                     }

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/word/EntryCard.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/word/EntryCard.kt
@@ -24,6 +24,7 @@ import androidx.compose.ui.unit.dp
 import com.slovy.slovymovyapp.data.forms.GridCell
 import com.slovy.slovymovyapp.data.remote.FormsSchemeView
 import com.slovy.slovymovyapp.data.remote.LanguageCardPosEntry
+import com.slovy.slovymovyapp.data.remote.LanguageCardResponseSense
 import com.slovy.slovymovyapp.data.remote.RelatedWord
 import com.slovy.slovymovyapp.ui.components.PartOfSpeechIndicator
 import kotlin.math.max
@@ -549,12 +550,26 @@ internal fun EntryCard(
 
                 // Senses - edge-to-edge (no horizontal padding)
                 val ambiguousTranslations = remember(entry.senses) {
+                    val fingerprint = { sense: LanguageCardResponseSense ->
+                        sense.translations.values.flatten()
+                            .map { it.targetLangWord }
+                            .sorted()
+                            .joinToString(",")
+                    }
                     val counts = mutableMapOf<String, Int>()
                     entry.senses.forEach { sense ->
-                        sense.translations.values.flatten()
-                            .forEach { counts[it.targetLangWord] = (counts[it.targetLangWord] ?: 0) + 1 }
+                        val fp = fingerprint(sense)
+                        if (fp.isNotEmpty()) counts[fp] = (counts[fp] ?: 0) + 1
                     }
-                    counts.filterValues { it > 1 }.keys
+                    val duplicated = counts.filterValues { it > 1 }.keys
+                    entry.senses
+                        .filter { fingerprint(it) in duplicated }
+                        .flatMap { sense ->
+                            sense.translations.values.flatten()
+                                .filter { !it.targetLangWord.contains(' ') }
+                                .map { it.targetLangWord }
+                        }
+                        .toSet()
                 }
                 entry.senses.forEach { sense ->
                     val senseState = entryState.senses.find { it.senseId == sense.senseId }

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/word/SenseCard.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/word/SenseCard.kt
@@ -486,7 +486,6 @@ private fun LanguageCardResponseSense.hasAmbiguousClarifications(ambiguous: Set<
     return translations.values.flatten().any { it.targetLangWord in ambiguous && it.targetLangSenseClarification != null }
 }
 
-
 internal fun colorForLemma(lemma: String?, baseColor: Color): Color {
     if (lemma == null) return baseColor
 

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/word/SenseCard.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/word/SenseCard.kt
@@ -39,7 +39,8 @@ data class SenseCardData(
     val error: String? = null,
     val translationLoading: Boolean = false,
     val translationError: String? = null,
-    val diagnosticInfoOnError: String? = null
+    val diagnosticInfoOnError: String? = null,
+    val ambiguousTranslations: Set<String> = emptySet()
 )
 
 @Composable
@@ -112,6 +113,11 @@ internal fun SenseCard(
                                 style = MaterialTheme.typography.titleMedium,
                                 clickableWords = relatedWords.keys,
                                 onWordClick = onWordClick
+                            )
+                        } else if (sense.hasAmbiguousClarifications(data.ambiguousTranslations)) {
+                            TranslationsHeaderWithClarifications(
+                                sense = sense,
+                                ambiguous = data.ambiguousTranslations,
                             )
                         } else {
                             HighlightedText(
@@ -190,6 +196,28 @@ internal fun SenseCard(
                             .padding(start = 16.dp, end = 16.dp, top = 8.dp, bottom = 16.dp),
                         verticalArrangement = Arrangement.spacedBy(16.dp)
                     ) {
+                        if (translationBasedHeader != null) {
+                            val withClarifications = sense.translationsWithClarifications()
+                            if (withClarifications.isNotEmpty()) {
+                                Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+                                    withClarifications.forEach { translation ->
+                                        Text(
+                                            text = buildAnnotatedString {
+                                                withStyle(SpanStyle(fontWeight = FontWeight.SemiBold)) {
+                                                    append(translation.targetLangWord)
+                                                }
+                                                append(" → ")
+                                                append(translation.targetLangSenseClarification!!)
+                                            },
+                                            style = MaterialTheme.typography.bodySmall.copy(
+                                                color = MaterialTheme.colorScheme.onSurfaceVariant
+                                            ),
+                                        )
+                                    }
+                                }
+                            }
+                        }
+
                         if (sense.targetLangDefinitions.isNotEmpty()) {
                             Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
                                 SectionLabel("Definition")
@@ -439,6 +467,32 @@ internal fun LanguageCardResponseSense.collectLanguages(): List<Language> {
     return ordered.toList()
 }
 
+@Composable
+private fun TranslationsHeaderWithClarifications(
+    sense: LanguageCardResponseSense,
+    ambiguous: Set<String>,
+) {
+    val multiLang = sense.translations.keys.size > 1
+    val clarificationColor = MaterialTheme.colorScheme.onSurfaceVariant
+    val style = MaterialTheme.typography.titleMedium
+    sense.translations.entries.sortedBy { it.key }.forEach { (_, langTranslations) ->
+        val annotated = buildAnnotatedString {
+            if (multiLang) append("$bullet ")
+            langTranslations.sortedBy { it.targetLangWord }.forEachIndexed { index, translation ->
+                if (index > 0) append(", ")
+                append(translation.targetLangWord)
+                val clarification = translation.targetLangSenseClarification
+                if (translation.targetLangWord in ambiguous && clarification != null) {
+                    withStyle(SpanStyle(color = clarificationColor)) {
+                        append(" $bullet $clarification")
+                    }
+                }
+            }
+        }
+        Text(text = annotated, style = style)
+    }
+}
+
 private fun LanguageCardResponseSense.translationsHeader(): String? {
     if (translations.isEmpty()) {
         return null
@@ -448,6 +502,16 @@ private fun LanguageCardResponseSense.translationsHeader(): String? {
         prefix + it.value.map { translation -> translation.targetLangWord }.sortedBy { text -> text }
             .joinToString(separator = ", ")
     }
+}
+
+private fun LanguageCardResponseSense.hasAmbiguousClarifications(ambiguous: Set<String>): Boolean {
+    return translations.values.flatten().any { it.targetLangWord in ambiguous && it.targetLangSenseClarification != null }
+}
+
+private fun LanguageCardResponseSense.translationsWithClarifications(): List<LanguageCardTranslation> {
+    return translations.entries.sortedBy { it.key }
+        .flatMap { it.value.sortedBy { t -> t.targetLangWord } }
+        .filter { it.targetLangSenseClarification != null }
 }
 
 internal fun colorForLemma(lemma: String?, baseColor: Color): Color {

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/word/SenseCard.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/word/SenseCard.kt
@@ -19,10 +19,13 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.layout.positionInWindow
+import androidx.compose.ui.text.LinkAnnotation
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextDecoration
+import androidx.compose.ui.text.withLink
 import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.dp
 import com.slovy.slovymovyapp.data.Language
@@ -118,6 +121,8 @@ internal fun SenseCard(
                             TranslationsHeaderWithClarifications(
                                 sense = sense,
                                 ambiguous = data.ambiguousTranslations,
+                                clickableWords = relatedWords.keys,
+                                onWordClick = onWordClick
                             )
                         } else {
                             HighlightedText(
@@ -449,18 +454,33 @@ internal fun LanguageCardResponseSense.collectLanguages(): List<Language> {
 private fun TranslationsHeaderWithClarifications(
     sense: LanguageCardResponseSense,
     ambiguous: Set<String>,
+    clickableWords: Set<String> = emptySet(),
+    onWordClick: (String) -> Unit = {}
 ) {
     val multiLang = sense.translations.keys.size > 1
     val clarificationColor = MaterialTheme.colorScheme.onSurfaceVariant
+    val clickableStyle = SpanStyle(
+        color = MaterialTheme.colorScheme.primary,
+        fontWeight = FontWeight.Medium,
+        textDecoration = TextDecoration.Underline
+    )
     val style = MaterialTheme.typography.titleMedium
     sense.translations.entries.sortedBy { it.key }.forEach { (_, langTranslations) ->
         val annotated = buildAnnotatedString {
             if (multiLang) append("$bullet ")
             langTranslations.sortedBy { it.targetLangWord }.forEachIndexed { index, translation ->
                 if (index > 0) append(", ")
-                append(translation.targetLangWord)
+                val word = translation.targetLangWord
+                val isClickable = clickableWords.any { it.equals(word, ignoreCase = true) }
+                if (isClickable) {
+                    withLink(LinkAnnotation.Clickable(tag = "CLICKABLE_WORD_$word", linkInteractionListener = { onWordClick(word) })) {
+                        withStyle(clickableStyle) { append(word) }
+                    }
+                } else {
+                    append(word)
+                }
                 val clarification = translation.targetLangSenseClarification
-                if (translation.targetLangWord in ambiguous && clarification != null) {
+                if (word in ambiguous && clarification != null) {
                     withStyle(SpanStyle(color = clarificationColor)) {
                         append(" $bullet $clarification")
                     }

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/word/SenseCard.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/word/SenseCard.kt
@@ -117,17 +117,10 @@ internal fun SenseCard(
                                 clickableWords = relatedWords.keys,
                                 onWordClick = onWordClick
                             )
-                        } else if (sense.hasAmbiguousClarifications(data.ambiguousTranslations)) {
-                            TranslationsHeaderWithClarifications(
+                        } else {
+                            TranslationHeader(
                                 sense = sense,
                                 ambiguous = data.ambiguousTranslations,
-                                clickableWords = relatedWords.keys,
-                                onWordClick = onWordClick
-                            )
-                        } else {
-                            HighlightedText(
-                                text = translationBasedHeader,
-                                style = MaterialTheme.typography.titleMedium,
                                 clickableWords = relatedWords.keys,
                                 onWordClick = onWordClick
                             )
@@ -451,12 +444,25 @@ internal fun LanguageCardResponseSense.collectLanguages(): List<Language> {
 }
 
 @Composable
-private fun TranslationsHeaderWithClarifications(
+internal fun TranslationHeader(
     sense: LanguageCardResponseSense,
     ambiguous: Set<String>,
     clickableWords: Set<String> = emptySet(),
     onWordClick: (String) -> Unit = {}
 ) {
+    val hasClarifications = ambiguous.isNotEmpty() &&
+            sense.translations.values.flatten().any { it.targetLangWord in ambiguous && it.targetLangSenseClarification != null }
+
+    if (!hasClarifications) {
+        HighlightedText(
+            text = sense.translationsHeader() ?: "",
+            style = MaterialTheme.typography.titleMedium,
+            clickableWords = clickableWords,
+            onWordClick = onWordClick
+        )
+        return
+    }
+
     val multiLang = sense.translations.keys.size > 1
     val clarificationColor = MaterialTheme.colorScheme.onSurfaceVariant
     val clickableStyle = SpanStyle(
@@ -473,7 +479,7 @@ private fun TranslationsHeaderWithClarifications(
                 val word = translation.targetLangWord
                 val isClickable = clickableWords.any { it.equals(word, ignoreCase = true) }
                 if (isClickable) {
-                    withLink(LinkAnnotation.Clickable(tag = "CLICKABLE_WORD_$word", linkInteractionListener = { onWordClick(word) })) {
+                    withLink(LinkAnnotation.Clickable(tag = "$CLICKABLE_WORD_TAG_PREFIX$word", linkInteractionListener = { onWordClick(word) })) {
                         withStyle(clickableStyle) { append(word) }
                     }
                 } else {
@@ -500,10 +506,6 @@ private fun LanguageCardResponseSense.translationsHeader(): String? {
         prefix + it.value.map { translation -> translation.targetLangWord }.sortedBy { text -> text }
             .joinToString(separator = ", ")
     }
-}
-
-private fun LanguageCardResponseSense.hasAmbiguousClarifications(ambiguous: Set<String>): Boolean {
-    return translations.values.flatten().any { it.targetLangWord in ambiguous && it.targetLangSenseClarification != null }
 }
 
 internal fun colorForLemma(lemma: String?, baseColor: Color): Color {

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/word/SenseCard.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/word/SenseCard.kt
@@ -196,28 +196,6 @@ internal fun SenseCard(
                             .padding(start = 16.dp, end = 16.dp, top = 8.dp, bottom = 16.dp),
                         verticalArrangement = Arrangement.spacedBy(16.dp)
                     ) {
-                        if (translationBasedHeader != null) {
-                            val withClarifications = sense.translationsWithClarifications()
-                            if (withClarifications.isNotEmpty()) {
-                                Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
-                                    withClarifications.forEach { translation ->
-                                        Text(
-                                            text = buildAnnotatedString {
-                                                withStyle(SpanStyle(fontWeight = FontWeight.SemiBold)) {
-                                                    append(translation.targetLangWord)
-                                                }
-                                                append(" → ")
-                                                append(translation.targetLangSenseClarification!!)
-                                            },
-                                            style = MaterialTheme.typography.bodySmall.copy(
-                                                color = MaterialTheme.colorScheme.onSurfaceVariant
-                                            ),
-                                        )
-                                    }
-                                }
-                            }
-                        }
-
                         if (sense.targetLangDefinitions.isNotEmpty()) {
                             Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
                                 SectionLabel("Definition")
@@ -508,11 +486,6 @@ private fun LanguageCardResponseSense.hasAmbiguousClarifications(ambiguous: Set<
     return translations.values.flatten().any { it.targetLangWord in ambiguous && it.targetLangSenseClarification != null }
 }
 
-private fun LanguageCardResponseSense.translationsWithClarifications(): List<LanguageCardTranslation> {
-    return translations.entries.sortedBy { it.key }
-        .flatMap { it.value.sortedBy { t -> t.targetLangWord } }
-        .filter { it.targetLangSenseClarification != null }
-}
 
 internal fun colorForLemma(lemma: String?, baseColor: Color): Color {
     if (lemma == null) return baseColor

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/word/WordDetailsComponents.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/word/WordDetailsComponents.kt
@@ -24,6 +24,8 @@ import com.slovy.slovymovyapp.data.util.HtmlTagParser
  * Returns the appropriate navigation arrow based on word availability.
  * @param isOnline true if word is online-only, false if available offline, null if unknown
  */
+internal const val CLICKABLE_WORD_TAG_PREFIX = "CLICKABLE_WORD_"
+
 internal fun navigationArrow(isOnline: Boolean?): String =
     if (isOnline == false) "➤" else "➼"
 
@@ -185,7 +187,7 @@ internal fun appendTextWithW(
             if (isClickable) {
                 // Use LinkAnnotation for clickable words
                 val link = LinkAnnotation.Clickable(
-                    tag = "CLICKABLE_WORD_$word",
+                    tag = "$CLICKABLE_WORD_TAG_PREFIX$word",
                     linkInteractionListener = {
                         onWordClick(word)
                     }

--- a/composeApp/src/commonTest/kotlin/com/slovy/slovymovyapp/ui/word/AmbiguousTranslationsTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/slovy/slovymovyapp/ui/word/AmbiguousTranslationsTest.kt
@@ -7,6 +7,7 @@ import com.slovy.slovymovyapp.data.remote.LearnerLevel
 import com.slovy.slovymovyapp.data.remote.SenseFrequency
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 class AmbiguousTranslationsTest {
@@ -33,7 +34,8 @@ class AmbiguousTranslationsTest {
             sense("2", mapOf(Language.ENGLISH to trans("marry", "wed")))
         )
         val result = computeAmbiguousTranslations(senses)
-        assertEquals(setOf("marry", "wed"), result)
+        assertEquals(setOf("marry", "wed"), result["1"])
+        assertEquals(setOf("marry", "wed"), result["2"])
     }
 
     @Test
@@ -69,11 +71,38 @@ class AmbiguousTranslationsTest {
             sense("2", mapOf(Language.ENGLISH to trans("get married", "wed")))
         )
         // fingerprints match → ambiguous, but "get married" is multi-word so excluded from result
-        assertEquals(setOf("wed"), computeAmbiguousTranslations(senses))
+        assertEquals(setOf("wed"), computeAmbiguousTranslations(senses)["1"])
+        assertEquals(setOf("wed"), computeAmbiguousTranslations(senses)["2"])
     }
 
     @Test
     fun empty_senses_returns_empty() {
         assertTrue(computeAmbiguousTranslations(emptyList()).isEmpty())
+    }
+
+    @Test
+    fun non_duplicated_sense_not_flagged_when_sharing_word_with_duplicated_group() {
+        // senses "1" and "2" are duplicated; sense "3" shares "bank" but has a different set
+        val senses = listOf(
+            sense("1", mapOf(Language.ENGLISH to trans("bank"))),
+            sense("2", mapOf(Language.ENGLISH to trans("bank"))),
+            sense("3", mapOf(Language.ENGLISH to trans("bank", "shore")))
+        )
+        val result = computeAmbiguousTranslations(senses)
+        assertEquals(setOf("bank"), result["1"])
+        assertEquals(setOf("bank"), result["2"])
+        assertFalse(result.containsKey("3"), "sense 3 must not be flagged")
+    }
+
+    @Test
+    fun duplicate_entries_within_sense_treated_as_single_word() {
+        // same word listed twice in one sense — should still match a sense with it once
+        val senses = listOf(
+            sense("1", mapOf(Language.ENGLISH to trans("bank", "bank"))),
+            sense("2", mapOf(Language.ENGLISH to trans("bank")))
+        )
+        val result = computeAmbiguousTranslations(senses)
+        assertEquals(setOf("bank"), result["1"])
+        assertEquals(setOf("bank"), result["2"])
     }
 }

--- a/composeApp/src/commonTest/kotlin/com/slovy/slovymovyapp/ui/word/AmbiguousTranslationsTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/slovy/slovymovyapp/ui/word/AmbiguousTranslationsTest.kt
@@ -1,0 +1,79 @@
+package com.slovy.slovymovyapp.ui.word
+
+import com.slovy.slovymovyapp.data.Language
+import com.slovy.slovymovyapp.data.remote.LanguageCardResponseSense
+import com.slovy.slovymovyapp.data.remote.LanguageCardTranslation
+import com.slovy.slovymovyapp.data.remote.LearnerLevel
+import com.slovy.slovymovyapp.data.remote.SenseFrequency
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class AmbiguousTranslationsTest {
+
+    private fun sense(
+        id: String,
+        translations: Map<Language, List<LanguageCardTranslation>>
+    ) = LanguageCardResponseSense(
+        senseId = id,
+        senseDefinition = "",
+        learnerLevel = LearnerLevel.A1,
+        frequency = SenseFrequency.HIGH,
+        semanticGroupId = "",
+        translations = translations
+    )
+
+    private fun trans(vararg words: String) =
+        words.map { LanguageCardTranslation(targetLangWord = it) }
+
+    @Test
+    fun identical_translations_flagged() {
+        val senses = listOf(
+            sense("1", mapOf(Language.ENGLISH to trans("marry", "wed"))),
+            sense("2", mapOf(Language.ENGLISH to trans("marry", "wed")))
+        )
+        val result = computeAmbiguousTranslations(senses)
+        assertEquals(setOf("marry", "wed"), result)
+    }
+
+    @Test
+    fun different_translations_not_flagged() {
+        val senses = listOf(
+            sense("1", mapOf(Language.ENGLISH to trans("get married", "marry", "wed"))),
+            sense("2", mapOf(Language.ENGLISH to trans("marry", "wed")))
+        )
+        assertTrue(computeAmbiguousTranslations(senses).isEmpty())
+    }
+
+    @Test
+    fun single_sense_never_flagged() {
+        val senses = listOf(
+            sense("1", mapOf(Language.ENGLISH to trans("marry")))
+        )
+        assertTrue(computeAmbiguousTranslations(senses).isEmpty())
+    }
+
+    @Test
+    fun same_words_different_languages_not_flagged() {
+        val senses = listOf(
+            sense("1", mapOf(Language.ENGLISH to trans("bank"), Language.DUTCH to trans("bank"))),
+            sense("2", mapOf(Language.ENGLISH to trans("bank"), Language.DUTCH to trans("oever")))
+        )
+        assertTrue(computeAmbiguousTranslations(senses).isEmpty())
+    }
+
+    @Test
+    fun multi_word_translations_excluded_from_result() {
+        val senses = listOf(
+            sense("1", mapOf(Language.ENGLISH to trans("get married", "wed"))),
+            sense("2", mapOf(Language.ENGLISH to trans("get married", "wed")))
+        )
+        // fingerprints match → ambiguous, but "get married" is multi-word so excluded from result
+        assertEquals(setOf("wed"), computeAmbiguousTranslations(senses))
+    }
+
+    @Test
+    fun empty_senses_returns_empty() {
+        assertTrue(computeAmbiguousTranslations(emptyList()).isEmpty())
+    }
+}


### PR DESCRIPTION
## Summary

- When 2+ senses within a PoS share the exact same set of translations, appends a sense clarification inline next to each ambiguous one-word translation in the sense header
- Fingerprint includes language codes to avoid false positives across languages
- Clickable related-word navigation is preserved in the clarification header path
- Logic extracted to `computeAmbiguousTranslations()` for testability

## Test plan

- [ ] Two senses with identical translations → clarification shown inline in header
- [ ] Two senses with different translations (e.g. one has extra word) → no clarification
- [ ] Two senses with same words but different languages → no clarification
- [ ] Tapping a related word in a clarification header navigates correctly
- [ ] `./gradlew :composeApp:desktopTest --tests com.slovy.slovymovyapp.ui.word.AmbiguousTranslationsTest` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)