### PR TITLE
fix: add 2nd-person present rows and fix NL inversion form selection

### DIFF
--- a/composeApp/src/commonTest/kotlin/com/slovy/slovymovyapp/forms/EnConjugationSchemeTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/slovy/slovymovyapp/forms/EnConjugationSchemeTest.kt
@@ -108,6 +108,7 @@ class EnConjugationSchemeTest : BaseTest() {
             listOf(null, null),      // header row
             listOf(null, "test"),    // infinitive
             listOf(null, "test"),    // present (I)
+            listOf(null, "test"),    // present (you)
             listOf(null, "tests"),   // present (he/she/it)
             listOf(null, "testing"), // present participle
             listOf(null, "tested"),  // past simple

--- a/composeApp/src/commonTest/kotlin/com/slovy/slovymovyapp/forms/NlConjugationSchemeTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/slovy/slovymovyapp/forms/NlConjugationSchemeTest.kt
@@ -137,6 +137,32 @@ class NlConjugationSchemeTest : BaseTest() {
     }
 
     @Test
+    fun preprocessForms_tDeletion_irregularVowelLengthening_marksInversionForm() {
+        val resolver = NlConjugationScheme.NL_VERB.tagResolver
+
+        // gaan: "ga" is the inversion form, "gaat" is the main-clause form.
+        // Simple form+t gives "gat", not "gaat", so the irregular map must be used.
+        val ga = SchemeInputForm(
+            tags = listOf("present", "second-person", "singular"),
+            form = "ga",
+            source = FormSource.NATIVE,
+        )
+        val gaat = SchemeInputForm(
+            tags = listOf("present", "second-person", "singular"),
+            form = "gaat",
+            source = FormSource.NATIVE,
+        )
+
+        val result = resolver.preprocessForms(listOf(ga, gaat), lemma = "gaan")
+
+        val gaResult = result.filter { it.form == "ga" && "second-person" in it.tags }
+        val gaatResult = result.filter { it.form == "gaat" && "second-person" in it.tags }
+
+        assertTrue(gaResult.all { "gij" in it.tags }, "ga must be marked with gij as inversion form")
+        assertTrue(gaatResult.none { "gij" in it.tags }, "gaat must not be marked with gij")
+    }
+
+    @Test
     fun preprocessForms_tDeletion_noTForm_notMarked() {
         val resolver = NlConjugationScheme.NL_VERB.tagResolver
 

--- a/composeApp/src/commonTest/kotlin/com/slovy/slovymovyapp/forms/NlConjugationSchemeTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/slovy/slovymovyapp/forms/NlConjugationSchemeTest.kt
@@ -74,6 +74,88 @@ class NlConjugationSchemeTest : BaseTest() {
     }
 
     @Test
+    fun preprocessForms_tDeletion_marksInversionFormWithGij() {
+        val resolver = NlConjugationScheme.NL_VERB.tagResolver
+
+        // Synthetic forms mimicking hebben: both "heb" and "hebt" tagged as
+        // second-person+present+singular. "heb" is the inversion form (t-deletion);
+        // "hebt" is the main-clause form. The heuristic must inject "gij" onto "heb"
+        // so "hebt" wins the extra-tag tiebreaker.
+        val heb = SchemeInputForm(
+            tags = listOf("present", "second-person", "singular"),
+            form = "heb",
+            source = FormSource.NATIVE,
+        )
+        val hebt = SchemeInputForm(
+            tags = listOf("present", "second-person", "singular"),
+            form = "hebt",
+            source = FormSource.NATIVE,
+        )
+        // Also include a first-person form so preprocessForms has a realistic input set.
+        val hebFirst = SchemeInputForm(
+            tags = listOf("first-person", "present", "singular"),
+            form = "heb",
+            source = FormSource.NATIVE,
+        )
+
+        val result = resolver.preprocessForms(listOf(heb, hebt, hebFirst), lemma = "hebben")
+
+        val hebSecond = result.filter { it.form == "heb" && "second-person" in it.tags && "present" in it.tags }
+        val hebtSecond = result.filter { it.form == "hebt" && "second-person" in it.tags }
+
+        assertTrue(hebSecond.isNotEmpty(), "heb (second-person) must survive preprocessing")
+        assertTrue(hebSecond.all { "gij" in it.tags }, "heb (second-person) must be marked with gij as inversion form")
+        assertTrue(hebtSecond.isNotEmpty(), "hebt must survive preprocessing")
+        assertTrue(hebtSecond.none { "gij" in it.tags }, "hebt must not be marked with gij")
+    }
+
+    @Test
+    fun preprocessForms_tDeletion_separableVerb_marksInversionForm() {
+        val resolver = NlConjugationScheme.NL_VERB.tagResolver
+
+        // Separable-verb variant: "spreek af" (inversion) vs "spreekt af" (main-clause).
+        // The -t is on the finite token, so the heuristic must check token+t rather than
+        // whole-form+t.
+        val spreekAf = SchemeInputForm(
+            tags = listOf("present", "second-person", "singular"),
+            form = "spreek af",
+            source = FormSource.NATIVE,
+        )
+        val spreektAf = SchemeInputForm(
+            tags = listOf("present", "second-person", "singular"),
+            form = "spreekt af",
+            source = FormSource.NATIVE,
+        )
+
+        val result = resolver.preprocessForms(listOf(spreekAf, spreektAf), lemma = "afspreken")
+
+        val inversionResult = result.filter { it.form == "spreek af" && "second-person" in it.tags }
+        val mainResult = result.filter { it.form == "spreekt af" && "second-person" in it.tags }
+
+        assertTrue(inversionResult.all { "gij" in it.tags }, "spreek af must be marked with gij as inversion form")
+        assertTrue(mainResult.none { "gij" in it.tags }, "spreekt af must not be marked with gij")
+    }
+
+    @Test
+    fun preprocessForms_tDeletion_noTForm_notMarked() {
+        val resolver = NlConjugationScheme.NL_VERB.tagResolver
+
+        // When only one second-person present form exists (no -t counterpart),
+        // the heuristic must not fire — the form should not receive a gij tag.
+        val onlyForm = SchemeInputForm(
+            tags = listOf("present", "second-person", "singular"),
+            form = "word",
+            source = FormSource.NATIVE,
+        )
+
+        val result = resolver.preprocessForms(listOf(onlyForm), lemma = "worden")
+
+        val secondPersonResult = result.filter { it.form == "word" && "second-person" in it.tags }
+        assertTrue(secondPersonResult.isNotEmpty(), "form must survive preprocessing")
+        assertTrue(secondPersonResult.none { "gij" in it.tags }, "sole second-person form must not be marked with gij")
+    }
+
+    @Test
     fun dutchSnapshots_matchExpectedTables() = runBlocking {
         val (mgr, repo) = createSnapshotRepository()
         try {
@@ -128,7 +210,8 @@ class NlConjugationSchemeTest : BaseTest() {
             listOf(null, null),
             listOf(null, "te zeggen"),    // infinitive
             listOf(null, "zeg"),           // present (ik)
-            listOf(null, "zegt"),          // present (jij/hij/u)
+            listOf(null, "zegt"),          // present (jij/je)
+            listOf(null, "zegt"),          // present (hij/zij/het)
             listOf(null, "zegde\nzei"),    // past singular
             listOf(null, "zegden\nzeiden"), // past plural
             listOf(null, "gezegd"),        // past participle
@@ -177,7 +260,8 @@ class NlConjugationSchemeTest : BaseTest() {
             listOf(null, null),
             listOf(null, "uit te wringen"),    // infinitive
             listOf(null, "wring uit"),          // present (ik)
-            listOf(null, "wringt uit"),         // present (jij/hij/u)
+            listOf(null, "wringt uit"),         // present (jij/je)
+            listOf(null, "wringt uit"),         // present (hij/zij/het)
             listOf(null, "wrong uit"),          // past singular — modern form wins over archaic wrongt uit
             listOf(null, "wrongen uit"),        // past plural
             listOf(null, "uitgewrongen"),       // past participle
@@ -205,7 +289,8 @@ class NlConjugationSchemeTest : BaseTest() {
             listOf(null, null),
             listOf(null, "af te spreken"),     // infinitive
             listOf(null, "spreek af"),          // present (ik)
-            listOf(null, "spreekt af"),         // present (jij/hij/u)
+            listOf(null, "spreekt af"),         // present (jij/je)
+            listOf(null, "spreekt af"),         // present (hij/zij/het)
             listOf(null, "sprak af"),           // past singular — modern form wins over archaic spraakt af
             listOf(null, "spraken af"),         // past plural
             listOf(null, "afgesproken"),        // past participle
@@ -242,7 +327,8 @@ class NlConjugationSchemeTest : BaseTest() {
             listOf(null, null),
             listOf(null, "onder te stromen"),  // infinitive (long-form te-infinitive wins)
             listOf(null, "stroom onder"),      // present (ik) — main-clause form
-            listOf(null, "stroomt onder"),     // present (jij/hij/u)
+            listOf(null, "stroomt onder"),     // present (jij/je)
+            listOf(null, "stroomt onder"),     // present (hij/zij/het)
             listOf(null, "stroomde onder"),    // past singular
             listOf(null, "stroomden onder"),   // past plural
             listOf(null, "ondergestroomd"),    // past participle

--- a/composeApp/src/commonTest/kotlin/com/slovy/slovymovyapp/forms/NlConjugationSchemeTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/slovy/slovymovyapp/forms/NlConjugationSchemeTest.kt
@@ -132,7 +132,9 @@ class NlConjugationSchemeTest : BaseTest() {
         val inversionResult = result.filter { it.form == "spreek af" && "second-person" in it.tags }
         val mainResult = result.filter { it.form == "spreekt af" && "second-person" in it.tags }
 
+        assertTrue(inversionResult.isNotEmpty(), "spreek af (second-person) must survive preprocessing")
         assertTrue(inversionResult.all { "gij" in it.tags }, "spreek af must be marked with gij as inversion form")
+        assertTrue(mainResult.isNotEmpty(), "spreekt af must survive preprocessing")
         assertTrue(mainResult.none { "gij" in it.tags }, "spreekt af must not be marked with gij")
     }
 
@@ -158,7 +160,9 @@ class NlConjugationSchemeTest : BaseTest() {
         val gaResult = result.filter { it.form == "ga" && "second-person" in it.tags }
         val gaatResult = result.filter { it.form == "gaat" && "second-person" in it.tags }
 
+        assertTrue(gaResult.isNotEmpty(), "ga (second-person) must survive preprocessing")
         assertTrue(gaResult.all { "gij" in it.tags }, "ga must be marked with gij as inversion form")
+        assertTrue(gaatResult.isNotEmpty(), "gaat must survive preprocessing")
         assertTrue(gaatResult.none { "gij" in it.tags }, "gaat must not be marked with gij")
     }
 

--- a/shared/src/commonMain/kotlin/com/slovy/slovymovyapp/data/forms/configs/EnConjugationScheme.kt
+++ b/shared/src/commonMain/kotlin/com/slovy/slovymovyapp/data/forms/configs/EnConjugationScheme.kt
@@ -37,16 +37,29 @@ object EnConjugationScheme : ConjugationSchemeProvider {
                     result += SchemeInputForm(tags = listOf("infinitive"), form = baseWord, FormSource.HEURISTIC)
                 }
 
+                val presentSingularNonThird = forms.firstOrNull { form ->
+                    form.hasTag("present") && form.hasTag("singular") && !form.hasTag("third-person")
+                }
+
                 val hasFirstPersonPresent = forms.any {
                     it.hasTag("first-person") && it.hasTag("present") && it.hasTag("singular")
                 }
                 if (!hasFirstPersonPresent) {
-                    val presentSingularNonThird = forms.firstOrNull { form ->
-                        form.hasTag("present") && form.hasTag("singular") && !form.hasTag("third-person")
-                    }
                     val inferredForm = presentSingularNonThird?.form ?: baseWord
                     result += SchemeInputForm(
                         tags = listOf("first-person", "present", "singular"),
+                        form = inferredForm,
+                        FormSource.HEURISTIC
+                    )
+                }
+
+                val hasSecondPersonPresent = forms.any {
+                    it.hasTag("second-person") && it.hasTag("present") && it.hasTag("singular")
+                }
+                if (!hasSecondPersonPresent) {
+                    val inferredForm = presentSingularNonThird?.form ?: baseWord
+                    result += SchemeInputForm(
+                        tags = listOf("second-person", "present", "singular"),
                         form = inferredForm,
                         FormSource.HEURISTIC
                     )
@@ -142,6 +155,10 @@ object EnConjugationScheme : ConjugationSchemeProvider {
             row {
                 rowHeader("present (I)")
                 data(Person.FIRST, Tense.PRESENT, Num.SG)
+            }
+            row {
+                rowHeader("present (you)")
+                data(Person.SECOND, Tense.PRESENT, Num.SG)
             }
             row {
                 rowHeader("present (he/she/it)")

--- a/shared/src/commonMain/kotlin/com/slovy/slovymovyapp/data/forms/configs/EnConjugationScheme.kt
+++ b/shared/src/commonMain/kotlin/com/slovy/slovymovyapp/data/forms/configs/EnConjugationScheme.kt
@@ -57,7 +57,14 @@ object EnConjugationScheme : ConjugationSchemeProvider {
                     it.hasTag("second-person") && it.hasTag("present") && it.hasTag("singular")
                 }
                 if (!hasSecondPersonPresent) {
-                    val inferredForm = presentSingularNonThird?.form ?: baseWord
+                    // Prefer a generic (non-first, non-third) present singular over the
+                    // first-person fallback to avoid copying irregular 1st-person forms
+                    // (e.g. "am") as the 2nd-person synthesis. Fall back to the lemma.
+                    val nonFirstNonThirdPresent = forms.firstOrNull { form ->
+                        form.hasTag("present") && form.hasTag("singular")
+                            && !form.hasTag("first-person") && !form.hasTag("third-person")
+                    }
+                    val inferredForm = nonFirstNonThirdPresent?.form ?: baseWord
                     result += SchemeInputForm(
                         tags = listOf("second-person", "present", "singular"),
                         form = inferredForm,

--- a/shared/src/commonMain/kotlin/com/slovy/slovymovyapp/data/forms/configs/EnConjugationScheme.kt
+++ b/shared/src/commonMain/kotlin/com/slovy/slovymovyapp/data/forms/configs/EnConjugationScheme.kt
@@ -57,14 +57,17 @@ object EnConjugationScheme : ConjugationSchemeProvider {
                     it.hasTag("second-person") && it.hasTag("present") && it.hasTag("singular")
                 }
                 if (!hasSecondPersonPresent) {
-                    // Prefer a generic (non-first, non-third) present singular over the
-                    // first-person fallback to avoid copying irregular 1st-person forms
-                    // (e.g. "am") as the 2nd-person synthesis. Fall back to the lemma.
+                    // Prefer a generic (non-first, non-third) present singular to avoid
+                    // copying irregular 1st-person forms (e.g. "am") as 2nd-person.
+                    // Fall back to any non-third present singular (may be 1st-person),
+                    // then to the lemma as last resort.
                     val nonFirstNonThirdPresent = forms.firstOrNull { form ->
                         form.hasTag("present") && form.hasTag("singular")
                             && !form.hasTag("first-person") && !form.hasTag("third-person")
                     }
-                    val inferredForm = nonFirstNonThirdPresent?.form ?: baseWord
+                    val inferredForm = nonFirstNonThirdPresent?.form
+                        ?: presentSingularNonThird?.form
+                        ?: baseWord
                     result += SchemeInputForm(
                         tags = listOf("second-person", "present", "singular"),
                         form = inferredForm,

--- a/shared/src/commonMain/kotlin/com/slovy/slovymovyapp/data/forms/configs/NlConjugationScheme.kt
+++ b/shared/src/commonMain/kotlin/com/slovy/slovymovyapp/data/forms/configs/NlConjugationScheme.kt
@@ -154,7 +154,35 @@ object NlConjugationScheme : ConjugationSchemeProvider {
 
                 result
             }
-            return if (extras.isEmpty()) finalForms else finalForms + extras
+            // T-deletion heuristic: in Dutch inversion (jij/je before verb), the 2nd-person
+            // present -t is dropped ("Heb jij?" vs "Jij hebt"). Both the inversion form ("heb")
+            // and the main-clause form ("hebt") may carry second-person+present+singular tags.
+            // Inject "gij" onto inversion candidates so the -t form wins the extra-tag tiebreaker.
+            // Separable verbs: -t is on the finite token, so "spreek af" → "spreekt af".
+            val secondPersonPresentStrings = processedForms
+                .filter { "second-person" in it.tags && "present" in it.tags && "singular" in it.tags }
+                .map { it.form }
+                .toSet()
+            val withFiniteT: (String) -> String = { form ->
+                if (' ' in form) form.substringBefore(' ') + "t " + form.substringAfter(' ')
+                else form + "t"
+            }
+            val inversionForms2ndPerson = secondPersonPresentStrings
+                .filter { withFiniteT(it) in secondPersonPresentStrings }
+                .toSet()
+            val tDeletionMarkedForms = if (inversionForms2ndPerson.isEmpty()) finalForms else {
+                finalForms.map { form ->
+                    if (form.form in inversionForms2ndPerson
+                        && "second-person" in form.tags
+                        && "present" in form.tags
+                        && "singular" in form.tags
+                    ) {
+                        form.copy(tags = form.tags + "gij", source = FormSource.HEURISTIC)
+                    } else form
+                }
+            }
+
+            return if (extras.isEmpty()) tDeletionMarkedForms else tDeletionMarkedForms + extras
         }
 
         override fun selectCandidate(candidates: List<SchemeCellCandidate>): SchemeCellCandidate? {
@@ -205,7 +233,11 @@ object NlConjugationScheme : ConjugationSchemeProvider {
                 data(Tense.PRESENT, Person.FIRST, Num.SG, supporting = setOf(Mood.INDICATIVE))
             }
             row {
-                rowHeader("Present (jij/hij/u)")
+                rowHeader("Present (jij/je)")
+                data(Tense.PRESENT, Person.SECOND, Num.SG, supporting = setOf(Mood.INDICATIVE, Clause.MAIN))
+            }
+            row {
+                rowHeader("Present (hij/zij/het)")
                 data(Tense.PRESENT, Person.THIRD, Num.SG, supporting = setOf(Mood.INDICATIVE))
             }
             row {
@@ -237,7 +269,7 @@ object NlConjugationScheme : ConjugationSchemeProvider {
             row {
                 rowHeader("Present")
                 data(Tense.PRESENT, Person.FIRST, Num.SG, supporting = setOf(Mood.INDICATIVE))
-                data(Tense.PRESENT, Person.SECOND, Num.SG, supporting = setOf(Mood.INDICATIVE))
+                data(Tense.PRESENT, Person.SECOND, Num.SG, supporting = setOf(Mood.INDICATIVE, Clause.MAIN))
                 data(Tense.PRESENT, Person.THIRD, Num.SG, supporting = setOf(Mood.INDICATIVE))
                 data(Tense.PRESENT, Num.PL, supporting = setOf(Mood.INDICATIVE))
             }

--- a/shared/src/commonMain/kotlin/com/slovy/slovymovyapp/data/forms/configs/NlConjugationScheme.kt
+++ b/shared/src/commonMain/kotlin/com/slovy/slovymovyapp/data/forms/configs/NlConjugationScheme.kt
@@ -7,6 +7,17 @@ import com.slovy.slovymovyapp.data.forms.*
 
 object NlConjugationScheme : ConjugationSchemeProvider {
 
+    /**
+     * Maps inversion finite tokens to their main-clause counterparts for irregular verbs
+     * where simple +t does not produce the correct form (vowel-lengthening verbs).
+     * E.g. gaan: "ga" (inversion) → "gaat" (main-clause), not "gat".
+     */
+    private val irregularInversionToMain = mapOf(
+        "ga" to "gaat",
+        "sta" to "staat",
+        "sla" to "slaat",
+    )
+
     private object DutchSchemeTagResolver : SchemeTagResolver {
         override fun preprocessForms(forms: List<SchemeInputForm>, lemma: String?): List<SchemeInputForm> {
             // Drop forms that are purely parenthetical (e.g. "(kindeke)") or trailing-comma data
@@ -164,8 +175,9 @@ object NlConjugationScheme : ConjugationSchemeProvider {
                 .map { it.form }
                 .toSet()
             val withFiniteT: (String) -> String = { form ->
-                if (' ' in form) form.substringBefore(' ') + "t " + form.substringAfter(' ')
-                else form + "t"
+                val token = form.substringBefore(' ')
+                val rest = if (' ' in form) " " + form.substringAfter(' ') else ""
+                (irregularInversionToMain[token] ?: (token + "t")) + rest
             }
             val inversionForms2ndPerson = secondPersonPresentStrings
                 .filter { withFiniteT(it) in secondPersonPresentStrings }


### PR DESCRIPTION
## Summary

- **EN verb**: added `present (you)` row to the short view; preprocessing now synthesizes `second-person/present/singular` from the same non-third-person fallback used for 1st person, so the cell is never empty on verbs with generic present tags
- **NL verb**: split the merged `Present (jij/hij/u)` essentials cell into separate `Present (jij/je)` (2nd person) and `Present (hij/zij/het)` (3rd person) rows — correctly differentiates zijn (`bent` / `is`), hebben (`hebt` / `heeft`), etc.
- **NL inversion fix**: added `Clause.MAIN` as supporting tag on 2nd-person present cells; added a t-deletion heuristic in `preprocessForms` that injects `gij` onto inversion forms (e.g. `heb` when `hebt` exists, `spreek af` when `spreekt af` exists) so the main-clause `-t` form wins the extra-tag tiebreaker

## Test plan

- [ ] EN/NL scheme snapshots updated and passing
- [ ] Three new focused unit tests for t-deletion preprocessing: ambiguous non-separable (`heb`/`hebt`), separable (`spreek af`/`spreekt af`), and no-counterpart (heuristic must not fire)
- [ ] `./gradlew :composeApp:desktopTest` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)