### PR TITLE
feat(settings): add Acknowledgements to About section

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/AboutSection.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/AboutSection.kt
@@ -2,6 +2,8 @@ package com.slovy.slovymovyapp.ui
 
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Feedback
 import androidx.compose.material.icons.outlined.Info
@@ -78,8 +80,10 @@ fun AcknowledgementsBottomSheetContent() {
     Column(
         modifier = Modifier
             .fillMaxWidth()
+            .verticalScroll(rememberScrollState())
             .padding(horizontal = AppSpacing.lg)
-            .padding(bottom = AppSpacing.xl),
+            .padding(bottom = AppSpacing.xl)
+            .navigationBarsPadding(),
         verticalArrangement = Arrangement.spacedBy(AppSpacing.lg)
     ) {
         Text(

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/AboutSection.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/AboutSection.kt
@@ -5,11 +5,16 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Feedback
 import androidx.compose.material.icons.outlined.Info
+import androidx.compose.material.icons.outlined.VolunteerActivism
 import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.platform.LocalUriHandler
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.dp
 import com.slovy.slovymovyapp.AppBuildConfig
 import com.slovy.slovymovyapp.ui.theme.AppSpacing
@@ -17,7 +22,8 @@ import com.slovy.slovymovyapp.ui.theme.AppSpacing
 @Composable
 fun AboutSection(
     buildConfig: AppBuildConfig,
-    onSendFeedback: () -> Unit = {}
+    onSendFeedback: () -> Unit = {},
+    onAcknowledgements: () -> Unit = {}
 ) {
     ElevatedCard(
         modifier = Modifier.fillMaxWidth(),
@@ -40,11 +46,103 @@ fun AboutSection(
                 color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f)
             )
             AboutItem(
+                icon = Icons.Outlined.VolunteerActivism,
+                title = "Acknowledgements",
+                subtitle = "Data sources & credits",
+                onClick = onAcknowledgements
+            )
+            HorizontalDivider(
+                modifier = Modifier.padding(horizontal = AppSpacing.lg),
+                thickness = 0.5.dp,
+                color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f)
+            )
+            AboutItem(
                 icon = Icons.Outlined.Info,
                 title = "Version",
                 subtitle = buildConfig.versionName
             )
         }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun AcknowledgementsBottomSheet(onDismiss: () -> Unit) {
+    ModalBottomSheet(onDismissRequest = onDismiss) {
+        AcknowledgementsBottomSheetContent()
+    }
+}
+
+@Composable
+fun AcknowledgementsBottomSheetContent() {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = AppSpacing.lg)
+            .padding(bottom = AppSpacing.xl),
+        verticalArrangement = Arrangement.spacedBy(AppSpacing.lg)
+    ) {
+        Text(
+            text = "Acknowledgements",
+            style = MaterialTheme.typography.headlineSmall,
+            fontWeight = FontWeight.SemiBold
+        )
+        AcknowledgementItem(
+            title = "Vocabulary data",
+            body = "Our word data is sourced from Wiktionary, the free multilingual dictionary built by volunteers worldwide.",
+            urlLabel = "wiktionary.org",
+            url = "https://www.wiktionary.org"
+        )
+        HorizontalDivider(
+            thickness = 0.5.dp,
+            color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f)
+        )
+        AcknowledgementItem(
+            title = "Dictionary extracts",
+            body = "We use pre-processed dictionary data from Kaikki.org, extracted from Wiktionary using the open-source wiktextract tool by Tatu Ylonen.",
+            urlLabel = "kaikki.org",
+            url = "https://kaikki.org"
+        )
+        HorizontalDivider(
+            thickness = 0.5.dp,
+            color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f)
+        )
+        Text(
+            text = "We're grateful to the Wiktionary community and to Tatu Ylonen for making this data freely available.",
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+    }
+}
+
+@Composable
+private fun AcknowledgementItem(
+    title: String,
+    body: String,
+    urlLabel: String,
+    url: String
+) {
+    val uriHandler = LocalUriHandler.current
+    Column(
+        modifier = Modifier.fillMaxWidth(),
+        verticalArrangement = Arrangement.spacedBy(AppSpacing.xs)
+    ) {
+        Text(
+            text = title,
+            style = MaterialTheme.typography.titleMedium,
+            fontWeight = FontWeight.SemiBold
+        )
+        Text(
+            text = body,
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+        Text(
+            text = urlLabel,
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.primary,
+            modifier = Modifier.clickable { uriHandler.openUri(url) }
+        )
     }
 }
 
@@ -80,5 +178,15 @@ fun AboutItem(
                 color = MaterialTheme.colorScheme.onSurfaceVariant
             )
         }
+    }
+}
+
+@Preview
+@Composable
+private fun AcknowledgementsBottomSheetPreview(
+    @PreviewParameter(ThemePreviewProvider::class) isDark: Boolean
+) {
+    ThemedPreview(darkTheme = isDark) {
+        AcknowledgementsBottomSheetContent()
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/SettingsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/SettingsScreen.kt
@@ -74,6 +74,7 @@ data class SettingsUiState(
 
     // About
     val buildConfig: AppBuildConfig = AppBuildConfig("compile", 42, true, "com.slovy.slovymovyapp"),
+    val acknowledgementsVisible: Boolean = false,
 
     // Feedback
     val feedbackDialogVisible: Boolean = false,
@@ -625,6 +626,14 @@ class SettingsViewModel(
         return url
     }
 
+    fun openAcknowledgements() {
+        state = state.copy(acknowledgementsVisible = true)
+    }
+
+    fun dismissAcknowledgements() {
+        state = state.copy(acknowledgementsVisible = false)
+    }
+
     fun openFeedbackDialog() {
         state = state.copy(
             feedbackDialogVisible = true,
@@ -803,6 +812,8 @@ fun SettingsScreen(
         onDismissError = { viewModel.dismissError() },
         onConfirmDelete = { viewModel.confirmDelete() },
         onDismissDeleteConfirmation = { viewModel.dismissDeleteConfirmation() },
+        onAcknowledgements = { viewModel.openAcknowledgements() },
+        onDismissAcknowledgements = { viewModel.dismissAcknowledgements() },
         onSendFeedback = { viewModel.openFeedbackDialog() },
         onDismissFeedback = { viewModel.dismissFeedbackDialog() },
         onFeedbackCommentChange = { viewModel.updateFeedbackComment(it) },
@@ -837,6 +848,8 @@ fun SettingsScreenContent(
     onDismissError: () -> Unit = {},
     onConfirmDelete: () -> Unit = {},
     onDismissDeleteConfirmation: () -> Unit = {},
+    onAcknowledgements: () -> Unit = {},
+    onDismissAcknowledgements: () -> Unit = {},
     onSendFeedback: () -> Unit = {},
     onDismissFeedback: () -> Unit = {},
     onFeedbackCommentChange: (String) -> Unit = {},
@@ -1064,7 +1077,8 @@ fun SettingsScreenContent(
                                 item {
                                     AboutSection(
                                         buildConfig = buildConfig,
-                                        onSendFeedback = onSendFeedback
+                                        onSendFeedback = onSendFeedback,
+                                        onAcknowledgements = onAcknowledgements
                                     )
                                 }
                             }
@@ -1082,6 +1096,10 @@ fun SettingsScreenContent(
                 onConfirm = onConfirmDelete,
                 onDismiss = onDismissDeleteConfirmation
             )
+        }
+
+        if (state.acknowledgementsVisible) {
+            AcknowledgementsBottomSheet(onDismiss = onDismissAcknowledgements)
         }
 
         if (state.feedbackDialogVisible) {
@@ -1375,6 +1393,21 @@ private fun SettingsScreenPreviewWithMixedStates(
                     "trans_en_pl" to DownloadProgress(2 * 1024 * 1024, 7 * 1024 * 1024)
                 ),
                 isAppDataExportSupported = true,
+            )
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun SettingsScreenPreviewAcknowledgements(
+    @PreviewParameter(ThemePreviewProvider::class) isDark: Boolean
+) {
+    ThemedPreview(darkTheme = isDark) {
+        SettingsScreenContent(
+            state = SettingsUiState(
+                isLoading = false,
+                acknowledgementsVisible = true
             )
         )
     }


### PR DESCRIPTION
## Summary

- Adds an **Acknowledgements** row (VolunteerActivism icon) to the About card in Settings, between Feedback and Version
- Tapping the row opens a `ModalBottomSheet` crediting Wiktionary and Kaikki.org/wiktextract with tappable URLs
- State managed via `acknowledgementsVisible` in `SettingsUiState`; `openAcknowledgements` / `dismissAcknowledgements` in `SettingsViewModel`
- Preview added for the bottom sheet content and for the settings screen with the sheet open

## Test plan

- [ ] Tap Acknowledgements row → bottom sheet opens
- [ ] Swipe down → sheet dismisses
- [ ] Tapping wiktionary.org / kaikki.org opens browser
- [ ] Light and dark theme previews look correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)