### PR TITLE
fix(word): remove erroneous clickable styling on translation words in clarification header

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/word/SenseCard.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/word/SenseCard.kt
@@ -19,13 +19,10 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.layout.positionInWindow
-import androidx.compose.ui.text.LinkAnnotation
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.style.TextDecoration
-import androidx.compose.ui.text.withLink
 import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.dp
 import com.slovy.slovymovyapp.data.Language
@@ -467,21 +464,30 @@ internal fun TranslationHeader(
     val clarificationColor = MaterialTheme.colorScheme.onSurfaceVariant
     val style = MaterialTheme.typography.titleMedium
     sense.translations.entries.sortedBy { it.key }.forEach { (_, langTranslations) ->
-        val annotated = buildAnnotatedString {
-            if (multiLang) append("$bullet ")
-            langTranslations.sortedBy { it.targetLangWord }.forEachIndexed { index, translation ->
-                if (index > 0) append(", ")
-                val word = translation.targetLangWord
-                append(word)
-                val clarification = translation.targetLangSenseClarification
-                if (word in ambiguous && clarification != null) {
-                    withStyle(SpanStyle(color = clarificationColor)) {
-                        append(" $bullet $clarification")
-                    }
-                }
+        Text(
+            text = buildClarificationRow(langTranslations, ambiguous, multiLang, clarificationColor),
+            style = style
+        )
+    }
+}
+
+internal fun buildClarificationRow(
+    langTranslations: List<LanguageCardTranslation>,
+    ambiguous: Set<String>,
+    multiLang: Boolean,
+    clarificationColor: Color = Color.Unspecified
+) = buildAnnotatedString {
+    if (multiLang) append("$bullet ")
+    langTranslations.sortedBy { it.targetLangWord }.forEachIndexed { index, translation ->
+        if (index > 0) append(", ")
+        val word = translation.targetLangWord
+        append(word)
+        val clarification = translation.targetLangSenseClarification
+        if (word in ambiguous && clarification != null) {
+            withStyle(SpanStyle(color = clarificationColor)) {
+                append(" $bullet $clarification")
             }
         }
-        Text(text = annotated, style = style)
     }
 }
 

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/word/SenseCard.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/word/SenseCard.kt
@@ -465,11 +465,6 @@ internal fun TranslationHeader(
 
     val multiLang = sense.translations.keys.size > 1
     val clarificationColor = MaterialTheme.colorScheme.onSurfaceVariant
-    val clickableStyle = SpanStyle(
-        color = MaterialTheme.colorScheme.primary,
-        fontWeight = FontWeight.Medium,
-        textDecoration = TextDecoration.Underline
-    )
     val style = MaterialTheme.typography.titleMedium
     sense.translations.entries.sortedBy { it.key }.forEach { (_, langTranslations) ->
         val annotated = buildAnnotatedString {
@@ -477,14 +472,7 @@ internal fun TranslationHeader(
             langTranslations.sortedBy { it.targetLangWord }.forEachIndexed { index, translation ->
                 if (index > 0) append(", ")
                 val word = translation.targetLangWord
-                val isClickable = clickableWords.any { it.equals(word, ignoreCase = true) }
-                if (isClickable) {
-                    withLink(LinkAnnotation.Clickable(tag = "$CLICKABLE_WORD_TAG_PREFIX$word", linkInteractionListener = { onWordClick(word) })) {
-                        withStyle(clickableStyle) { append(word) }
-                    }
-                } else {
-                    append(word)
-                }
+                append(word)
                 val clarification = translation.targetLangSenseClarification
                 if (word in ambiguous && clarification != null) {
                     withStyle(SpanStyle(color = clarificationColor)) {

--- a/composeApp/src/commonTest/kotlin/com/slovy/slovymovyapp/ui/word/AmbiguousTranslationsTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/slovy/slovymovyapp/ui/word/AmbiguousTranslationsTest.kt
@@ -9,6 +9,7 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
+import kotlin.test.assertNotNull
 
 class AmbiguousTranslationsTest {
 
@@ -92,6 +93,29 @@ class AmbiguousTranslationsTest {
         assertEquals(setOf("bank"), result["1"])
         assertEquals(setOf("bank"), result["2"])
         assertFalse(result.containsKey("3"), "sense 3 must not be flagged")
+    }
+
+    @Test
+    fun clarificationRow_ambiguousWord_hasNoLinkAnnotation() {
+        // Regression: translation words must never be clickable links — they are in a different
+        // language from the source relatedWords index and navigation would be wrong.
+        val translations = listOf(
+            LanguageCardTranslation(targetLangWord = "miss", targetLangSenseClarification = "someone/something"),
+            LanguageCardTranslation(targetLangWord = "miss", targetLangSenseClarification = "a target")
+        )
+        val ambiguous = setOf("miss")
+        val annotated = buildClarificationRow(translations, ambiguous, multiLang = false)
+        val links = annotated.getLinkAnnotations(0, annotated.length)
+        assertTrue(links.isEmpty(), "clarification row must not contain any link annotations, found: $links")
+    }
+
+    @Test
+    fun clarificationRow_clarificationTextAppended() {
+        val translations = listOf(
+            LanguageCardTranslation(targetLangWord = "miss", targetLangSenseClarification = "a target")
+        )
+        val annotated = buildClarificationRow(translations, setOf("miss"), multiLang = false)
+        assertNotNull(annotated.text.contains("a target"), "clarification text must appear in the row")
     }
 
     @Test

--- a/composeApp/src/commonTest/kotlin/com/slovy/slovymovyapp/ui/word/AmbiguousTranslationsTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/slovy/slovymovyapp/ui/word/AmbiguousTranslationsTest.kt
@@ -9,7 +9,6 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
-import kotlin.test.assertNotNull
 
 class AmbiguousTranslationsTest {
 
@@ -115,7 +114,7 @@ class AmbiguousTranslationsTest {
             LanguageCardTranslation(targetLangWord = "miss", targetLangSenseClarification = "a target")
         )
         val annotated = buildClarificationRow(translations, setOf("miss"), multiLang = false)
-        assertNotNull(annotated.text.contains("a target"), "clarification text must appear in the row")
+        assertTrue(annotated.text.contains("a target"), "clarification text must appear in the row")
     }
 
     @Test


### PR DESCRIPTION
## Summary

- `TranslationHeader` was checking translation words against source-language `relatedWords`, making them appear as tappable links navigating to source-language entries (e.g. tapping "miss" as an EN translation of "missen" navigated to the NL word "miss")
- Translation words are in a different language and should never be navigable via the source-language related-words index
- Fix: removed the `clickableWords` check and link annotation from the clarification rendering path — translations are now always plain text when clarifications are shown
- The non-clarification path (`HighlightedText`) is unchanged and still correctly highlights `<w>`-tagged words

## Test plan

- [ ] Open a word with ambiguous translations (e.g. "missen") — translation words should be plain, non-tappable text
- [ ] Words tagged with `<w>` in definitions/examples still navigate correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)