### PR TITLE
fix(favorites): scroll to top when a new favorite is added

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/App.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/App.kt
@@ -533,7 +533,7 @@ fun App(
                         args.lemma,
                         args.targetSenseId,
                         args.translationLanguages,
-                        onFavoriteAdded = { favoritesViewModel.requestScrollToTop() }
+                        onFavoriteAdded = { senseId -> favoritesViewModel.requestScrollToTop(senseId) }
                     ).also { created ->
                         wordDetailViewModels[args] = created
                     }

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/App.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/App.kt
@@ -533,7 +533,7 @@ fun App(
                         args.lemma,
                         args.targetSenseId,
                         args.translationLanguages,
-                        onFavoriteAdded = { senseId -> favoritesViewModel.requestScrollToTop(senseId) }
+                        onFavoriteAdded = { favoritesViewModel.requestScrollToTop() }
                     ).also { created ->
                         wordDetailViewModels[args] = created
                     }

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/App.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/App.kt
@@ -442,7 +442,7 @@ fun App(
                 )
             }
             composable<AppDestination.Favorites> {
-                // Reload favorites when navigating to this screen
+                // Reload favorites when navigating to this screen.
                 LaunchedEffect(Unit) {
                     favoritesViewModel.loadFavorites()
                 }
@@ -532,7 +532,8 @@ fun App(
                         args.dictionaryLanguage,
                         args.lemma,
                         args.targetSenseId,
-                        args.translationLanguages
+                        args.translationLanguages,
+                        onFavoriteAdded = { favoritesViewModel.requestScrollToTop() }
                     ).also { created ->
                         wordDetailViewModels[args] = created
                     }

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/FavoritesScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/FavoritesScreen.kt
@@ -60,7 +60,8 @@ sealed interface FavoritesUiState {
         val favoriteLemmas: Set<String> = emptySet(),
         val availableLanguages: List<Language> = emptyList(),
         val selectedLanguage: Language? = null,
-        val isLanguageDropdownExpanded: Boolean = false
+        val isLanguageDropdownExpanded: Boolean = false,
+        val scrollToTopVersion: Int = 0
     ) : FavoritesUiState {
         val showNoResults: Boolean get() = senses.isEmpty() && query.isNotEmpty()
         val showLanguagePicker: Boolean get() = availableLanguages.size > 1
@@ -77,6 +78,13 @@ class FavoritesViewModel(
 
     val scrollState = LazyListState()
     val snackbarHostState = SnackbarHostState()
+
+    private var pendingScrollToTop = false
+
+    /** Called from outside (e.g. word detail) when a favorite was just added. */
+    fun requestScrollToTop() {
+        pendingScrollToTop = true
+    }
 
     private val queryFlow = MutableStateFlow(QueryState("", Uuid.random()))
 
@@ -98,7 +106,14 @@ class FavoritesViewModel(
                         .flowOn(Dispatchers.Default)
                 }
                 .collect { newState ->
-                    state = newState
+                    val shouldScrollToTop = pendingScrollToTop
+                    if (shouldScrollToTop) pendingScrollToTop = false
+                    val prevVersion = (state as? FavoritesUiState.Content)?.scrollToTopVersion ?: 0
+                    state = if (shouldScrollToTop) {
+                        newState.copy(scrollToTopVersion = prevVersion + 1)
+                    } else {
+                        newState
+                    }
                     prefetchSenses(newState.senses.take(PREFETCH_LIMIT))
                 }
         }
@@ -342,6 +357,13 @@ fun FavoritesScreen(
     LaunchedEffect(viewModel.scrollState.isScrollInProgress) {
         if (viewModel.scrollState.isScrollInProgress) {
             focusManager.clearFocus()
+        }
+    }
+
+    val scrollToTopVersion = (viewModel.state as? FavoritesUiState.Content)?.scrollToTopVersion ?: 0
+    LaunchedEffect(scrollToTopVersion) {
+        if (scrollToTopVersion > 0) {
+            viewModel.scrollState.scrollToItem(0)
         }
     }
 

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/FavoritesScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/FavoritesScreen.kt
@@ -222,12 +222,12 @@ class FavoritesViewModel(
     }
 
     private fun applyNewState(newState: FavoritesUiState.Content) {
+        val currentVersion = (state as? FavoritesUiState.Content)?.scrollToTopVersion ?: 0
         state = if (pendingScrollToTop) {
             pendingScrollToTop = false
-            val prevVersion = (state as? FavoritesUiState.Content)?.scrollToTopVersion ?: 0
-            newState.copy(scrollToTopVersion = prevVersion + 1)
+            newState.copy(scrollToTopVersion = currentVersion + 1)
         } else {
-            newState
+            newState.copy(scrollToTopVersion = currentVersion)
         }
     }
 

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/FavoritesScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/FavoritesScreen.kt
@@ -84,9 +84,6 @@ class FavoritesViewModel(
     /** Called from outside (e.g. word detail) when a favorite was just added. */
     fun requestScrollToTop() {
         pendingScrollToTop = true
-        // Trigger a reload so the flag is always consumed even if the Favorites screen's
-        // initial loadFavorites() ran before onFavoriteAdded was invoked.
-        loadFavorites()
     }
 
     private val queryFlow = MutableStateFlow(QueryState("", Uuid.random()))
@@ -365,7 +362,7 @@ fun FavoritesScreen(
 
     val scrollToTopVersion = (viewModel.state as? FavoritesUiState.Content)?.scrollToTopVersion ?: 0
     LaunchedEffect(scrollToTopVersion) {
-        if (scrollToTopVersion > 0) {
+        if (scrollToTopVersion > 0 && viewModel.scrollState.layoutInfo.totalItemsCount > 0) {
             viewModel.scrollState.scrollToItem(0)
         }
     }

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/FavoritesScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/FavoritesScreen.kt
@@ -237,6 +237,12 @@ class FavoritesViewModel(
         }
     }
 
+    /** Called by the composable after scrollToItem(0) completes to reset the scroll trigger. */
+    fun consumeScrollToTop() {
+        val content = state as? FavoritesUiState.Content ?: return
+        state = content.copy(scrollToTopVersion = 0)
+    }
+
     /** Computes and applies favorites state. Exposed for tests; production code uses the
      *  debounced flow or [toggleFavorite] which handle threading via [Dispatchers.Default]. */
     internal suspend fun loadAndApplyState(query: String) {
@@ -380,8 +386,11 @@ fun FavoritesScreen(
         // scrollToItem is a suspend function that queues the scroll for the next layout pass.
         // LaunchedEffect fires after the composition that bumped scrollToTopVersion, so the
         // LazyColumn already has the new item at index 0 in its composition when layout runs.
+        // consumeScrollToTop resets the version to 0 so re-entering Favorites does not
+        // replay the scroll.
         if (scrollToTopVersion > 0) {
             viewModel.scrollState.scrollToItem(0)
+            viewModel.consumeScrollToTop()
         }
     }
 

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/FavoritesScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/FavoritesScreen.kt
@@ -61,6 +61,7 @@ sealed interface FavoritesUiState {
         val availableLanguages: List<Language> = emptyList(),
         val selectedLanguage: Language? = null,
         val isLanguageDropdownExpanded: Boolean = false,
+        val allFavoriteIds: Set<String> = emptySet(),
         val scrollToTopVersion: Int = 0
     ) : FavoritesUiState {
         val showNoResults: Boolean get() = senses.isEmpty() && query.isNotEmpty()
@@ -211,19 +212,29 @@ class FavoritesViewModel(
             availableLanguages = availableLanguages,
             selectedLanguage = selectedLanguage,
             isLanguageDropdownExpanded = if (availableLanguages.size > 1)
-                currentContent?.isLanguageDropdownExpanded ?: false else false
+                currentContent?.isLanguageDropdownExpanded ?: false else false,
+            allFavoriteIds = allFavorites.map { it.senseId }.toSet()
         )
     }
 
     private fun applyScrollVersion(newState: FavoritesUiState.Content): FavoritesUiState.Content {
         val targetSenseId = pendingScrollForSenseId ?: return newState
-        pendingScrollForSenseId = null
-        // Only scroll if the added sense is actually visible in the reloaded list.
-        // If the user removed it before navigating here, or it's filtered out by the
-        // current language selection, skip the scroll.
-        if (newState.senses.none { it.senseId == targetSenseId }) return newState
-        val prevVersion = (state as? FavoritesUiState.Content)?.scrollToTopVersion ?: 0
-        return newState.copy(scrollToTopVersion = prevVersion + 1)
+        return when {
+            // Sense was deleted from favorites entirely — drop the request.
+            targetSenseId !in newState.allFavoriteIds -> {
+                pendingScrollForSenseId = null
+                newState
+            }
+            // Sense is in favorites but hidden by an active query or language filter —
+            // keep the request pending until it becomes visible.
+            newState.senses.none { it.senseId == targetSenseId } -> newState
+            // Sense is visible — trigger scroll.
+            else -> {
+                pendingScrollForSenseId = null
+                val prevVersion = (state as? FavoritesUiState.Content)?.scrollToTopVersion ?: 0
+                newState.copy(scrollToTopVersion = prevVersion + 1)
+            }
+        }
     }
 
     /** Computes and applies favorites state. Exposed for tests; production code uses the
@@ -364,9 +375,13 @@ fun FavoritesScreen(
         }
     }
 
-    val scrollToTopVersion = (viewModel.state as? FavoritesUiState.Content)?.scrollToTopVersion ?: 0
+    val scrollToTopContent = viewModel.state as? FavoritesUiState.Content
+    val scrollToTopVersion = scrollToTopContent?.scrollToTopVersion ?: 0
     LaunchedEffect(scrollToTopVersion) {
-        if (scrollToTopVersion > 0) {
+        // Guard: version is only bumped when the target sense is visible, so senses
+        // is non-empty here. The explicit check prevents a hang if that invariant
+        // is ever violated by future changes.
+        if (scrollToTopVersion > 0 && scrollToTopContent?.senses?.isNotEmpty() == true) {
             // Wait for the first layout pass so scrollToItem(0) sees the updated item list.
             snapshotFlow { viewModel.scrollState.layoutInfo.totalItemsCount }
                 .first { it > 0 }

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/FavoritesScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/FavoritesScreen.kt
@@ -84,6 +84,9 @@ class FavoritesViewModel(
     /** Called from outside (e.g. word detail) when a favorite was just added. */
     fun requestScrollToTop() {
         pendingScrollToTop = true
+        // Trigger a reload so the flag is always consumed even if the Favorites screen's
+        // initial loadFavorites() ran before onFavoriteAdded was invoked.
+        loadFavorites()
     }
 
     private val queryFlow = MutableStateFlow(QueryState("", Uuid.random()))
@@ -106,14 +109,7 @@ class FavoritesViewModel(
                         .flowOn(Dispatchers.Default)
                 }
                 .collect { newState ->
-                    val shouldScrollToTop = pendingScrollToTop
-                    if (shouldScrollToTop) pendingScrollToTop = false
-                    val prevVersion = (state as? FavoritesUiState.Content)?.scrollToTopVersion ?: 0
-                    state = if (shouldScrollToTop) {
-                        newState.copy(scrollToTopVersion = prevVersion + 1)
-                    } else {
-                        newState
-                    }
+                    state = applyScrollVersion(newState)
                     prefetchSenses(newState.senses.take(PREFETCH_LIMIT))
                 }
         }
@@ -222,10 +218,17 @@ class FavoritesViewModel(
         )
     }
 
+    private fun applyScrollVersion(newState: FavoritesUiState.Content): FavoritesUiState.Content {
+        val shouldScroll = pendingScrollToTop
+        if (shouldScroll) pendingScrollToTop = false
+        val prevVersion = (state as? FavoritesUiState.Content)?.scrollToTopVersion ?: 0
+        return if (shouldScroll) newState.copy(scrollToTopVersion = prevVersion + 1) else newState
+    }
+
     /** Computes and applies favorites state. Exposed for tests; production code uses the
      *  debounced flow or [toggleFavorite] which handle threading via [Dispatchers.Default]. */
     internal suspend fun loadAndApplyState(query: String) {
-        state = computeFavoritesState(query, state as? FavoritesUiState.Content)
+        state = applyScrollVersion(computeFavoritesState(query, state as? FavoritesUiState.Content))
     }
 
 

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/FavoritesScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/FavoritesScreen.kt
@@ -79,11 +79,11 @@ class FavoritesViewModel(
     val scrollState = LazyListState()
     val snackbarHostState = SnackbarHostState()
 
-    private var pendingScrollToTop = false
+    private var pendingScrollForSenseId: String? = null
 
     /** Called from outside (e.g. word detail) when a favorite was just added. */
-    fun requestScrollToTop() {
-        pendingScrollToTop = true
+    fun requestScrollToTop(senseId: String) {
+        pendingScrollForSenseId = senseId
     }
 
     private val queryFlow = MutableStateFlow(QueryState("", Uuid.random()))
@@ -216,10 +216,14 @@ class FavoritesViewModel(
     }
 
     private fun applyScrollVersion(newState: FavoritesUiState.Content): FavoritesUiState.Content {
-        val shouldScroll = pendingScrollToTop
-        if (shouldScroll) pendingScrollToTop = false
+        val targetSenseId = pendingScrollForSenseId ?: return newState
+        pendingScrollForSenseId = null
+        // Only scroll if the added sense is actually visible in the reloaded list.
+        // If the user removed it before navigating here, or it's filtered out by the
+        // current language selection, skip the scroll.
+        if (newState.senses.none { it.senseId == targetSenseId }) return newState
         val prevVersion = (state as? FavoritesUiState.Content)?.scrollToTopVersion ?: 0
-        return if (shouldScroll) newState.copy(scrollToTopVersion = prevVersion + 1) else newState
+        return newState.copy(scrollToTopVersion = prevVersion + 1)
     }
 
     /** Computes and applies favorites state. Exposed for tests; production code uses the

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/FavoritesScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/FavoritesScreen.kt
@@ -362,7 +362,10 @@ fun FavoritesScreen(
 
     val scrollToTopVersion = (viewModel.state as? FavoritesUiState.Content)?.scrollToTopVersion ?: 0
     LaunchedEffect(scrollToTopVersion) {
-        if (scrollToTopVersion > 0 && viewModel.scrollState.layoutInfo.totalItemsCount > 0) {
+        if (scrollToTopVersion > 0) {
+            // Wait for the first layout pass so scrollToItem(0) sees the updated item list.
+            snapshotFlow { viewModel.scrollState.layoutInfo.totalItemsCount }
+                .first { it > 0 }
             viewModel.scrollState.scrollToItem(0)
         }
     }

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/FavoritesScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/FavoritesScreen.kt
@@ -61,7 +61,6 @@ sealed interface FavoritesUiState {
         val availableLanguages: List<Language> = emptyList(),
         val selectedLanguage: Language? = null,
         val isLanguageDropdownExpanded: Boolean = false,
-        val allFavoriteIds: Set<String> = emptySet(),
         val scrollToTopVersion: Int = 0
     ) : FavoritesUiState {
         val showNoResults: Boolean get() = senses.isEmpty() && query.isNotEmpty()
@@ -80,11 +79,11 @@ class FavoritesViewModel(
     val scrollState = LazyListState()
     val snackbarHostState = SnackbarHostState()
 
-    private var pendingScrollForSenseId: String? = null
+    private var pendingScrollToTop: Boolean = false
 
     /** Called from outside (e.g. word detail) when a favorite was just added. */
-    fun requestScrollToTop(senseId: String) {
-        pendingScrollForSenseId = senseId
+    fun requestScrollToTop() {
+        pendingScrollToTop = true
     }
 
     private val queryFlow = MutableStateFlow(QueryState("", Uuid.random()))
@@ -107,7 +106,7 @@ class FavoritesViewModel(
                         .flowOn(Dispatchers.Default)
                 }
                 .collect { newState ->
-                    state = applyScrollVersion(newState)
+                    applyNewState(newState)
                     prefetchSenses(newState.senses.take(PREFETCH_LIMIT))
                 }
         }
@@ -213,28 +212,7 @@ class FavoritesViewModel(
             selectedLanguage = selectedLanguage,
             isLanguageDropdownExpanded = if (availableLanguages.size > 1)
                 currentContent?.isLanguageDropdownExpanded ?: false else false,
-            allFavoriteIds = allFavorites.map { it.senseId }.toSet()
         )
-    }
-
-    private fun applyScrollVersion(newState: FavoritesUiState.Content): FavoritesUiState.Content {
-        val targetSenseId = pendingScrollForSenseId ?: return newState
-        return when {
-            // Sense was deleted from favorites entirely — drop the request.
-            targetSenseId !in newState.allFavoriteIds -> {
-                pendingScrollForSenseId = null
-                newState
-            }
-            // Sense is in favorites but hidden by an active query or language filter —
-            // keep the request pending until it becomes visible.
-            newState.senses.none { it.senseId == targetSenseId } -> newState
-            // Sense is visible — trigger scroll.
-            else -> {
-                pendingScrollForSenseId = null
-                val prevVersion = (state as? FavoritesUiState.Content)?.scrollToTopVersion ?: 0
-                newState.copy(scrollToTopVersion = prevVersion + 1)
-            }
-        }
     }
 
     /** Called by the composable after scrollToItem(0) completes to reset the scroll trigger. */
@@ -243,10 +221,20 @@ class FavoritesViewModel(
         state = content.copy(scrollToTopVersion = 0)
     }
 
+    private fun applyNewState(newState: FavoritesUiState.Content) {
+        state = if (pendingScrollToTop) {
+            pendingScrollToTop = false
+            val prevVersion = (state as? FavoritesUiState.Content)?.scrollToTopVersion ?: 0
+            newState.copy(scrollToTopVersion = prevVersion + 1)
+        } else {
+            newState
+        }
+    }
+
     /** Computes and applies favorites state. Exposed for tests; production code uses the
      *  debounced flow or [toggleFavorite] which handle threading via [Dispatchers.Default]. */
     internal suspend fun loadAndApplyState(query: String) {
-        state = applyScrollVersion(computeFavoritesState(query, state as? FavoritesUiState.Content))
+        applyNewState(computeFavoritesState(query, state as? FavoritesUiState.Content))
     }
 
 

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/FavoritesScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/FavoritesScreen.kt
@@ -383,9 +383,15 @@ fun FavoritesScreen(
         // is ever violated by future changes.
         if (scrollToTopVersion > 0 && scrollToTopContent?.senses?.isNotEmpty() == true) {
             // Wait for the first layout pass so scrollToItem(0) sees the updated item list.
-            snapshotFlow { viewModel.scrollState.layoutInfo.totalItemsCount }
-                .first { it > 0 }
-            viewModel.scrollState.scrollToItem(0)
+            // Timeout guards against the edge case where items are removed before the
+            // layout emits >0, which would otherwise suspend until composable disposal.
+            val layoutReady = withTimeoutOrNull(500L) {
+                snapshotFlow { viewModel.scrollState.layoutInfo.totalItemsCount }
+                    .first { it > 0 }
+            }
+            if (layoutReady != null) {
+                viewModel.scrollState.scrollToItem(0)
+            }
         }
     }
 

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/FavoritesScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/FavoritesScreen.kt
@@ -61,7 +61,7 @@ sealed interface FavoritesUiState {
         val availableLanguages: List<Language> = emptyList(),
         val selectedLanguage: Language? = null,
         val isLanguageDropdownExpanded: Boolean = false,
-        val scrollToTopVersion: Int = 0
+        val scrollToTop: Boolean = false
     ) : FavoritesUiState {
         val showNoResults: Boolean get() = senses.isEmpty() && query.isNotEmpty()
         val showLanguagePicker: Boolean get() = availableLanguages.size > 1
@@ -218,16 +218,15 @@ class FavoritesViewModel(
     /** Called by the composable after scrollToItem(0) completes to reset the scroll trigger. */
     fun consumeScrollToTop() {
         val content = state as? FavoritesUiState.Content ?: return
-        state = content.copy(scrollToTopVersion = 0)
+        state = content.copy(scrollToTop = false)
     }
 
     private fun applyNewState(newState: FavoritesUiState.Content) {
-        val currentVersion = (state as? FavoritesUiState.Content)?.scrollToTopVersion ?: 0
         state = if (pendingScrollToTop) {
             pendingScrollToTop = false
-            newState.copy(scrollToTopVersion = currentVersion + 1)
+            newState.copy(scrollToTop = true)
         } else {
-            newState.copy(scrollToTopVersion = currentVersion)
+            newState.copy(scrollToTop = (state as? FavoritesUiState.Content)?.scrollToTop ?: false)
         }
     }
 
@@ -369,14 +368,9 @@ fun FavoritesScreen(
         }
     }
 
-    val scrollToTopVersion = (viewModel.state as? FavoritesUiState.Content)?.scrollToTopVersion ?: 0
-    LaunchedEffect(scrollToTopVersion) {
-        // scrollToItem is a suspend function that queues the scroll for the next layout pass.
-        // LaunchedEffect fires after the composition that bumped scrollToTopVersion, so the
-        // LazyColumn already has the new item at index 0 in its composition when layout runs.
-        // consumeScrollToTop resets the version to 0 so re-entering Favorites does not
-        // replay the scroll.
-        if (scrollToTopVersion > 0) {
+    val scrollToTop = (viewModel.state as? FavoritesUiState.Content)?.scrollToTop ?: false
+    LaunchedEffect(scrollToTop) {
+        if (scrollToTop) {
             viewModel.scrollState.scrollToItem(0)
             viewModel.consumeScrollToTop()
         }

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/FavoritesScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/FavoritesScreen.kt
@@ -375,23 +375,13 @@ fun FavoritesScreen(
         }
     }
 
-    val scrollToTopContent = viewModel.state as? FavoritesUiState.Content
-    val scrollToTopVersion = scrollToTopContent?.scrollToTopVersion ?: 0
+    val scrollToTopVersion = (viewModel.state as? FavoritesUiState.Content)?.scrollToTopVersion ?: 0
     LaunchedEffect(scrollToTopVersion) {
-        // Guard: version is only bumped when the target sense is visible, so senses
-        // is non-empty here. The explicit check prevents a hang if that invariant
-        // is ever violated by future changes.
-        if (scrollToTopVersion > 0 && scrollToTopContent?.senses?.isNotEmpty() == true) {
-            // Wait for the first layout pass so scrollToItem(0) sees the updated item list.
-            // Timeout guards against the edge case where items are removed before the
-            // layout emits >0, which would otherwise suspend until composable disposal.
-            val layoutReady = withTimeoutOrNull(500L) {
-                snapshotFlow { viewModel.scrollState.layoutInfo.totalItemsCount }
-                    .first { it > 0 }
-            }
-            if (layoutReady != null) {
-                viewModel.scrollState.scrollToItem(0)
-            }
+        // scrollToItem is a suspend function that queues the scroll for the next layout pass.
+        // LaunchedEffect fires after the composition that bumped scrollToTopVersion, so the
+        // LazyColumn already has the new item at index 0 in its composition when layout runs.
+        if (scrollToTopVersion > 0) {
+            viewModel.scrollState.scrollToItem(0)
         }
     }
 

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/word/WordDetailsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/word/WordDetailsScreen.kt
@@ -262,7 +262,7 @@ class WordDetailViewModel(
     private val lemma: String = "",
     val targetSenseId: String? = null,
     private val translationLanguages: List<Language>? = null,
-    private val onFavoriteAdded: (() -> Unit)? = null
+    private val onFavoriteAdded: ((senseId: String) -> Unit)? = null
 ) : ViewModel() {
     var state by mutableStateOf<WordDetailUiState>(
         WordDetailUiState.Empty(
@@ -532,7 +532,7 @@ class WordDetailViewModel(
                     favoritesRepository.remove(senseId, lang)
                 } else {
                     favoritesRepository.add(senseId, lang, lemma)
-                    onFavoriteAdded?.invoke()
+                    onFavoriteAdded?.invoke(senseId)
                 }
                 loadFavorites()
             }

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/word/WordDetailsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/word/WordDetailsScreen.kt
@@ -261,7 +261,8 @@ class WordDetailViewModel(
     val dictionaryLanguage: Language,
     private val lemma: String = "",
     val targetSenseId: String? = null,
-    private val translationLanguages: List<Language>? = null
+    private val translationLanguages: List<Language>? = null,
+    private val onFavoriteAdded: (() -> Unit)? = null
 ) : ViewModel() {
     var state by mutableStateOf<WordDetailUiState>(
         WordDetailUiState.Empty(
@@ -531,6 +532,7 @@ class WordDetailViewModel(
                     favoritesRepository.remove(senseId, lang)
                 } else {
                     favoritesRepository.add(senseId, lang, lemma)
+                    onFavoriteAdded?.invoke()
                 }
                 loadFavorites()
             }

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/word/WordDetailsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/word/WordDetailsScreen.kt
@@ -262,7 +262,7 @@ class WordDetailViewModel(
     private val lemma: String = "",
     val targetSenseId: String? = null,
     private val translationLanguages: List<Language>? = null,
-    private val onFavoriteAdded: ((senseId: String) -> Unit)? = null
+    private val onFavoriteAdded: (() -> Unit)? = null
 ) : ViewModel() {
     var state by mutableStateOf<WordDetailUiState>(
         WordDetailUiState.Empty(
@@ -532,7 +532,7 @@ class WordDetailViewModel(
                     favoritesRepository.remove(senseId, lang)
                 } else {
                     favoritesRepository.add(senseId, lang, lemma)
-                    onFavoriteAdded?.invoke(senseId)
+                    onFavoriteAdded?.invoke()
                 }
                 loadFavorites()
             }

--- a/composeApp/src/commonTest/kotlin/com/slovy/slovymovyapp/ui/FavoritesViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/slovy/slovymovyapp/ui/FavoritesViewModelTest.kt
@@ -236,6 +236,31 @@ open class FavoritesViewModelTest : BaseTest() {
     }
 
     @Test
+    fun requestScrollToTop_filteredOut_keepsPendingUntilVisible() = runTest {
+        val favRepo = favoritesRepository()
+        favRepo.deleteAll()
+        favRepo.add("s1", Language.ENGLISH, "hello")
+        favRepo.add("s2", Language.ENGLISH, "world")
+
+        val vm = createViewModel(favRepo)
+        vm.loadAndApplyState("")
+
+        // User adds s3 but Favorites reloads with an active query that hides it
+        favRepo.add("s3", Language.ENGLISH, "newword")
+        vm.requestScrollToTop("s3")
+        vm.loadAndApplyState("hello") // query hides s3
+
+        assertEquals(0, contentState(vm).scrollToTopVersion,
+            "Should not scroll while the new sense is filtered out by query")
+
+        // User clears the query — s3 becomes visible
+        vm.loadAndApplyState("")
+
+        assertTrue(contentState(vm).scrollToTopVersion > 0,
+            "Should scroll once the filtered-out sense becomes visible")
+    }
+
+    @Test
     fun dropdownExpandedState_resetsWhenPickerBecomesHidden() = runTest {
         val favRepo = favoritesRepository()
         favRepo.deleteAll()

--- a/composeApp/src/commonTest/kotlin/com/slovy/slovymovyapp/ui/FavoritesViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/slovy/slovymovyapp/ui/FavoritesViewModelTest.kt
@@ -188,7 +188,7 @@ open class FavoritesViewModelTest : BaseTest() {
         vm.loadAndApplyState("")
         assertEquals(0, contentState(vm).scrollToTopVersion, "Version should start at 0")
 
-        vm.requestScrollToTop()
+        vm.requestScrollToTop("s1")
         vm.loadAndApplyState("")
 
         assertTrue(contentState(vm).scrollToTopVersion > 0,
@@ -207,13 +207,32 @@ open class FavoritesViewModelTest : BaseTest() {
 
         // Favorite is added and onFavoriteAdded fires after the initial load
         favRepo.add("s1", Language.ENGLISH, "hello")
-        vm.requestScrollToTop() // sets the pending flag
+        vm.requestScrollToTop("s1") // sets the pending flag
         vm.loadAndApplyState("") // simulate the subsequent Favorites reload (debounced queryFlow)
 
         val content = contentState(vm)
         assertEquals(1, content.senses.size, "New favorite should be present")
         assertTrue(content.scrollToTopVersion > 0,
             "Should scroll to top even when the initial Favorites load ran before onFavoriteAdded")
+    }
+
+    @Test
+    fun requestScrollToTop_addThenRemove_doesNotScroll() = runTest {
+        val favRepo = favoritesRepository()
+        favRepo.deleteAll()
+        favRepo.add("s1", Language.ENGLISH, "hello")
+
+        val vm = createViewModel(favRepo)
+        vm.loadAndApplyState("")
+
+        // User adds a new favorite then removes it before Favorites reloads
+        favRepo.add("s2", Language.ENGLISH, "world")
+        vm.requestScrollToTop("s2")
+        favRepo.remove("s2", Language.ENGLISH)
+        vm.loadAndApplyState("")
+
+        assertEquals(0, contentState(vm).scrollToTopVersion,
+            "Should not scroll if the added sense was removed before the reload")
     }
 
     @Test

--- a/composeApp/src/commonTest/kotlin/com/slovy/slovymovyapp/ui/FavoritesViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/slovy/slovymovyapp/ui/FavoritesViewModelTest.kt
@@ -186,13 +186,13 @@ open class FavoritesViewModelTest : BaseTest() {
 
         val vm = createViewModel(favRepo)
         vm.loadAndApplyState("")
-        assertEquals(0, contentState(vm).scrollToTopVersion, "Version should start at 0")
+        assertFalse(contentState(vm).scrollToTop, "scrollToTop should start as false")
 
         vm.requestScrollToTop()
         vm.loadAndApplyState("")
 
-        assertTrue(contentState(vm).scrollToTopVersion > 0,
-            "scrollToTopVersion should be incremented after requestScrollToTop + load")
+        assertTrue(contentState(vm).scrollToTop,
+            "scrollToTop should be true after requestScrollToTop + load")
     }
 
     @Test
@@ -203,7 +203,7 @@ open class FavoritesViewModelTest : BaseTest() {
         val vm = createViewModel(favRepo)
         // Simulate Favorites screen's initial loadFavorites() running before the favorite is added
         vm.loadAndApplyState("")
-        assertEquals(0, contentState(vm).scrollToTopVersion)
+        assertFalse(contentState(vm).scrollToTop)
 
         // Favorite is added and onFavoriteAdded fires after the initial load
         favRepo.add("s1", Language.ENGLISH, "hello")
@@ -212,7 +212,7 @@ open class FavoritesViewModelTest : BaseTest() {
 
         val content = contentState(vm)
         assertEquals(1, content.senses.size, "New favorite should be present")
-        assertTrue(content.scrollToTopVersion > 0,
+        assertTrue(content.scrollToTop,
             "Should scroll to top even when the initial Favorites load ran before onFavoriteAdded")
     }
 
@@ -231,7 +231,7 @@ open class FavoritesViewModelTest : BaseTest() {
         vm.requestScrollToTop()
         vm.loadAndApplyState("hello") // query hides s3
 
-        assertTrue(contentState(vm).scrollToTopVersion > 0,
+        assertTrue(contentState(vm).scrollToTop,
             "Should scroll to top of the filtered results immediately, flag is not kept pending")
     }
 
@@ -250,7 +250,7 @@ open class FavoritesViewModelTest : BaseTest() {
         favRepo.remove("s2", Language.ENGLISH)
         vm.loadAndApplyState("")
 
-        assertTrue(contentState(vm).scrollToTopVersion > 0,
+        assertTrue(contentState(vm).scrollToTop,
             "Should still scroll to top even if the added sense was removed before reload")
     }
 
@@ -267,15 +267,15 @@ open class FavoritesViewModelTest : BaseTest() {
         favRepo.add("s2", Language.ENGLISH, "world")
         vm.requestScrollToTop()
         vm.loadAndApplyState("")
-        assertTrue(contentState(vm).scrollToTopVersion > 0, "Version should be bumped")
+        assertTrue(contentState(vm).scrollToTop, "scrollToTop should be true after add")
 
         // Composable consumes the scroll event (as LaunchedEffect does after scrollToItem)
         vm.consumeScrollToTop()
-        assertEquals(0, contentState(vm).scrollToTopVersion, "Version should reset to 0 after consume")
+        assertFalse(contentState(vm).scrollToTop, "scrollToTop should reset to false after consume")
 
         // Simulate re-entering Favorites (loadFavorites fires on screen entry, no new add)
         vm.loadAndApplyState("")
-        assertEquals(0, contentState(vm).scrollToTopVersion,
+        assertFalse(contentState(vm).scrollToTop,
             "Re-entering Favorites without a new add must not re-trigger scroll")
     }
 

--- a/composeApp/src/commonTest/kotlin/com/slovy/slovymovyapp/ui/FavoritesViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/slovy/slovymovyapp/ui/FavoritesViewModelTest.kt
@@ -188,7 +188,7 @@ open class FavoritesViewModelTest : BaseTest() {
         vm.loadAndApplyState("")
         assertEquals(0, contentState(vm).scrollToTopVersion, "Version should start at 0")
 
-        vm.requestScrollToTop("s1")
+        vm.requestScrollToTop()
         vm.loadAndApplyState("")
 
         assertTrue(contentState(vm).scrollToTopVersion > 0,
@@ -207,7 +207,7 @@ open class FavoritesViewModelTest : BaseTest() {
 
         // Favorite is added and onFavoriteAdded fires after the initial load
         favRepo.add("s1", Language.ENGLISH, "hello")
-        vm.requestScrollToTop("s1") // sets the pending flag
+        vm.requestScrollToTop() // sets the pending flag
         vm.loadAndApplyState("") // simulate the subsequent Favorites reload (debounced queryFlow)
 
         val content = contentState(vm)
@@ -217,47 +217,41 @@ open class FavoritesViewModelTest : BaseTest() {
     }
 
     @Test
-    fun requestScrollToTop_addThenRemove_doesNotScroll() = runTest {
+    fun requestScrollToTop_scrollsEvenWhenFilterActive() = runTest {
         val favRepo = favoritesRepository()
         favRepo.deleteAll()
         favRepo.add("s1", Language.ENGLISH, "hello")
+        favRepo.add("s2", Language.ENGLISH, "world")
 
         val vm = createViewModel(favRepo)
         vm.loadAndApplyState("")
 
-        // User adds a new favorite then removes it before Favorites reloads
-        favRepo.add("s2", Language.ENGLISH, "world")
-        vm.requestScrollToTop("s2")
-        favRepo.remove("s2", Language.ENGLISH)
-        vm.loadAndApplyState("")
+        // Add a new favorite and request scroll while a query is active
+        favRepo.add("s3", Language.ENGLISH, "newword")
+        vm.requestScrollToTop()
+        vm.loadAndApplyState("hello") // query hides s3
 
-        assertEquals(0, contentState(vm).scrollToTopVersion,
-            "Should not scroll if the added sense was removed before the reload")
+        assertTrue(contentState(vm).scrollToTopVersion > 0,
+            "Should scroll to top of the filtered results immediately, flag is not kept pending")
     }
 
     @Test
-    fun requestScrollToTop_filteredOut_keepsPendingUntilVisible() = runTest {
+    fun requestScrollToTop_scrollsEvenWhenSenseRemovedBeforeReload() = runTest {
         val favRepo = favoritesRepository()
         favRepo.deleteAll()
         favRepo.add("s1", Language.ENGLISH, "hello")
-        favRepo.add("s2", Language.ENGLISH, "world")
 
         val vm = createViewModel(favRepo)
         vm.loadAndApplyState("")
 
-        // User adds s3 but Favorites reloads with an active query that hides it
-        favRepo.add("s3", Language.ENGLISH, "newword")
-        vm.requestScrollToTop("s3")
-        vm.loadAndApplyState("hello") // query hides s3
-
-        assertEquals(0, contentState(vm).scrollToTopVersion,
-            "Should not scroll while the new sense is filtered out by query")
-
-        // User clears the query — s3 becomes visible
+        // Add then immediately remove before reload
+        favRepo.add("s2", Language.ENGLISH, "world")
+        vm.requestScrollToTop()
+        favRepo.remove("s2", Language.ENGLISH)
         vm.loadAndApplyState("")
 
         assertTrue(contentState(vm).scrollToTopVersion > 0,
-            "Should scroll once the filtered-out sense becomes visible")
+            "Should still scroll to top even if the added sense was removed before reload")
     }
 
     @Test
@@ -271,7 +265,7 @@ open class FavoritesViewModelTest : BaseTest() {
 
         // Add a favorite and trigger scroll
         favRepo.add("s2", Language.ENGLISH, "world")
-        vm.requestScrollToTop("s2")
+        vm.requestScrollToTop()
         vm.loadAndApplyState("")
         assertTrue(contentState(vm).scrollToTopVersion > 0, "Version should be bumped")
 

--- a/composeApp/src/commonTest/kotlin/com/slovy/slovymovyapp/ui/FavoritesViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/slovy/slovymovyapp/ui/FavoritesViewModelTest.kt
@@ -179,6 +179,44 @@ open class FavoritesViewModelTest : BaseTest() {
     }
 
     @Test
+    fun requestScrollToTop_incrementsScrollToTopVersionOnNextLoad() = runTest {
+        val favRepo = favoritesRepository()
+        favRepo.deleteAll()
+        favRepo.add("s1", Language.ENGLISH, "hello")
+
+        val vm = createViewModel(favRepo)
+        vm.loadAndApplyState("")
+        assertEquals(0, contentState(vm).scrollToTopVersion, "Version should start at 0")
+
+        vm.requestScrollToTop()
+        vm.loadAndApplyState("")
+
+        assertTrue(contentState(vm).scrollToTopVersion > 0,
+            "scrollToTopVersion should be incremented after requestScrollToTop + load")
+    }
+
+    @Test
+    fun requestScrollToTop_raceCondition_scrollHappensEvenWhenInitialLoadRunsFirst() = runTest {
+        val favRepo = favoritesRepository()
+        favRepo.deleteAll()
+
+        val vm = createViewModel(favRepo)
+        // Simulate Favorites screen's initial loadFavorites() running before the favorite is added
+        vm.loadAndApplyState("")
+        assertEquals(0, contentState(vm).scrollToTopVersion)
+
+        // Favorite is added and onFavoriteAdded fires after the initial load
+        favRepo.add("s1", Language.ENGLISH, "hello")
+        vm.requestScrollToTop() // sets flag + triggers its own loadFavorites()
+        vm.loadAndApplyState("") // simulate the reload triggered by requestScrollToTop
+
+        val content = contentState(vm)
+        assertEquals(1, content.senses.size, "New favorite should be present")
+        assertTrue(content.scrollToTopVersion > 0,
+            "Should scroll to top even when the initial Favorites load ran before onFavoriteAdded")
+    }
+
+    @Test
     fun dropdownExpandedState_resetsWhenPickerBecomesHidden() = runTest {
         val favRepo = favoritesRepository()
         favRepo.deleteAll()

--- a/composeApp/src/commonTest/kotlin/com/slovy/slovymovyapp/ui/FavoritesViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/slovy/slovymovyapp/ui/FavoritesViewModelTest.kt
@@ -207,8 +207,8 @@ open class FavoritesViewModelTest : BaseTest() {
 
         // Favorite is added and onFavoriteAdded fires after the initial load
         favRepo.add("s1", Language.ENGLISH, "hello")
-        vm.requestScrollToTop() // sets flag + triggers its own loadFavorites()
-        vm.loadAndApplyState("") // simulate the reload triggered by requestScrollToTop
+        vm.requestScrollToTop() // sets the pending flag
+        vm.loadAndApplyState("") // simulate the subsequent Favorites reload (debounced queryFlow)
 
         val content = contentState(vm)
         assertEquals(1, content.senses.size, "New favorite should be present")

--- a/composeApp/src/commonTest/kotlin/com/slovy/slovymovyapp/ui/FavoritesViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/slovy/slovymovyapp/ui/FavoritesViewModelTest.kt
@@ -261,6 +261,31 @@ open class FavoritesViewModelTest : BaseTest() {
     }
 
     @Test
+    fun scrollToTop_notRetriggered_afterVersionConsumed() = runTest {
+        val favRepo = favoritesRepository()
+        favRepo.deleteAll()
+        favRepo.add("s1", Language.ENGLISH, "hello")
+
+        val vm = createViewModel(favRepo)
+        vm.loadAndApplyState("")
+
+        // Add a favorite and trigger scroll
+        favRepo.add("s2", Language.ENGLISH, "world")
+        vm.requestScrollToTop("s2")
+        vm.loadAndApplyState("")
+        assertTrue(contentState(vm).scrollToTopVersion > 0, "Version should be bumped")
+
+        // Composable consumes the scroll event (as LaunchedEffect does after scrollToItem)
+        vm.consumeScrollToTop()
+        assertEquals(0, contentState(vm).scrollToTopVersion, "Version should reset to 0 after consume")
+
+        // Simulate re-entering Favorites (loadFavorites fires on screen entry, no new add)
+        vm.loadAndApplyState("")
+        assertEquals(0, contentState(vm).scrollToTopVersion,
+            "Re-entering Favorites without a new add must not re-trigger scroll")
+    }
+
+    @Test
     fun dropdownExpandedState_resetsWhenPickerBecomesHidden() = runTest {
         val favRepo = favoritesRepository()
         favRepo.deleteAll()


### PR DESCRIPTION
## Summary

- After adding a word to favorites from the word detail screen, navigating to Favorites now scrolls to the newly added item at the top of the list.
- Returning from a related-word navigation preserves the previous scroll position (no unintended scroll to top).

## How it works

- `WordDetailViewModel` gains an `onFavoriteAdded` callback, invoked only when adding (not removing) a favorite.
- In `App.kt`, the callback calls `favoritesViewModel.requestScrollToTop()`, which sets a `pendingScrollToTop` flag.
- When the favorites list reloads (via `loadFavorites()`), the collect block detects the flag and increments `scrollToTopVersion` in `FavoritesUiState.Content`.
- `FavoritesScreen` has a `LaunchedEffect(scrollToTopVersion)` that scrolls to item 0 — it fires *after* Compose has recomposed with the new items, avoiding the key-based position preservation issue that caused the off-by-one scroll.

## Test plan

- [ ] Add a word to favorites from the word detail screen → navigate to Favorites → new word appears at top
- [ ] From Favorites, navigate to a related word and back → scroll position is preserved
- [ ] Remove a favorite (undo snackbar) → no unintended scroll to top

🤖 Generated with [Claude Code](https://claude.com/claude-code)