### PR TITLE
fix: move word family section below entries

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/word/WordDetailsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/word/WordDetailsScreen.kt
@@ -936,7 +936,7 @@ fun WordDetailScreenContent(
                         modifier = Modifier
                             .fillMaxSize()
                             .verticalScroll(scrollState)
-                            .padding(horizontal = 12.dp, vertical = 20.dp),
+                            .padding(start = 12.dp, end = 12.dp, top = 8.dp, bottom = 20.dp),
                         cardLoading = state.cardLoading,
                         cardError = state.cardError,
                         translationLoading = state.translationLoading,
@@ -1036,30 +1036,6 @@ private fun WordDetailContent(
         },
         verticalArrangement = Arrangement.spacedBy(8.dp),
     ) {
-        // Display word family if available
-        if (card.wordFamily.isNotEmpty()) {
-            Column(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = 8.dp, vertical = 4.dp),
-                verticalArrangement = Arrangement.spacedBy(12.dp)
-            ) {
-                EntryList(
-                    label = "Word Family",
-                    values = card.wordFamily,
-                    containerColor = MaterialTheme.colorScheme.primaryContainer,
-                    contentColor = MaterialTheme.colorScheme.onPrimaryContainer,
-                    relatedWords = card.relatedWords,
-                    onWordClick = onWordClick,
-                    favoriteLemmas = favoriteLemmas
-                )
-            }
-            HorizontalDivider(
-                modifier = Modifier.padding(vertical = 8.dp),
-                color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f)
-            )
-        }
-
         if (card.entries.isEmpty()) {
             Text(
                 text = "No entries available.",
@@ -1098,6 +1074,29 @@ private fun WordDetailContent(
                         onSensePositioned(senseId, relativeY)
                     },
                     onSenseFavoriteToggle = onSenseFavoriteToggle,
+                    relatedWords = card.relatedWords,
+                    onWordClick = onWordClick,
+                    favoriteLemmas = favoriteLemmas
+                )
+            }
+        }
+
+        if (card.wordFamily.isNotEmpty()) {
+            HorizontalDivider(
+                modifier = Modifier.padding(vertical = 8.dp),
+                color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f)
+            )
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 8.dp, vertical = 4.dp),
+                verticalArrangement = Arrangement.spacedBy(12.dp)
+            ) {
+                EntryList(
+                    label = "Word Family",
+                    values = card.wordFamily,
+                    containerColor = MaterialTheme.colorScheme.primaryContainer,
+                    contentColor = MaterialTheme.colorScheme.onPrimaryContainer,
                     relatedWords = card.relatedWords,
                     onWordClick = onWordClick,
                     favoriteLemmas = favoriteLemmas


### PR DESCRIPTION
## Summary
- Moves the Word Family block to the bottom of the word detail card (after entries, not above them)
- Reduces top scroll padding from 20dp to 8dp to compensate for the section no longer anchoring the top
- Divider is now placed above the Word Family block since it sits at the bottom

Closes #509

## Test plan
- [ ] Open a word that has a word family — confirm family appears below all entries
- [ ] Open a word with no word family — confirm no divider or empty section appears
- [ ] Check scroll position and top spacing looks correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<img width="300" height="650" alt="Screenshot 2026-04-19 at 13 01 57" src="https://github.com/user-attachments/assets/bb071d42-96c9-4964-98e8-db9e95c6401e" />

