### PR TITLE
feat: premium UI design tweaks — word details, chips, icons

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/SearchScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/SearchScreen.kt
@@ -11,7 +11,6 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.DownloadForOffline
 import androidx.compose.material.icons.filled.Favorite
 import androidx.compose.foundation.Image
 import androidx.compose.material3.*
@@ -37,6 +36,7 @@ import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
+import com.slovy.slovymovyapp.ui.word.DownloadVector
 import com.slovy.slovymovyapp.ui.word.FavoriteAccentColor
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.ViewModel
@@ -481,20 +481,19 @@ private fun SearchResultCard(
                 .padding(horizontal = 16.dp, vertical = 20.dp),
             verticalAlignment = Alignment.CenterVertically
         ) {
-            // Word display
             Text(
                 text = item.display,
-                style = MaterialTheme.typography.titleMedium,
+                style = MaterialTheme.typography.titleMedium.copy(
+                    fontWeight = androidx.compose.ui.text.font.FontWeight.SemiBold
+                ),
                 color = MaterialTheme.colorScheme.onSurface,
                 modifier = Modifier.weight(1f)
             )
 
-            // Icons section - aligned to the right
             Row(
                 horizontalArrangement = Arrangement.spacedBy(12.dp),
                 verticalAlignment = Alignment.CenterVertically
             ) {
-                // Show language badge if searching multiple dictionaries
                 if (showLanguageIndicator) {
                     Badge(
                         text = item.language.selfName,
@@ -504,7 +503,6 @@ private fun SearchResultCard(
                     )
                 }
 
-                // Favorite icon
                 if (item.isFavorite) {
                     Icon(
                         imageVector = Icons.Filled.Favorite,
@@ -512,13 +510,10 @@ private fun SearchResultCard(
                         tint = MaterialTheme.colorScheme.error,
                         modifier = Modifier.size(20.dp)
                     )
-                }
-
-                // Online-only / download icon
-                if (item.onlineOnly) {
+                } else if (item.onlineOnly) {
                     Icon(
-                        imageVector = Icons.Filled.DownloadForOffline,
-                        contentDescription = "Online",
+                        imageVector = DownloadVector,
+                        contentDescription = "Not downloaded",
                         tint = MaterialTheme.colorScheme.onSurfaceVariant,
                         modifier = Modifier.size(20.dp)
                     )

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/SearchScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/SearchScreen.kt
@@ -510,7 +510,8 @@ private fun SearchResultCard(
                         tint = MaterialTheme.colorScheme.error,
                         modifier = Modifier.size(20.dp)
                     )
-                } else if (item.onlineOnly) {
+                }
+                if (item.onlineOnly) {
                     Icon(
                         imageVector = DownloadVector,
                         contentDescription = "Not downloaded",

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/components/PartOfSpeechIndicator.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/components/PartOfSpeechIndicator.kt
@@ -2,7 +2,6 @@ package com.slovy.slovymovyapp.ui.components
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.ContainedLoadingIndicator
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.MaterialTheme
@@ -10,10 +9,11 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.text.capitalize
-import androidx.compose.ui.text.intl.Locale
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import com.slovy.slovymovyapp.ui.ThemePreviewProvider
 import com.slovy.slovymovyapp.ui.ThemedPreview
 import com.slovy.slovymovyapp.ui.theme.AppSpacing
@@ -53,12 +53,10 @@ fun PartOfSpeechIndicator(
         horizontalArrangement = Arrangement.spacedBy(AppSpacing.sm)
     ) {
         if (!cardLoading && cardError == null) {
-            // Vertical color bar
             Box(
                 modifier = Modifier
-                    .width(4.dp)
-                    .height(24.dp)
-                    .background(color, RoundedCornerShape(2.dp))
+                    .size(7.dp)
+                    .background(color, CircleShape)
             )
         } else if (cardLoading) {
             ContainedLoadingIndicator(indicatorColor = color)
@@ -67,20 +65,19 @@ fun PartOfSpeechIndicator(
         }
 
         if (!cardLoading && cardError == null) {
-            // Part of speech label
+            val label = if (meaningCount != null) {
+                "${partOfSpeech} · $meaningCount sense${pluralEnding(meaningCount)}"
+            } else {
+                partOfSpeech
+            }.uppercase()
             Text(
-                text = partOfSpeech.capitalize(Locale.current),
-                style = MaterialTheme.typography.titleMedium,
+                text = label,
+                style = MaterialTheme.typography.labelSmall.copy(
+                    fontWeight = FontWeight.Bold,
+                    letterSpacing = 1.2.sp
+                ),
                 color = MaterialTheme.colorScheme.onSurface
             )
-            // Optional meaning count (secondary)
-            if (meaningCount != null) {
-                Text(
-                    text = "· $meaningCount meaning${pluralEnding(meaningCount)}",
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant
-                )
-            }
         } else if (cardLoading) {
             Text(
                 text = "Generating definitions and examples…",
@@ -133,7 +130,7 @@ fun PartOfSpeechBadge(
             .padding(horizontal = AppSpacing.md, vertical = 6.dp)
     ) {
         Text(
-            text = partOfSpeech.capitalize(Locale.current),
+            text = partOfSpeech.replaceFirstChar { it.uppercase() },
             style = MaterialTheme.typography.labelSmall,
             color = color
         )

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/word/EntryCard.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/word/EntryCard.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.outlined.LibraryBooks
 import androidx.compose.material3.*
+import androidx.compose.ui.semantics.Role
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.platform.LocalDensity
@@ -516,13 +517,14 @@ internal fun EntryCard(
                 if (entry.formsViews.isNotEmpty()) {
                     Box(
                         modifier = Modifier
+                            .minimumInteractiveComponentSize()
                             .clip(RoundedCornerShape(50))
                             .border(
                                 1.dp,
                                 MaterialTheme.colorScheme.outlineVariant,
                                 RoundedCornerShape(50)
                             )
-                            .clickable { onFormsToggle() }
+                            .clickable(role = Role.Button) { onFormsToggle() }
                             .padding(top = 4.dp, bottom = 4.dp, start = 9.dp, end = 10.dp)
                     ) {
                         Row(

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/word/EntryCard.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/word/EntryCard.kt
@@ -412,14 +412,15 @@ private fun GrammarSection(
     expanded: Boolean,
     onToggle: () -> Unit,
     onFormsViewSelect: (String) -> Unit,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    showToggleButton: Boolean = true
 ) {
     val selectedFormsView = formsViews.firstOrNull { it.view.viewId == selectedViewId } ?: formsViews.first()
     val selectedViewIdResolved = selectedFormsView.view.viewId
     val shape = RoundedCornerShape(14.dp)
 
     Column(modifier = modifier, verticalArrangement = Arrangement.spacedBy(8.dp)) {
-        Surface(
+        if (showToggleButton) Surface(
             modifier = Modifier
                 .clip(shape)
                 .clickable(onClick = onToggle),
@@ -500,7 +501,7 @@ internal fun EntryCard(
                 .fillMaxWidth()
                 .clip(MaterialTheme.shapes.extraLarge)
                 .clickable(onClick = onEntryToggle)
-                .padding(horizontal = 8.dp, vertical = 14.dp),
+                .padding(horizontal = 4.dp, vertical = 4.dp),
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.spacedBy(12.dp)
         ) {
@@ -512,6 +513,37 @@ internal fun EntryCard(
             )
             if (!cardLoading && cardError == null) {
                 Spacer(modifier = Modifier.weight(1f))
+
+                if (entry.formsViews.isNotEmpty()) {
+                    Box(
+                        modifier = Modifier
+                            .clip(RoundedCornerShape(50))
+                            .border(
+                                0.5.dp,
+                                MaterialTheme.colorScheme.outlineVariant,
+                                RoundedCornerShape(50)
+                            )
+                            .clickable { onFormsToggle() }
+                            .padding(top = 4.dp, bottom = 4.dp, start = 9.dp, end = 10.dp)
+                    ) {
+                        Row(
+                            horizontalArrangement = Arrangement.spacedBy(4.dp),
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            Icon(
+                                imageVector = Icons.AutoMirrored.Outlined.LibraryBooks,
+                                contentDescription = if (entryState.formsExpanded) "Hide forms" else "Show forms",
+                                modifier = Modifier.size(12.dp),
+                                tint = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
+                            Text(
+                                text = "Forms",
+                                style = MaterialTheme.typography.labelSmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
+                        }
+                    }
+                }
 
                 Icon(
                     imageVector = if (expanded) ExpandLessVector else ExpandMoreVector,
@@ -544,7 +576,8 @@ internal fun EntryCard(
                         expanded = entryState.formsExpanded,
                         onToggle = onFormsToggle,
                         onFormsViewSelect = onFormsViewSelect,
-                        modifier = Modifier.padding(horizontal = 8.dp)
+                        modifier = Modifier.padding(horizontal = 8.dp),
+                        showToggleButton = false
                     )
                 }
 

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/word/EntryCard.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/word/EntryCard.kt
@@ -18,9 +18,11 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.Layout
 import androidx.compose.ui.text.font.FontStyle
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.Constraints
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import com.slovy.slovymovyapp.data.forms.GridCell
 import com.slovy.slovymovyapp.data.remote.FormsSchemeView
 import com.slovy.slovymovyapp.data.remote.LanguageCardPosEntry
@@ -482,7 +484,6 @@ internal fun EntryCard(
     cardError: String? = null,
     translationLoading: Boolean = false,
     translationError: String? = null,
-    onEntryToggle: () -> Unit,
     onFormsToggle: () -> Unit,
     onFormsViewSelect: (String) -> Unit,
     onSenseToggle: (String) -> Unit,
@@ -493,25 +494,23 @@ internal fun EntryCard(
     lemma: String,
     favoriteLemmas: Set<String> = emptySet()
 ) {
-    val expanded = entryState.expanded && !cardLoading && cardError == null
+    val showContent = !cardLoading && cardError == null
     Column(modifier = Modifier.fillMaxWidth()) {
-        // POS Header - kept with its own padding
+        // POS Header
         Row(
             modifier = Modifier
                 .fillMaxWidth()
-                .clip(MaterialTheme.shapes.extraLarge)
-                .clickable(onClick = onEntryToggle)
                 .padding(horizontal = 4.dp, vertical = 4.dp),
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.spacedBy(12.dp)
         ) {
             PartOfSpeechIndicator(
                 partOfSpeech = entry.pos.name,
-                meaningCount = if (!cardLoading && cardError == null) entry.senses.size else null,
+                meaningCount = if (showContent) entry.senses.size else null,
                 cardLoading = cardLoading,
                 cardError = cardError
             )
-            if (!cardLoading && cardError == null) {
+            if (showContent) {
                 Spacer(modifier = Modifier.weight(1f))
 
                 if (entry.formsViews.isNotEmpty()) {
@@ -519,7 +518,7 @@ internal fun EntryCard(
                         modifier = Modifier
                             .clip(RoundedCornerShape(50))
                             .border(
-                                0.5.dp,
+                                1.dp,
                                 MaterialTheme.colorScheme.outlineVariant,
                                 RoundedCornerShape(50)
                             )
@@ -527,7 +526,7 @@ internal fun EntryCard(
                             .padding(top = 4.dp, bottom = 4.dp, start = 9.dp, end = 10.dp)
                     ) {
                         Row(
-                            horizontalArrangement = Arrangement.spacedBy(4.dp),
+                            horizontalArrangement = Arrangement.spacedBy(6.dp),
                             verticalAlignment = Alignment.CenterVertically
                         ) {
                             Icon(
@@ -538,35 +537,25 @@ internal fun EntryCard(
                             )
                             Text(
                                 text = "Forms",
-                                style = MaterialTheme.typography.labelSmall,
+                                style = MaterialTheme.typography.labelSmall.copy(
+                                    fontSize = 11.5.sp,
+                                    fontWeight = FontWeight.SemiBold,
+                                    letterSpacing = 0.3.sp
+                                ),
                                 color = MaterialTheme.colorScheme.onSurfaceVariant
                             )
                         }
                     }
                 }
-
-                Icon(
-                    imageVector = if (expanded) ExpandLessVector else ExpandMoreVector,
-                    contentDescription = if (expanded) {
-                        "Collapse ${entry.pos} entry"
-                    } else {
-                        "Expand ${entry.pos} entry"
-                    },
-                    tint = MaterialTheme.colorScheme.onSurfaceVariant
-                )
             }
         }
 
-        AnimatedVisibility(
-            visible = expanded,
-            enter = expandVertically() + fadeIn(),
-            exit = shrinkVertically() + fadeOut()
-        ) {
+        if (showContent) {
             Column(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(bottom = 8.dp),
-                verticalArrangement = Arrangement.spacedBy(12.dp)
+                    .padding(top = if (entry.formsViews.isEmpty()) 8.dp else 2.dp, bottom = 8.dp),
+                verticalArrangement = Arrangement.spacedBy(8.dp)
             ) {
                 // Grammar section - indented under POS header
                 if (entry.formsViews.isNotEmpty()) {

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/word/SenseCard.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/word/SenseCard.kt
@@ -375,7 +375,7 @@ internal fun ExampleItem(
             ExampleText(
                 text = example.text,
                 style = MaterialTheme.typography.bodyLarge.copy(
-                    fontStyle = androidx.compose.ui.text.font.FontStyle.Italic,
+                    fontStyle = androidx.compose.ui.text.font.FontStyle.Normal,
                     lineHeight = MaterialTheme.typography.bodyLarge.lineHeight * 1.1f
                 ),
             )

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/word/SenseCard.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/word/SenseCard.kt
@@ -195,22 +195,24 @@ internal fun SenseCard(
                             Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
                                 SectionLabel("Definition")
                                 Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
-                                    if (translationBasedHeader != null) {
-                                        HighlightedText(
-                                            text = sense.senseDefinition,
-                                            clickableWords = relatedWords.keys,
-                                            onWordClick = onWordClick,
-                                            style = MaterialTheme.typography.bodyLarge,
-                                        )
-                                    }
+                                    // Target language definition first (English) — primary
                                     HighlightedText(
                                         text = sense.targetLangDefinitions.map { definition ->
                                             definition.value.replaceFirstChar { if (it.isUpperCase()) it.lowercase() else it.toString() }
                                         }.joinToString("\n"),
-                                        style = MaterialTheme.typography.bodyMedium.copy(
-                                            color = MaterialTheme.colorScheme.onSurfaceVariant
-                                        ),
+                                        clickableWords = relatedWords.keys,
+                                        onWordClick = onWordClick,
+                                        style = MaterialTheme.typography.bodyLarge,
                                     )
+                                    // Source language definition second (Dutch) — secondary
+                                    if (translationBasedHeader != null && sense.senseDefinition.isNotBlank()) {
+                                        HighlightedText(
+                                            text = sense.senseDefinition,
+                                            style = MaterialTheme.typography.bodyMedium.copy(
+                                                color = MaterialTheme.colorScheme.onSurfaceVariant
+                                            ),
+                                        )
+                                    }
                                 }
                             }
                         }
@@ -371,6 +373,7 @@ internal fun ExampleItem(
             ExampleText(
                 text = example.text,
                 style = MaterialTheme.typography.bodyLarge.copy(
+                    fontStyle = androidx.compose.ui.text.font.FontStyle.Italic,
                     lineHeight = MaterialTheme.typography.bodyLarge.lineHeight * 1.1f
                 ),
             )
@@ -423,11 +426,11 @@ internal fun LevelAndFrequencyRow(
     ) {
         val (lc, lcc) = colorsForLevel(level)
         val (fc, fcc) = colorsForFrequency(frequency)
-        Badge(text = level.name, containerColor = lc, contentColor = lcc)
-        Badge(text = frequency.label, containerColor = fc, contentColor = fcc)
+        MetaBadge(text = level.name, containerColor = lc, contentColor = lcc)
+        MetaBadge(text = frequency.label, containerColor = fc, contentColor = fcc)
         if (nameType != null && nameType != NameType.NO) {
             val (nc, ncc) = colorsForNameType(nameType)
-            Badge(text = nameType.displayName, containerColor = nc, contentColor = ncc)
+            MetaBadge(text = nameType.displayName, containerColor = nc, contentColor = ncc)
         }
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/word/SenseCard.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/word/SenseCard.kt
@@ -211,6 +211,8 @@ internal fun SenseCard(
                                             style = MaterialTheme.typography.bodyMedium.copy(
                                                 color = MaterialTheme.colorScheme.onSurfaceVariant
                                             ),
+                                            clickableWords = relatedWords.keys,
+                                            onWordClick = onWordClick,
                                         )
                                     }
                                 }
@@ -403,7 +405,7 @@ private fun ExampleText(
         color = style.color
     )
     val annotated = buildAnnotatedString {
-        appendTextWithW(this, text, highlight, highlight, emptySet()) { }
+        appendTextWithW(this, text, highlight, highlight, emptySet())
     }
 
     Text(

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/word/SenseCard.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/word/SenseCard.kt
@@ -195,7 +195,6 @@ internal fun SenseCard(
                             Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
                                 SectionLabel("Definition")
                                 Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
-                                    // Target language definition first (English) — primary
                                     HighlightedText(
                                         text = sense.targetLangDefinitions.map { definition ->
                                             definition.value.replaceFirstChar { if (it.isUpperCase()) it.lowercase() else it.toString() }
@@ -204,7 +203,6 @@ internal fun SenseCard(
                                         onWordClick = onWordClick,
                                         style = MaterialTheme.typography.bodyLarge,
                                     )
-                                    // Source language definition second (Dutch) — secondary
                                     if (translationBasedHeader != null && sense.senseDefinition.isNotBlank()) {
                                         HighlightedText(
                                             text = sense.senseDefinition,

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/word/WordDetailsColors.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/word/WordDetailsColors.kt
@@ -256,6 +256,7 @@ internal fun colorsForAntonyms(): Pair<Color, Color> {
     }
 }
 
+// Stroke color is black so Icon() tint overrides it correctly. Do not render these via Image().
 private val strokeRound = SolidColor(Color.Black)
 
 internal val ChapterDiamondVector: ImageVector = ImageVector.Builder(

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/word/WordDetailsColors.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/word/WordDetailsColors.kt
@@ -4,7 +4,10 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.PathFillType
 import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.graphics.StrokeJoin
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.graphics.vector.addPathNodes as parsePathNodes
 import androidx.compose.ui.graphics.vector.path
 import androidx.compose.ui.unit.dp
 import com.slovy.slovymovyapp.data.remote.LearnerLevel
@@ -252,6 +255,67 @@ internal fun colorsForAntonyms(): Pair<Color, Color> {
         Color(0xFFEBDDD8) to Color(0xFF7A4A50) // Light dusty rose / Mauve
     }
 }
+
+private val strokeRound = SolidColor(Color.Black)
+
+internal val ChapterDiamondVector: ImageVector = ImageVector.Builder(
+    name = "ChapterDiamond",
+    defaultWidth = 14.dp,
+    defaultHeight = 14.dp,
+    viewportWidth = 24f,
+    viewportHeight = 24f
+).apply {
+    addPath(
+        pathData = parsePathNodes("M12 4 L14 10 L20 12 L14 14 L12 20 L10 14 L4 12 L10 10 Z"),
+        fill = null,
+        stroke = strokeRound,
+        strokeLineWidth = 1.2f,
+        strokeLineCap = StrokeCap.Round,
+        strokeLineJoin = StrokeJoin.Round
+    )
+}.build()
+
+internal val SpeakerVector: ImageVector = ImageVector.Builder(
+    name = "Speaker",
+    defaultWidth = 24.dp,
+    defaultHeight = 24.dp,
+    viewportWidth = 24f,
+    viewportHeight = 24f
+).apply {
+    addPath(
+        pathData = parsePathNodes("M11 5L6 9H2v6h4l5 4V5z"),
+        fill = null,
+        stroke = strokeRound,
+        strokeLineWidth = 2f,
+        strokeLineCap = StrokeCap.Round,
+        strokeLineJoin = StrokeJoin.Round
+    )
+    addPath(
+        pathData = parsePathNodes("M19.1 5a9 9 0 0 1 0 14M15.5 8.5a5 5 0 0 1 0 7"),
+        fill = null,
+        stroke = strokeRound,
+        strokeLineWidth = 2f,
+        strokeLineCap = StrokeCap.Round,
+        strokeLineJoin = StrokeJoin.Round
+    )
+}.build()
+
+internal val DownloadVector: ImageVector = ImageVector.Builder(
+    name = "Download",
+    defaultWidth = 24.dp,
+    defaultHeight = 24.dp,
+    viewportWidth = 24f,
+    viewportHeight = 24f
+).apply {
+    addPath(
+        pathData = parsePathNodes("M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4M7 10l5 5 5-5M12 15V3"),
+        fill = null,
+        stroke = strokeRound,
+        strokeLineWidth = 2f,
+        strokeLineCap = StrokeCap.Round,
+        strokeLineJoin = StrokeJoin.Round
+    )
+}.build()
 
 internal val ExpandMoreVector: ImageVector = ImageVector.Builder(
     name = "ExpandableChevronDown",

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/word/WordDetailsComponents.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/word/WordDetailsComponents.kt
@@ -1,5 +1,6 @@
 package com.slovy.slovymovyapp.ui.word
 
+import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
@@ -152,7 +153,7 @@ internal fun HighlightedText(
         fontWeight = FontWeight.Medium,
         textDecoration = TextDecoration.Underline
     )
-    val annotated = remember(text, clickableWords, onWordClick) {
+    val annotated = remember(text, clickableWords, onWordClick, highlight, clickableHighlight) {
         buildAnnotatedString {
             appendTextWithW(this, text, highlight, clickableHighlight, clickableWords, onWordClick)
         }
@@ -218,16 +219,17 @@ internal fun Badge(
         color = containerColor,
         contentColor = contentColor,
         shape = shape,
+        border = if (isClickable) BorderStroke(0.5.dp, contentColor.copy(alpha = 0.18f)) else null,
         modifier = if (onClick != null) {
             Modifier.clickable(onClick = onClick)
         } else Modifier
     ) {
         Row(
-            horizontalArrangement = Arrangement.spacedBy(5.dp),
+            horizontalArrangement = Arrangement.spacedBy(6.dp),
             verticalAlignment = Alignment.CenterVertically,
             modifier = Modifier.padding(
-                start = if (isFavorite) 9.dp else 11.dp,
-                end = 10.dp,
+                start = if (isClickable && isFavorite) 9.dp else if (isClickable) 11.dp else 12.dp,
+                end = if (isClickable) 8.dp else 12.dp,
                 top = 5.dp,
                 bottom = 5.dp
             )

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/word/WordDetailsComponents.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/word/WordDetailsComponents.kt
@@ -29,7 +29,7 @@ import com.slovy.slovymovyapp.data.util.HtmlTagParser
 internal const val CLICKABLE_WORD_TAG_PREFIX = "CLICKABLE_WORD_"
 
 internal fun navigationArrow(isOnline: Boolean?): String =
-    if (isOnline == false) "›" else "›› "
+    if (isOnline == false) "›" else "››"
 
 @Composable
 internal fun SectionLabel(text: String) {

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/word/WordDetailsComponents.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/word/WordDetailsComponents.kt
@@ -7,7 +7,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ErrorOutline
 import androidx.compose.material3.*
-import androidx.compose.runtime.Composable
+import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -152,8 +152,10 @@ internal fun HighlightedText(
         fontWeight = FontWeight.Medium,
         textDecoration = TextDecoration.Underline
     )
-    val annotated = buildAnnotatedString {
-        appendTextWithW(this, text, highlight, clickableHighlight, clickableWords, onWordClick)
+    val annotated = remember(text, clickableWords, onWordClick) {
+        buildAnnotatedString {
+            appendTextWithW(this, text, highlight, clickableHighlight, clickableWords, onWordClick)
+        }
     }
 
     Text(
@@ -176,31 +178,22 @@ internal fun appendTextWithW(
 
     segments.forEach { segment ->
         if (segment.isTagged) {
-            // This is a word inside <w> tags
             val word = segment.text
             val isClickable = clickableWords.any { it.equals(word, ignoreCase = true) }
             val styleToUse = if (isClickable) clickableHighlight else highlight
 
             if (isClickable) {
-                // Use LinkAnnotation for clickable words
                 val link = LinkAnnotation.Clickable(
                     tag = "$CLICKABLE_WORD_TAG_PREFIX$word",
-                    linkInteractionListener = {
-                        onWordClick(word)
-                    }
+                    linkInteractionListener = { onWordClick(word) }
                 )
                 builder.withLink(link) {
-                    builder.withStyle(styleToUse) {
-                        builder.append(word)
-                    }
+                    builder.withStyle(styleToUse) { builder.append(word) }
                 }
             } else {
-                builder.withStyle(styleToUse) {
-                    builder.append(word)
-                }
+                builder.withStyle(styleToUse) { builder.append(word) }
             }
         } else {
-            // Regular text, no highlighting
             builder.append(segment.text)
         }
     }

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/word/WordDetailsComponents.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/word/WordDetailsComponents.kt
@@ -1,6 +1,6 @@
 package com.slovy.slovymovyapp.ui.word
 
-import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -17,6 +17,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import com.slovy.slovymovyapp.data.remote.RelatedWord
 import com.slovy.slovymovyapp.data.util.HtmlTagParser
 
@@ -27,23 +28,19 @@ import com.slovy.slovymovyapp.data.util.HtmlTagParser
 internal const val CLICKABLE_WORD_TAG_PREFIX = "CLICKABLE_WORD_"
 
 internal fun navigationArrow(isOnline: Boolean?): String =
-    if (isOnline == false) "➤" else "➼"
+    if (isOnline == false) "›" else "›› "
 
 @Composable
 internal fun SectionLabel(text: String) {
-    Column(
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(top = 4.dp)
-    ) {
-        HighlightedText(
-            text = text,
-            style = MaterialTheme.typography.titleSmall.copy(
-                fontWeight = FontWeight.Bold,
-                color = MaterialTheme.colorScheme.onSurface
-            )
-        )
-    }
+    Text(
+        text = text.uppercase(),
+        style = MaterialTheme.typography.labelSmall.copy(
+            fontWeight = FontWeight.Bold,
+            letterSpacing = 1.2.sp,
+        ),
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+        modifier = Modifier.padding(top = 4.dp)
+    )
 }
 
 @OptIn(ExperimentalMaterial3ExpressiveApi::class)
@@ -114,8 +111,8 @@ internal fun EntryList(
         SectionLabel(label)
         FlowRow(
             modifier = Modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.spacedBy(8.dp),
-            verticalArrangement = Arrangement.spacedBy(8.dp)
+            horizontalArrangement = Arrangement.spacedBy(6.dp),
+            verticalArrangement = Arrangement.spacedBy(6.dp)
         ) {
             values.forEach { word ->
                 val matchingKey = relatedWords.keys.firstOrNull { it.equals(word, ignoreCase = true) }
@@ -214,8 +211,11 @@ internal fun Badge(
     text: String,
     containerColor: Color,
     contentColor: Color,
-    style: TextStyle = MaterialTheme.typography.labelMedium,
-    shape: Shape = RoundedCornerShape(6.dp),
+    style: TextStyle = MaterialTheme.typography.bodySmall.copy(
+        fontWeight = FontWeight.Medium,
+        fontSize = 13.sp
+    ),
+    shape: Shape = RoundedCornerShape(14.dp),
     isClickable: Boolean = false,
     isOnline: Boolean? = null,
     isFavorite: Boolean = false,
@@ -225,41 +225,66 @@ internal fun Badge(
         color = containerColor,
         contentColor = contentColor,
         shape = shape,
-        border = BorderStroke(
-            width = if (isClickable) 0.75.dp else 0.5.dp,
-            color = contentColor.copy(alpha = if (isClickable) 0.4f else 0.15f)
-        ),
-        tonalElevation = if (isClickable) 2.dp else 0.dp,
-        shadowElevation = if (isClickable) 1.dp else 0.dp,
         modifier = if (onClick != null) {
             Modifier.clickable(onClick = onClick)
         } else Modifier
     ) {
         Row(
-            horizontalArrangement = Arrangement.spacedBy(4.dp),
+            horizontalArrangement = Arrangement.spacedBy(5.dp),
             verticalAlignment = Alignment.CenterVertically,
-            modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp)
+            modifier = Modifier.padding(
+                start = if (isFavorite) 9.dp else 11.dp,
+                end = 10.dp,
+                top = 5.dp,
+                bottom = 5.dp
+            )
         ) {
             if (isFavorite) {
                 Text(
                     text = "\u2665",
-                    style = style,
+                    style = style.copy(fontSize = 11.sp),
                     color = FavoriteAccentColor
                 )
             }
             Text(
                 text = text,
-                style = style.copy(
-                    fontWeight = if (isClickable) FontWeight.Medium else style.fontWeight
-                )
+                style = style
             )
             if (isClickable) {
                 Text(
                     text = navigationArrow(isOnline),
-                    style = style.copy(fontWeight = FontWeight.Bold),
+                    style = style.copy(
+                        fontSize = 10.sp,
+                        fontWeight = FontWeight.Bold,
+                        letterSpacing = (-0.5).sp
+                    ),
                     color = contentColor.copy(alpha = 0.7f)
                 )
             }
         }
+    }
+}
+
+@Composable
+internal fun MetaBadge(
+    text: String,
+    containerColor: Color,
+    contentColor: Color,
+) {
+    Box(
+        modifier = Modifier
+            .background(containerColor, RoundedCornerShape(4.dp))
+            .padding(horizontal = 8.dp, vertical = 3.dp)
+    ) {
+        Text(
+            text = text,
+            style = MaterialTheme.typography.labelSmall.copy(
+                fontWeight = FontWeight.SemiBold,
+                fontSize = 11.sp,
+                letterSpacing = 0.3.sp,
+                lineHeight = 14.sp
+            ),
+            color = contentColor
+        )
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/word/WordDetailsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/word/WordDetailsScreen.kt
@@ -862,8 +862,7 @@ fun WordDetailScreenContent(
                     title = {
                         Row(
                             verticalAlignment = Alignment.CenterVertically,
-                            horizontalArrangement = Arrangement.Center,
-                            modifier = Modifier.graphicsLayer { alpha = titleAlpha }
+                            horizontalArrangement = Arrangement.Center
                         ) {
                             Text(
                                 text = titleText,
@@ -872,9 +871,10 @@ fun WordDetailScreenContent(
                                     letterSpacing = (-0.3).sp
                                 ),
                                 maxLines = 1,
-                                overflow = TextOverflow.Ellipsis
+                                overflow = TextOverflow.Ellipsis,
+                                modifier = Modifier.graphicsLayer { alpha = titleAlpha }
                             )
-                            if (state is WordDetailUiState.Content) {
+                            if (showTitleInBar && state is WordDetailUiState.Content) {
                                 Spacer(modifier = Modifier.width(8.dp))
                                 IconButton(
                                     onClick = { if (isPlaying) onStopWord() else onPlayWord() },

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/word/WordDetailsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/word/WordDetailsScreen.kt
@@ -6,22 +6,26 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
-import androidx.compose.material.icons.automirrored.filled.VolumeUp
 import androidx.compose.material.icons.filled.StopCircle
 import androidx.compose.material.icons.outlined.Flag
 import androidx.compose.material3.*
 import androidx.compose.material3.pulltorefresh.PullToRefreshBox
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.tween
 import androidx.compose.runtime.*
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.layout.positionInWindow
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.slovy.slovymovyapp.data.Language
@@ -844,71 +848,50 @@ fun WordDetailScreenContent(
         is WordDetailUiState.Content -> state.card.lemma
         is WordDetailUiState.Empty -> state.lemma ?: fallbackTitle
     }
+    val density = LocalDensity.current
+    val heroThresholdPx = remember(density) { with(density) { 80.dp.toPx() } }
+    val showTitleInBar = state is WordDetailUiState.Empty || scrollState.value > heroThresholdPx
+    val titleAlpha by animateFloatAsState(
+        targetValue = if (showTitleInBar) 1f else 0f,
+        animationSpec = tween(durationMillis = 150),
+        label = "titleAlpha"
+    )
 
     Scaffold(
         topBar = {
-            CenterAlignedTopAppBar(
-                title = {
-                    Row(
-                        verticalAlignment = Alignment.CenterVertically,
-                        horizontalArrangement = Arrangement.Center
-                    ) {
-                        when (state) {
-                            is WordDetailUiState.Content ->
-                                Text(
-                                    text = state.card.lemma,
-                                    style = MaterialTheme.typography.headlineSmall.copy(
-                                        fontWeight = FontWeight.SemiBold
-                                    ),
-                                    maxLines = 1,
-                                    softWrap = false,
-                                    overflow = TextOverflow.Ellipsis
-                                )
-
-                            is WordDetailUiState.Empty -> HighlightedText(
+            Column {
+                CenterAlignedTopAppBar(
+                    title = {
+                        if (showTitleInBar) {
+                            Text(
                                 text = titleText,
-                                style = MaterialTheme.typography.headlineSmall.copy(
-                                    fontWeight = FontWeight.SemiBold
+                                style = MaterialTheme.typography.titleLarge.copy(
+                                    fontWeight = FontWeight.Medium,
+                                    letterSpacing = (-0.3).sp
                                 ),
-                                textAlign = TextAlign.Center
+                                textAlign = TextAlign.Center,
+                                maxLines = 1,
+                                overflow = TextOverflow.Ellipsis,
+                                modifier = Modifier.graphicsLayer { alpha = titleAlpha }
                             )
                         }
-
-                        if (state is WordDetailUiState.Content) {
-                            Spacer(modifier = Modifier.width(8.dp))
-                            IconButton(
-                                onClick = { if (isPlaying) onStopWord() else onPlayWord() },
-                                enabled = canPlay && !isPreparing,
-                                modifier = Modifier.size(36.dp)
-                            ) {
-                                when {
-                                    isPreparing -> CircularProgressIndicator(
-                                        modifier = Modifier.size(24.dp),
-                                        strokeWidth = 2.dp
-                                    )
-
-                                    else -> Icon(
-                                        imageVector = if (isPlaying) Icons.Filled.StopCircle else Icons.AutoMirrored.Filled.VolumeUp,
-                                        contentDescription = if (isPlaying) "Stop" else "Play word",
-                                        tint = MaterialTheme.colorScheme.primary
-                                    )
-                                }
-                            }
-                        }
-                    }
-                },
-                navigationIcon = {
-                    IconButton(onClick = onBack) {
-                        Icon(
-                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
-                            contentDescription = "Back"
+                    },
+                    navigationIcon = {
+                        IconButton(onClick = onBack) {
+                            Icon(
+                                imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                                contentDescription = "Back"
                         )
                     }
                 },
-                colors = TopAppBarDefaults.topAppBarColors(
-                    containerColor = MaterialTheme.colorScheme.background
+                    colors = TopAppBarDefaults.topAppBarColors(
+                        containerColor = MaterialTheme.colorScheme.background
+                    )
                 )
-            )
+                HorizontalDivider(
+                    color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = titleAlpha * 0.6f)
+                )
+            }
         },
         bottomBar = {
             AppNavigationBar(
@@ -936,11 +919,16 @@ fun WordDetailScreenContent(
                         modifier = Modifier
                             .fillMaxSize()
                             .verticalScroll(scrollState)
-                            .padding(start = 12.dp, end = 12.dp, top = 8.dp, bottom = 20.dp),
+                            .padding(bottom = 20.dp),
                         cardLoading = state.cardLoading,
                         cardError = state.cardError,
                         translationLoading = state.translationLoading,
                         translationError = state.translationError,
+                        isPlaying = isPlaying,
+                        isPreparing = isPreparing,
+                        canPlay = canPlay,
+                        onPlayWord = onPlayWord,
+                        onStopWord = onStopWord,
                         onEntryToggle = onEntryToggle,
                         onFormsToggle = onFormsToggle,
                         onFormsViewSelect = onFormsViewSelect,
@@ -1017,6 +1005,11 @@ private fun WordDetailContent(
     cardError: String? = null,
     translationLoading: Boolean = false,
     translationError: String? = null,
+    isPlaying: Boolean = false,
+    isPreparing: Boolean = false,
+    canPlay: Boolean = false,
+    onPlayWord: () -> Unit = {},
+    onStopWord: () -> Unit = {},
     onEntryToggle: (String) -> Unit,
     onFormsToggle: (String) -> Unit,
     onFormsViewSelect: (String, String) -> Unit,
@@ -1034,8 +1027,66 @@ private fun WordDetailContent(
         modifier = modifier.onGloballyPositioned { coordinates ->
             scrollContainerY = coordinates.positionInWindow().y
         },
-        verticalArrangement = Arrangement.spacedBy(8.dp),
     ) {
+        // Hero lemma
+        var lemmaFontSize by remember(card.lemma) { mutableStateOf(42.sp) }
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(start = 20.dp, end = 12.dp, top = 8.dp, bottom = 16.dp),
+            verticalAlignment = Alignment.Bottom,
+            horizontalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            Text(
+                text = card.lemma,
+                style = MaterialTheme.typography.displaySmall.copy(
+                    fontSize = lemmaFontSize,
+                    fontWeight = FontWeight.Medium,
+                    lineHeight = (lemmaFontSize.value * 1.05f).sp,
+                    letterSpacing = (-0.3).sp
+                ),
+                color = MaterialTheme.colorScheme.onSurface,
+                maxLines = 1,
+                overflow = TextOverflow.Clip,
+                modifier = Modifier.weight(1f, fill = false),
+                onTextLayout = { result ->
+                    if (result.hasVisualOverflow && lemmaFontSize > 22.sp) {
+                        lemmaFontSize = (lemmaFontSize.value * 0.9f).sp
+                    }
+                }
+            )
+            IconButton(
+                onClick = { if (isPlaying) onStopWord() else onPlayWord() },
+                enabled = canPlay && !isPreparing,
+                modifier = Modifier
+                    .padding(bottom = 4.dp)
+                    .size(36.dp)
+            ) {
+                when {
+                    isPreparing -> CircularProgressIndicator(
+                        modifier = Modifier.size(20.dp),
+                        strokeWidth = 2.dp,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                    else -> Icon(
+                        imageVector = if (isPlaying) Icons.Filled.StopCircle else SpeakerVector,
+                        contentDescription = if (isPlaying) "Stop" else "Play word",
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant
+                            .copy(alpha = if (canPlay) 1f else 0.38f)
+                    )
+                }
+            }
+        }
+
+        ChapterRule()
+
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(start = 16.dp, end = 16.dp, top = 0.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+
         if (card.entries.isEmpty()) {
             Text(
                 text = "No entries available.",
@@ -1122,5 +1173,32 @@ private fun WordDetailContent(
                 style = MaterialTheme.typography.bodyMedium
             )
         }
+        } // end inner content Column
+    }
+}
+
+@Composable
+private fun ChapterRule() {
+    val color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.45f)
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(start = 40.dp, end = 40.dp, top = 2.dp, bottom = 8.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        HorizontalDivider(
+            modifier = Modifier.weight(1f),
+            color = color.copy(alpha = 0.45f * 0.35f)
+        )
+        Icon(
+            imageVector = ChapterDiamondVector,
+            contentDescription = null,
+            modifier = Modifier.padding(horizontal = 8.dp),
+            tint = color
+        )
+        HorizontalDivider(
+            modifier = Modifier.weight(1f),
+            color = color.copy(alpha = 0.45f * 0.35f)
+        )
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/word/WordDetailsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/word/WordDetailsScreen.kt
@@ -792,7 +792,6 @@ fun WordDetailScreen(
         onFeedbackCommentChange = { viewModel.updateFeedbackComment(it) },
         onFeedbackEmailChange = { viewModel.updateFeedbackEmail(it) },
         onSubmitFeedback = { viewModel.submitFeedback() },
-        onEntryToggle = { entryId -> viewModel.toggleEntry(entryId) },
         onFormsToggle = { entryId -> viewModel.toggleForms(entryId) },
         onFormsViewSelect = { entryId, viewId -> viewModel.selectFormsView(entryId, viewId) },
         onSenseToggle = { entryId, senseId -> viewModel.toggleSense(entryId, senseId) },
@@ -834,7 +833,6 @@ fun WordDetailScreenContent(
     onFeedbackCommentChange: (String) -> Unit = {},
     onFeedbackEmailChange: (String) -> Unit = {},
     onSubmitFeedback: () -> Unit = {},
-    onEntryToggle: (String) -> Unit = {},
     onFormsToggle: (String) -> Unit = {},
     onFormsViewSelect: (String, String) -> Unit = { _, _ -> },
     onSenseToggle: (String, String) -> Unit = { _, _ -> },
@@ -862,18 +860,42 @@ fun WordDetailScreenContent(
             Column {
                 CenterAlignedTopAppBar(
                     title = {
-                        if (showTitleInBar) {
+                        Row(
+                            verticalAlignment = Alignment.CenterVertically,
+                            horizontalArrangement = Arrangement.Center,
+                            modifier = Modifier.graphicsLayer { alpha = titleAlpha }
+                        ) {
                             Text(
                                 text = titleText,
                                 style = MaterialTheme.typography.titleLarge.copy(
                                     fontWeight = FontWeight.Medium,
                                     letterSpacing = (-0.3).sp
                                 ),
-                                textAlign = TextAlign.Center,
                                 maxLines = 1,
-                                overflow = TextOverflow.Ellipsis,
-                                modifier = Modifier.graphicsLayer { alpha = titleAlpha }
+                                overflow = TextOverflow.Ellipsis
                             )
+                            if (state is WordDetailUiState.Content) {
+                                Spacer(modifier = Modifier.width(8.dp))
+                                IconButton(
+                                    onClick = { if (isPlaying) onStopWord() else onPlayWord() },
+                                    enabled = canPlay && !isPreparing,
+                                    modifier = Modifier.size(36.dp)
+                                ) {
+                                    when {
+                                        isPreparing -> CircularProgressIndicator(
+                                            modifier = Modifier.size(20.dp),
+                                            strokeWidth = 2.dp,
+                                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                                        )
+                                        else -> Icon(
+                                            imageVector = if (isPlaying) Icons.Filled.StopCircle else SpeakerVector,
+                                            contentDescription = if (isPlaying) "Stop" else "Play word",
+                                            tint = MaterialTheme.colorScheme.onSurfaceVariant
+                                                .copy(alpha = if (canPlay) 1f else 0.38f)
+                                        )
+                                    }
+                                }
+                            }
                         }
                     },
                     navigationIcon = {
@@ -881,9 +903,9 @@ fun WordDetailScreenContent(
                             Icon(
                                 imageVector = Icons.AutoMirrored.Filled.ArrowBack,
                                 contentDescription = "Back"
-                        )
-                    }
-                },
+                            )
+                        }
+                    },
                     colors = TopAppBarDefaults.topAppBarColors(
                         containerColor = MaterialTheme.colorScheme.background
                     )
@@ -929,7 +951,6 @@ fun WordDetailScreenContent(
                         canPlay = canPlay,
                         onPlayWord = onPlayWord,
                         onStopWord = onStopWord,
-                        onEntryToggle = onEntryToggle,
                         onFormsToggle = onFormsToggle,
                         onFormsViewSelect = onFormsViewSelect,
                         onSenseToggle = onSenseToggle,
@@ -1010,7 +1031,6 @@ private fun WordDetailContent(
     canPlay: Boolean = false,
     onPlayWord: () -> Unit = {},
     onStopWord: () -> Unit = {},
-    onEntryToggle: (String) -> Unit,
     onFormsToggle: (String) -> Unit,
     onFormsViewSelect: (String, String) -> Unit,
     onSenseToggle: (String, String) -> Unit,

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/word/WordDetailsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/word/WordDetailsScreen.kt
@@ -1115,7 +1115,6 @@ private fun WordDetailContent(
                     cardError = cardError,
                     translationLoading = translationLoading,
                     translationError = translationError,
-                    onEntryToggle = { onEntryToggle(entryState.entryId) },
                     onFormsToggle = { onFormsToggle(entryState.entryId) },
                     onFormsViewSelect = { viewId -> onFormsViewSelect(entryState.entryId, viewId) },
                     onSenseToggle = { senseId -> onSenseToggle(entryState.entryId, senseId) },

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/word/WordDetailsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/word/WordDetailsScreen.kt
@@ -838,7 +838,7 @@ fun WordDetailScreenContent(
     val density = LocalDensity.current
     val heroThresholdPx = remember(density) { mutableFloatStateOf(with(density) { 80.dp.toPx() }) }
     val isEmptyState = state is WordDetailUiState.Empty
-    val showTitleInBar by remember(isEmptyState) {
+    val showTitleInBar by remember(isEmptyState, scrollState) {
         derivedStateOf { isEmptyState || scrollState.value > heroThresholdPx.value }
     }
     val titleAlpha by animateFloatAsState(
@@ -1048,7 +1048,10 @@ private fun WordDetailContent(
                 if (size.height > 0) onHeroMeasured(size.height.toFloat())
             }
         ) {
-        var lemmaFontSize by remember(card.lemma) { mutableStateOf(42.sp) }
+        val fontScale = LocalDensity.current.fontScale
+        BoxWithConstraints(modifier = Modifier.fillMaxWidth()) {
+        val maxWidth = constraints.maxWidth
+        var lemmaFontSize by remember(card.lemma, maxWidth, fontScale) { mutableStateOf(42.sp) }
         Row(
             modifier = Modifier
                 .fillMaxWidth()
@@ -1066,7 +1069,7 @@ private fun WordDetailContent(
                 ),
                 color = MaterialTheme.colorScheme.onSurface,
                 maxLines = 1,
-                overflow = TextOverflow.Clip,
+                overflow = TextOverflow.Ellipsis,
                 modifier = Modifier.weight(1f, fill = false),
                 onTextLayout = { result ->
                     if (result.hasVisualOverflow && lemmaFontSize > 22.sp) {
@@ -1096,6 +1099,7 @@ private fun WordDetailContent(
                 }
             }
         }
+        } // end BoxWithConstraints
 
         ChapterRule()
         } // end hero measurement Column

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/word/WordDetailsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/word/WordDetailsScreen.kt
@@ -18,7 +18,9 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.layout.positionInWindow
+import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.text.font.FontWeight
@@ -834,9 +836,10 @@ fun WordDetailScreenContent(
         is WordDetailUiState.Empty -> state.lemma ?: fallbackTitle
     }
     val density = LocalDensity.current
-    val heroThresholdPx = remember(density) { with(density) { 80.dp.toPx() } }
-    val showTitleInBar by remember(heroThresholdPx) {
-        derivedStateOf { state is WordDetailUiState.Empty || scrollState.value > heroThresholdPx }
+    val heroThresholdPx = remember(density) { mutableFloatStateOf(with(density) { 80.dp.toPx() }) }
+    val isEmptyState = state is WordDetailUiState.Empty
+    val showTitleInBar by remember(isEmptyState) {
+        derivedStateOf { isEmptyState || scrollState.value > heroThresholdPx.value }
     }
     val titleAlpha by animateFloatAsState(
         targetValue = if (showTitleInBar) 1f else 0f,
@@ -948,7 +951,8 @@ fun WordDetailScreenContent(
                         onSenseFavoriteToggle = onSenseFavoriteToggle,
                         onWordClick = onWordClick,
                         favoriteLemmas = favoriteLemmas,
-                        onOpenFeedback = onOpenFeedback
+                        onOpenFeedback = onOpenFeedback,
+                        onHeroMeasured = { heroThresholdPx.value = it }
                     )
                 }
 
@@ -1028,7 +1032,8 @@ private fun WordDetailContent(
     onSenseFavoriteToggle: (String) -> Unit = {},
     onWordClick: (String) -> Unit = {},
     favoriteLemmas: Set<String> = emptySet(),
-    onOpenFeedback: () -> Unit = {}
+    onOpenFeedback: () -> Unit = {},
+    onHeroMeasured: (Float) -> Unit = {}
 ) {
     var scrollContainerY by remember { mutableStateOf(0f) }
 
@@ -1037,7 +1042,12 @@ private fun WordDetailContent(
             scrollContainerY = coordinates.positionInWindow().y
         },
     ) {
-        // Hero lemma
+        // Hero section — measured so the top bar threshold tracks actual layout height
+        Column(
+            modifier = Modifier.fillMaxWidth().onSizeChanged { size: IntSize ->
+                if (size.height > 0) onHeroMeasured(size.height.toFloat())
+            }
+        ) {
         var lemmaFontSize by remember(card.lemma) { mutableStateOf(42.sp) }
         Row(
             modifier = Modifier
@@ -1088,6 +1098,7 @@ private fun WordDetailContent(
         }
 
         ChapterRule()
+        } // end hero measurement Column
 
         Column(
             modifier = Modifier

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/word/WordDetailsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/word/WordDetailsScreen.kt
@@ -80,7 +80,6 @@ val WordDetailUiState.isRefreshing: Boolean
 
 data class EntryUiState(
     val entryId: String,
-    val expanded: Boolean = true,
     val formsExpanded: Boolean = false,
     val selectedFormsViewId: String? = null,
     val senses: List<SenseUiState> = emptyList()
@@ -139,7 +138,6 @@ private fun LanguageCardPosEntry.toEntryUiState(
     numPos: Int
 ): EntryUiState = EntryUiState(
     entryId = "${pos.name.lowercase()}_$index",
-    expanded = true,
     formsExpanded = false,
     selectedFormsViewId = formsViews.firstOrNull()?.view?.viewId,
     senses = senses.map {
@@ -170,9 +168,6 @@ private fun LanguageCardResponseSense.toSenseUiState(
         showFavoriteToggle = true
     )
 }
-
-private fun WordDetailUiState.Content.toggleEntry(entryId: String): WordDetailUiState.Content =
-    updateEntry(entryId) { entry -> entry.copy(expanded = !entry.expanded) }
 
 private fun WordDetailUiState.Content.toggleForms(entryId: String): WordDetailUiState.Content =
     updateEntry(entryId) { entry -> entry.copy(formsExpanded = !entry.formsExpanded) }
@@ -205,7 +200,6 @@ private fun WordDetailUiState.Content.mergeStateFrom(
         merged = merged.updateEntry(previousEntry.entryId) { entry ->
             val availableViews = availableFormsViewsByEntryId[entry.entryId].orEmpty()
             var updatedEntry = entry.copy(
-                expanded = previousEntry.expanded,
                 formsExpanded = previousEntry.formsExpanded,
                 selectedFormsViewId = resolveSelectedFormsViewId(
                     previousEntry.selectedFormsViewId,
@@ -560,13 +554,6 @@ class WordDetailViewModel(
         hasScrolledToTarget = true
     }
 
-    fun toggleEntry(entryId: String) {
-        val current = state
-        if (current is WordDetailUiState.Content) {
-            state = current.toggleEntry(entryId)
-        }
-    }
-
     fun toggleForms(entryId: String) {
         val current = state
         if (current is WordDetailUiState.Content) {
@@ -848,7 +835,9 @@ fun WordDetailScreenContent(
     }
     val density = LocalDensity.current
     val heroThresholdPx = remember(density) { with(density) { 80.dp.toPx() } }
-    val showTitleInBar = state is WordDetailUiState.Empty || scrollState.value > heroThresholdPx
+    val showTitleInBar by remember(heroThresholdPx) {
+        derivedStateOf { state is WordDetailUiState.Empty || scrollState.value > heroThresholdPx }
+    }
     val titleAlpha by animateFloatAsState(
         targetValue = if (showTitleInBar) 1f else 0f,
         animationSpec = tween(durationMillis = 150),

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/word/preview/WordDetailsPreview_Basic.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/word/preview/WordDetailsPreview_Basic.kt
@@ -26,7 +26,6 @@ private fun WordDetailScreenPreviewCollapsed(
         val base = sampleTestingCard().toContentUiState(isSenseFavorite = isSenseFavoritePreview)
         val collapsedEntries = base.entries.map { entryState ->
             entryState.copy(
-                expanded = false,
                 formsExpanded = false,
                 senses = entryState.senses.map { senseState ->
                     senseState.copy(

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/word/preview/WordDetailsPreview_EdgeCases.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/word/preview/WordDetailsPreview_EdgeCases.kt
@@ -28,7 +28,6 @@ private fun WordDetailScreenPreviewNoTranslationsAllExpanded(
         val base = sampleNoTranslationCard().toContentUiState(isSenseFavorite = isSenseFavoritePreview)
         val expanded = base.entries.map { entryState ->
             entryState.copy(
-                expanded = true,
                 formsExpanded = true,
                 senses = entryState.senses.map { senseState ->
                     senseState.copy(
@@ -54,7 +53,6 @@ private fun WordDetailScreenPreviewNoTranslationsCollapsed(
         val base = sampleNoTranslationCard().toContentUiState(isSenseFavorite = isSenseFavoritePreview)
         val collapsedEntries = base.entries.map { entryState ->
             entryState.copy(
-                expanded = false,
                 formsExpanded = false,
                 senses = entryState.senses.map { senseState ->
                     senseState.copy(
@@ -91,7 +89,6 @@ private fun WordDetailScreenPreviewMultilingualCollapsed(
         val base = sampleMultilingualCard().toContentUiState(isSenseFavorite = isSenseFavoritePreview)
         val collapsedEntries = base.entries.map { entryState ->
             entryState.copy(
-                expanded = false,
                 formsExpanded = false,
                 senses = entryState.senses.map { senseState ->
                     senseState.copy(

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/word/preview/WordDetailsPreview_FormsGrid.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/word/preview/WordDetailsPreview_FormsGrid.kt
@@ -128,7 +128,6 @@ private fun formsFocusedState(
         entries = base.entries.mapIndexed { index, entryState ->
             if (index == 0) {
                 entryState.copy(
-                    expanded = true,
                     formsExpanded = formsExpanded,
                     selectedFormsViewId = selectedViewId ?: entryState.selectedFormsViewId,
                     senses = entryState.senses.map { senseState ->
@@ -140,7 +139,7 @@ private fun formsFocusedState(
                     }
                 )
             } else {
-                entryState.copy(expanded = false, formsExpanded = false)
+                entryState.copy(formsExpanded = false)
             }
         }
     )

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/word/preview/WordDetailsPreview_UIStates.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/word/preview/WordDetailsPreview_UIStates.kt
@@ -63,7 +63,6 @@ private fun WordDetailScreenPreviewPartiallyExpanded(
         val base = sampleMultilingualCard().toContentUiState(isSenseFavorite = isSenseFavoritePreview)
         val mixedEntries = base.entries.mapIndexed { entryIndex, entryState ->
             entryState.copy(
-                expanded = true,
                 formsExpanded = entryIndex == 0, // Only first entry has forms expanded
                 senses = entryState.senses.mapIndexed { senseIndex, senseState ->
                     senseState.copy(

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/word/preview/WordDetailsPreview_WordFamily.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/word/preview/WordDetailsPreview_WordFamily.kt
@@ -89,7 +89,6 @@ private fun WordDetailScreenPreviewWithClickableHighlightedWords(
         )
         val expanded = base.entries.map { entryState ->
             entryState.copy(
-                expanded = true,
                 formsExpanded = true,
                 senses = entryState.senses.map { senseState ->
                     senseState.copy(

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/word/preview/WordDetailsPreview_Words.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/word/preview/WordDetailsPreview_Words.kt
@@ -28,7 +28,6 @@ private fun WordDetailScreenPreviewAmazonCollapsed(
         val base = sampleAmazonCard().toContentUiState(isSenseFavorite = isSenseFavoritePreview)
         val collapsedEntries = base.entries.map { entryState ->
             entryState.copy(
-                expanded = false,
                 formsExpanded = false,
                 senses = entryState.senses.map { senseState ->
                     senseState.copy(
@@ -65,7 +64,6 @@ private fun WordDetailScreenPreviewCelebrationCollapsed(
         val base = sampleCelebrationCard().toContentUiState(isSenseFavorite = isSenseFavoritePreview)
         val collapsedEntries = base.entries.map { entryState ->
             entryState.copy(
-                expanded = false,
                 formsExpanded = false,
                 senses = entryState.senses.map { senseState ->
                     senseState.copy(
@@ -102,7 +100,6 @@ private fun WordDetailScreenPreviewProgrammaticallyCollapsed(
         val base = sampleProgrammaticallyCard().toContentUiState(isSenseFavorite = isSenseFavoritePreview)
         val collapsedEntries = base.entries.map { entryState ->
             entryState.copy(
-                expanded = false,
                 formsExpanded = false,
                 senses = entryState.senses.map { senseState ->
                     senseState.copy(
@@ -139,7 +136,6 @@ private fun WordDetailScreenPreviewRichmondCollapsed(
         val base = sampleRichmondCard().toContentUiState(isSenseFavorite = isSenseFavoritePreview)
         val collapsedEntries = base.entries.map { entryState ->
             entryState.copy(
-                expanded = false,
                 formsExpanded = false,
                 senses = entryState.senses.map { senseState ->
                     senseState.copy(
@@ -176,7 +172,6 @@ private fun WordDetailScreenPreviewKwartierCollapsed(
         val base = sampleKwartierCard().toContentUiState(isSenseFavorite = isSenseFavoritePreview)
         val collapsedEntries = base.entries.map { entryState ->
             entryState.copy(
-                expanded = false,
                 formsExpanded = false,
                 senses = entryState.senses.map { senseState ->
                     senseState.copy(
@@ -213,7 +208,6 @@ private fun WordDetailScreenPreviewProgrammaCollapsed(
         val base = sampleProgrammaCard().toContentUiState(isSenseFavorite = isSenseFavoritePreview)
         val collapsedEntries = base.entries.map { entryState ->
             entryState.copy(
-                expanded = false,
                 formsExpanded = false,
                 senses = entryState.senses.map { senseState ->
                     senseState.copy(


### PR DESCRIPTION
## Summary

- **Word details screen**: hero lemma with auto-shrinking font + TTS button; scroll-triggered top bar with fade title and TTS (only composed when visible, so invisible state can't be tapped or found by accessibility); diamond `ChapterRule` divider between hero and entries
- **EntryCard**: removed POS-level expand/collapse; Forms chip in header toggles the grammar table; correct spacing with/without forms
- **SenseCard**: target-language definition shown first (bodyLarge), source-language second (bodyMedium); both support word navigation; examples no longer italic; level/frequency/nameType use new `MetaBadge`
- **Chips**: `Badge` redesigned — 14dp radius, no shadow, border only on tappable pills; `MetaBadge` added for non-interactive metadata; `SectionLabel` updated to uppercase label style
- **Icons**: custom `SpeakerVector`, `DownloadVector`, `ChapterDiamondVector` added; `DownloadForOffline` material icon replaced with custom stroked `DownloadVector`
- **PartOfSpeechIndicator**: vertical bar replaced with 7dp dot; label combines POS + sense count in one uppercase string
- **Bug fixes**: `remember` key includes SpanStyle objects to prevent stale annotated strings on theme switch; search result online-only icon now shows even when item is also a favorite; dead `onEntryToggle` parameter removed

## Test plan

- [ ] Word details: lemma hero visible on load, top bar title + TTS fade in on scroll, TTS not tappable before hero collapses
- [ ] TTS play/stop works from both hero and top bar
- [ ] Forms chip toggles grammar table; no expand/collapse chevron on POS row
- [ ] Word navigation works in definitions across all languages (EN, NL, PL, RU)
- [ ] Theme switch: `<w>`-tagged words rerender with correct colors in both light and dark
- [ ] Search results: item that is both favorite and online-only shows both icons

🤖 Generated with [Claude Code](https://claude.com/claude-code)