### PR TITLE
fix: restore heart glyph rendering in word family / synonym chips

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/word/WordDetailsComponents.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/word/WordDetailsComponents.kt
@@ -14,6 +14,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.text.*
+import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import com.slovy.slovymovyapp.ui.theme.serifFontFamily
@@ -239,7 +240,7 @@ internal fun Badge(
             if (isFavorite) {
                 Text(
                     text = "\u2665",
-                    style = style.copy(fontSize = 11.sp),
+                    style = style.copy(fontSize = 11.sp, fontFamily = FontFamily.Default),
                     color = FavoriteAccentColor
                 )
             }


### PR DESCRIPTION
## Summary

- The Lora serif font added to `Badge`'s default text style caused the ♥ character in word family / synonym / antonym chips to render using Lora's glyph, visually altering its appearance
- Fix: explicitly set `fontFamily = FontFamily.Default` on the heart character so it always renders with the system font, regardless of the pill text style

## Test plan

- [ ] Open a word with word family / synonyms / antonyms — heart icon on saved words looks identical to before the Lora typography PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)