### PR TITLE
fix: strip <w> tags from plain-text LLM output fields

### DIFF
--- a/server/src/main/kotlin/com/slovy/slovymovyapp/server/ai/enhancer/LanguageCardEnhancer.kt
+++ b/server/src/main/kotlin/com/slovy/slovymovyapp/server/ai/enhancer/LanguageCardEnhancer.kt
@@ -76,8 +76,25 @@ class LanguageCardEnhancer {
         )
         val decodedResponse = Json.decodeFromString<LanguageCardResponse>(response)
         validateSenseIds(request, decodedResponse)
-        return decodedResponse
+        return decodedResponse.stripWTags()
     }
+
+    private fun String.stripWTags(): String = replace(Regex("</?w>"), "")
+
+    private fun LanguageCardResponse.stripWTags(): LanguageCardResponse = copy(
+        wordFamily = wordFamily?.map { it.stripWTags() },
+        entries = entries.map { entry ->
+            entry.copy(
+                senses = entry.senses.map { sense ->
+                    sense.copy(
+                        synonyms = sense.synonyms.map { it.stripWTags() },
+                        antonyms = sense.antonyms.map { it.stripWTags() },
+                        commonPhrases = sense.commonPhrases.map { it.stripWTags() }
+                    )
+                }
+            )
+        }
+    )
 
     /**
      * Builds the JSON schema for the language card response based on the request data.

--- a/server/src/test/kotlin/com/slovy/slovymovyapp/server/ai/enhancer/LanguageCardEnhancerTest.kt
+++ b/server/src/test/kotlin/com/slovy/slovymovyapp/server/ai/enhancer/LanguageCardEnhancerTest.kt
@@ -1,7 +1,9 @@
 package com.slovy.slovymovyapp.server.ai.enhancer
 
+import com.slovy.slovymovyapp.server.ai.*
 import com.slovy.slovymovyapp.server.ai.AIProviderType
 import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 
@@ -33,6 +35,58 @@ class LanguageCardEnhancerTest : BaseLLMTest() {
             assertTrue(firstSense.learnerLevel.isNotBlank(), "Learner level should not be blank")
             assertTrue(firstSense.frequency.isNotBlank(), "Frequency should not be blank")
         }
+    }
+
+    @Test
+    fun enhance_stripsWTagsFromAllPlainTextFields() {
+        val senseId = "abc123"
+        val taggedJson = """
+            {
+              "word_family": ["<w>runner</w>", "run"],
+              "entries": [{
+                "pos": "verb",
+                "senses": [{
+                  "sense_id": "$senseId",
+                  "sense_definition": "to <w>move</w> quickly",
+                  "learner_level": "A1",
+                  "frequency": "High",
+                  "semantic_group_id": "motion",
+                  "synonyms": ["<w>sprint</w>", "dash"],
+                  "antonyms": ["<w>walk</w>"],
+                  "common_phrases": ["<w>run away</w>", "run wild"]
+                }]
+              }]
+            }
+        """.trimIndent()
+
+        val fakeProvider = object : AIProvider {
+            override fun complete(parameters: AIParameters, cache: AICache, retryStrategy: RetryStrategy) = taggedJson
+            override fun getAvailableModels() = emptyList<ModelInfo>()
+            override fun isAvailable() = true
+            override fun countTokens(text: String, model: String) = 0
+        }
+
+        val request = LanguageCardRequest(
+            word = "run", langCode = "en",
+            entries = listOf(
+                LanguageCardEntry(
+                    pos = "verb",
+                    senses = listOf(LanguageCardSense(senseId = senseId, glosses = listOf("to move quickly")))
+                )
+            )
+        )
+
+        val response = LanguageCardEnhancer().enhance(request, fakeProvider, model = "fake")
+
+        // sense_definition and examples keep <w> markup (intentional highlighting)
+        assertEquals("to <w>move</w> quickly", response.entries[0].senses[0].senseDefinition)
+
+        // plain-text fields must have all <w> tags stripped
+        val sense = response.entries[0].senses[0]
+        assertEquals(listOf("sprint", "dash"), sense.synonyms)
+        assertEquals(listOf("walk"), sense.antonyms)
+        assertEquals(listOf("run away", "run wild"), sense.commonPhrases)
+        assertEquals(listOf("runner", "run"), response.wordFamily)
     }
 
     @Test


### PR DESCRIPTION
## Summary
LLM occasionally wraps plain-text fields in `<w>...</w>` markup. Strip those tags in `LanguageCardEnhancer` immediately after decoding the response, so bad markup never reaches stored JSON or downloaded databases.

Fields stripped: `synonyms`, `antonyms`, `common_phrases`, `word_family` — all fields that must remain plain text.

`sense_definition` and `examples` are intentionally left untouched — they use `<w>` markup for legitimate word highlighting.

## Test plan
- [ ] `./gradlew :server:test --tests "*.LanguageCardEnhancerTest.enhance_stripsWTagsFromAllPlainTextFields"` passes
- [ ] Unit test uses a fake `AIProvider` and verifies all plain-text fields are stripped while `sense_definition` keeps its markup

🤖 Generated with [Claude Code](https://claude.com/claude-code)