### PR TITLE
fix: standalone lemma in local DB overrides RO form-fallback

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/data/remote/DictionaryRepository.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/data/remote/DictionaryRepository.kt
@@ -212,6 +212,7 @@ class DictionaryRepository(
     }
 
     // Loads related words from all databases. Offline rows replace online-only rows.
+    // Direct lemma hits always beat form-fallback results, even offline ones from an earlier DB.
     private fun loadRelatedWords(
         databases: List<DictionaryDatabase>,
         language: Language,
@@ -222,10 +223,23 @@ class DictionaryRepository(
         val result = mutableMapOf<String, RelatedWord>()
         // Normalize to lowercase for case-insensitive matching (DB stores lemmas lowercase)
         val lookupWords = relatedWords.map { it.lowercase() }.toSet()
+        // Forms confirmed as standalone lemmas — the fallback must never redirect these to a parent.
+        val foundAsLemmaKeys = mutableSetOf<String>()
+        // Keys whose current result came from a form-fallback; a direct lemma hit may still override them.
+        val formFallbackKeys = mutableSetOf<String>()
 
-        fun putIfMissingOrOnline(key: String, relatedWord: RelatedWord) {
+        fun putFromLemma(key: String, relatedWord: RelatedWord) {
+            // A direct lemma hit wins over: (1) any online-only result, (2) any form-fallback result.
+            if (result[key]?.online != false || key in formFallbackKeys) {
+                result[key] = relatedWord
+                formFallbackKeys.remove(key)
+            }
+        }
+
+        fun putFromFallback(key: String, relatedWord: RelatedWord) {
             if (result[key]?.online != false) {
                 result[key] = relatedWord
+                formFallbackKeys.add(key)
             }
         }
 
@@ -234,20 +248,20 @@ class DictionaryRepository(
             q.selectLemmasByWords(language.code, lookupWords.toList())
                 .executeAsList()
                 .forEach { row ->
-                    putIfMissingOrOnline(
-                        row.lemma,
-                        relatedWord(row.lemma, row.zipf_frequency, row.online_only)
-                    )
+                    putFromLemma(row.lemma, relatedWord(row.lemma, row.zipf_frequency, row.online_only))
+                    foundAsLemmaKeys.add(row.lemma)
                 }
 
             // Fallback: resolve inflected forms (e.g. "Gebogen" → parent lemma "buigen").
+            // Only applies to forms that are not standalone lemmas; standalone lemmas navigate
+            // to themselves regardless of online/offline status.
             // Keep the form as the map key so chip text stays unchanged, while
             // RelatedWord.lemma points navigation at the parent lemma.
             lookupWords
-                .filter { form -> result[form]?.online != false }
+                .filter { form -> form !in foundAsLemmaKeys }
                 .forEach { form ->
                     q.resolveRelatedForm(language, form)?.let { relatedWord ->
-                        putIfMissingOrOnline(form, relatedWord)
+                        putFromFallback(form, relatedWord)
                     }
                 }
         }

--- a/composeApp/src/commonTest/kotlin/com/slovy/slovymovyapp/repo/DictionaryRepositoryTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/slovy/slovymovyapp/repo/DictionaryRepositoryTest.kt
@@ -6,7 +6,9 @@ import com.slovy.slovymovyapp.data.dictionary.FormSource
 import com.slovy.slovymovyapp.data.dictionary.LearnerLevel
 import com.slovy.slovymovyapp.data.dictionary.SenseFrequency
 import com.slovy.slovymovyapp.data.favorites.FavoritesRepository
+import com.slovy.slovymovyapp.data.db.DatabaseProvider
 import com.slovy.slovymovyapp.data.local.LocalDbManager
+import com.slovy.slovymovyapp.data.remote.DataDbManager
 import com.slovy.slovymovyapp.data.remote.DictionaryRepository
 import com.slovy.slovymovyapp.data.remote.PartOfSpeech
 import com.slovy.slovymovyapp.data.settings.Setting
@@ -768,6 +770,145 @@ class DictionaryRepositoryTest : BaseTest() {
             assertEquals(5, newSuggestions.size, "Should still return 5 suggestions after excluding favorite")
         } finally {
             runBlocking { mgr.deleteDictionary(Language.ENGLISH) }
+        }
+    }
+
+    @Test
+    fun loadRelatedWords_does_not_redirect_lemma_to_parent_when_also_a_form() {
+        // "vergieten" is both a standalone lemma (verb, online-only) and a form of "vergiet" (noun plural).
+        // When viewing "vergiet", the family chip for "vergieten" must navigate to the verb lemma
+        // "vergieten", not be hijacked by the form-fallback into navigating back to "vergiet".
+        val platform = testPlatformDbSupport()
+        val mgr = testDataDbManager()
+        val localMgr = testLocalDbManager()
+
+        runBlocking { mgr.deleteDictionary(Language.DUTCH) }
+
+        val localDictPath = platform.getDatabasePath(LocalDbManager.LOCAL_DICTIONARY_FILENAME)
+        if (platform.fileExists(localDictPath)) platform.deleteFile(localDictPath)
+
+        try {
+            val q = localMgr.openLocalDictionary().dictionaryQueries
+
+            // "vergiet" (noun, offline) — the card we request; "vergieten" is its plural form
+            // and also its family member.  Higher zipf so it wins the form query ORDER BY.
+            val nounId = Uuid.random()
+            val nounPosId = Uuid.random()
+            q.insertLemma(nounId, "nl", "vergiet", "vergiet", 5.0, false)
+            q.insertLemmaPos(nounPosId, nounId, DictionaryPos.NOUN)
+            q.insertSense(
+                sense_id = Uuid.random(),
+                lemma_pos_id = nounPosId,
+                sense_definition = "colander",
+                learner_level = LearnerLevel.A2,
+                frequency = SenseFrequency.MIDDLE,
+                semantic_group_id = "g1",
+                name_type = null
+            )
+            q.insertForm(Uuid.random(), nounPosId, "vergieten", "vergieten", FormSource.NATIVE)
+            q.insertLemmaWordFamily(nounId, "vergieten")
+
+            // "vergieten" (verb, online-only) — a standalone lemma that shares its text with the
+            // noun's plural form.  Online-only so it would previously trigger the fallback.
+            val verbId = Uuid.random()
+            val verbPosId = Uuid.random()
+            q.insertLemma(verbId, "nl", "vergieten", "vergieten", 4.0, true)
+            q.insertLemmaPos(verbPosId, verbId, DictionaryPos.VERB)
+            q.insertSense(
+                sense_id = Uuid.random(),
+                lemma_pos_id = verbPosId,
+                sense_definition = "to spill",
+                learner_level = LearnerLevel.B1,
+                frequency = SenseFrequency.MIDDLE,
+                semantic_group_id = "g2",
+                name_type = null
+            )
+
+            val repo = DictionaryRepository(mgr, localMgr, favoritesRepository(), settingsRepository())
+            val card = runBlocking { repo.getLanguageCard(Language.DUTCH, "vergiet") }
+            assertNotNull(card, "Card should be built for 'vergiet'")
+
+            val resolved = card.relatedWords["vergieten"]
+            assertNotNull(resolved, "'vergieten' must be present in relatedWords of 'vergiet'")
+            assertEquals(
+                "vergieten", resolved.lemma,
+                "Online-only lemma 'vergieten' must not be redirected by form-fallback to parent 'vergiet'"
+            )
+        } finally {
+            localMgr.closeAll()
+            if (platform.fileExists(localDictPath)) platform.deleteFile(localDictPath)
+        }
+    }
+
+    @Test
+    fun loadRelatedWords_local_standalone_lemma_overrides_ro_form_fallback() {
+        // "vergieten" appears only as a form of "vergiet" in the RO database (no standalone lemma
+        // there), and as a standalone offline lemma in the local database.
+        // The RO-first pass fires the form-fallback and writes an offline result pointing to
+        // "vergiet". The subsequent local pass must replace it with the direct lemma hit
+        // pointing to "vergieten", even though both results are offline.
+        val platform = testPlatformDbSupport()
+        val mgr = testDataDbManager()
+        val localMgr = testLocalDbManager()
+
+        runBlocking { mgr.deleteDictionary(Language.DUTCH) }
+
+        val localDictPath = platform.getDatabasePath(LocalDbManager.LOCAL_DICTIONARY_FILENAME)
+        if (platform.fileExists(localDictPath)) platform.deleteFile(localDictPath)
+
+        val roDictPath = platform.getDatabasePath(DataDbManager.dictionaryFileName(Language.DUTCH))
+
+        try {
+            // Fake RO dictionary: "vergiet" noun with form "vergieten", no standalone "vergieten".
+            val roDriver = platform.createDictionaryDataDriver(roDictPath, readOnly = false)
+            val roQ = DatabaseProvider.createDictionaryDatabase(roDriver).dictionaryQueries
+            val nounId = Uuid.random()
+            val nounPosId = Uuid.random()
+            roQ.insertLemma(nounId, "nl", "vergiet", "vergiet", 5.0, false)
+            roQ.insertLemmaPos(nounPosId, nounId, DictionaryPos.NOUN)
+            roQ.insertSense(
+                sense_id = Uuid.random(),
+                lemma_pos_id = nounPosId,
+                sense_definition = "colander",
+                learner_level = LearnerLevel.A2,
+                frequency = SenseFrequency.MIDDLE,
+                semantic_group_id = "g1",
+                name_type = null
+            )
+            roQ.insertForm(Uuid.random(), nounPosId, "vergieten", "vergieten", FormSource.NATIVE)
+            roQ.insertLemmaWordFamily(nounId, "vergieten")
+            roDriver.close()
+
+            // Local dictionary: "vergieten" verb as a standalone offline lemma only.
+            val localQ = localMgr.openLocalDictionary().dictionaryQueries
+            val verbId = Uuid.random()
+            val verbPosId = Uuid.random()
+            localQ.insertLemma(verbId, "nl", "vergieten", "vergieten", 4.0, false)
+            localQ.insertLemmaPos(verbPosId, verbId, DictionaryPos.VERB)
+            localQ.insertSense(
+                sense_id = Uuid.random(),
+                lemma_pos_id = verbPosId,
+                sense_definition = "to spill",
+                learner_level = LearnerLevel.B1,
+                frequency = SenseFrequency.MIDDLE,
+                semantic_group_id = "g2",
+                name_type = null
+            )
+
+            val repo = DictionaryRepository(mgr, localMgr, favoritesRepository(), settingsRepository())
+            val card = runBlocking { repo.getLanguageCard(Language.DUTCH, "vergiet") }
+            assertNotNull(card, "Card should be built for 'vergiet'")
+
+            val resolved = card.relatedWords["vergieten"]
+            assertNotNull(resolved, "'vergieten' must be present in relatedWords of 'vergiet'")
+            assertEquals(
+                "vergieten", resolved.lemma,
+                "Standalone offline lemma in local DB must override the RO form-fallback result"
+            )
+        } finally {
+            localMgr.closeAll()
+            runBlocking { mgr.deleteDictionary(Language.DUTCH) }
+            if (platform.fileExists(localDictPath)) platform.deleteFile(localDictPath)
         }
     }
 


### PR DESCRIPTION
## Summary

- `loadRelatedWords` now tracks which results came from the form-fallback path (`formFallbackKeys`) so a direct lemma hit in a later database can override them, even if the form-fallback result was offline
- Split the old `putIfMissingOrOnline` into `putFromLemma` (also overrides form-fallback entries) and `putFromFallback` (marks the entry as overridable)
- Also fixed the form-fallback filter to use `foundAsLemmaKeys` instead of re-checking `result[form]?.online`, which is more correct and consistent with the new tracking

## Root cause

When the RO DB contains only the inflected-form mapping for a word (e.g. "vergieten" → parent "vergiet") and the local DB contains that same word as a standalone lemma, the RO pass fired the form-fallback first and wrote an offline `RelatedWord`. On the next local-DB pass, `putIfMissingOrOnline` refused to replace an existing offline result, so navigation still pointed to the parent lemma instead of the standalone one.

## Tests

- `loadRelatedWords_does_not_redirect_lemma_to_parent_when_also_a_form` — single DB, online-only standalone lemma
- `loadRelatedWords_local_standalone_lemma_overrides_ro_form_fallback` — mixed RO/local, both offline (the previously uncovered case)

## Test plan

- [ ] `./gradlew :composeApp:desktopTest --tests "*.DictionaryRepositoryTest.loadRelatedWords*"` passes
- [ ] Full `./gradlew :composeApp:desktopTest` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)