### PR TITLE
ui: improve dark theme card tinting and redesign word family chips

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/SearchScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/SearchScreen.kt
@@ -46,6 +46,7 @@ import com.slovy.slovymovyapp.ui.components.AppSearchBar
 import com.slovy.slovymovyapp.ui.components.EmptyState
 import com.slovy.slovymovyapp.ui.icons.SearchOtter
 import com.slovy.slovymovyapp.ui.icons.SlovyIcons
+import com.slovy.slovymovyapp.ui.theme.LocalIsDarkTheme
 import com.slovy.slovymovyapp.ui.theme.serifFontFamily
 import com.slovy.slovymovyapp.ui.word.Badge
 import com.slovy.slovymovyapp.ui.word.colorForLemma
@@ -468,7 +469,7 @@ private fun SearchResultCard(
     showLanguageIndicator: Boolean = false,
     onClick: () -> Unit
 ) {
-    val containerColor = colorForLemma(item.lemma, MaterialTheme.colorScheme.surface)
+    val containerColor = colorForLemma(item.lemma, MaterialTheme.colorScheme.surface, LocalIsDarkTheme.current)
     OutlinedCard(
         modifier = Modifier
             .fillMaxWidth()
@@ -626,7 +627,7 @@ private fun EmptySearchState(
 
 @Composable
 private fun SuggestionCard(lemma: String, onClick: () -> Unit) {
-    val containerColor = colorForLemma(lemma, MaterialTheme.colorScheme.surface)
+    val containerColor = colorForLemma(lemma, MaterialTheme.colorScheme.surface, LocalIsDarkTheme.current)
     OutlinedCard(
         modifier = Modifier
             .fillMaxWidth()

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/word/SenseCard.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/word/SenseCard.kt
@@ -29,6 +29,7 @@ import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.dp
 import com.slovy.slovymovyapp.data.Language
 import com.slovy.slovymovyapp.data.remote.*
+import com.slovy.slovymovyapp.ui.theme.LocalIsDarkTheme
 import com.slovy.slovymovyapp.ui.theme.serifFontFamily
 import org.jetbrains.compose.resources.stringResource
 import slovymovyapp.composeapp.generated.resources.*
@@ -72,7 +73,7 @@ internal fun SenseCard(
             },
         shape = MaterialTheme.shapes.small,
         colors = CardDefaults.outlinedCardColors(
-            containerColor = colorForLemma(data.lemma, MaterialTheme.colorScheme.surface)
+            containerColor = colorForLemma(data.lemma, MaterialTheme.colorScheme.surface, LocalIsDarkTheme.current)
         ),
         border = BorderStroke(0.5.dp, MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f))
     ) {
@@ -521,14 +522,22 @@ internal fun LanguageCardResponseSense.translationsHeader(): String? {
 private fun List<LanguageCardTranslation>.orderedByIdx(): List<LanguageCardTranslation> =
     sortedBy { it.idx }
 
-internal fun colorForLemma(lemma: String?, baseColor: Color): Color {
+internal fun colorForLemma(lemma: String?, baseColor: Color, isDark: Boolean = false): Color {
     if (lemma == null) return baseColor
 
     val hash = lemma.hashCode()
 
-    val hue = (hash and 0x3FF) / 1023f * 360f
+    val hue = if (isDark) {
+        200f + (hash and 0x3FF) / 1023f * 120f  // 200–320°: blue → purple
+    } else {
+        (hash and 0x3FF) / 1023f * 360f
+    }
     val saturation = 0.45f + ((hash shr 10) and 0x3F) / 63f * 0.30f
-    val lightness = 0.45f + ((hash shr 16) and 0x1F) / 31f * 0.20f
+    val lightness = if (isDark) {
+        0.55f + ((hash shr 16) and 0x1F) / 31f * 0.20f
+    } else {
+        0.45f + ((hash shr 16) and 0x1F) / 31f * 0.20f
+    }
     val tintColor = Color.hsl(hue = hue, saturation = saturation, lightness = lightness)
 
     val percent = 0.08f

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/word/WordDetailsComponents.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/word/WordDetailsComponents.kt
@@ -112,12 +112,13 @@ internal fun EntryList(
     favoriteLemmas: Set<String> = emptySet()
 ) {
     if (values.isEmpty()) return
+    val chipBorder = BorderStroke(1.dp, MaterialTheme.colorScheme.outlineVariant)
     Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
         SectionLabel(label)
         FlowRow(
             modifier = Modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.spacedBy(6.dp),
-            verticalArrangement = Arrangement.spacedBy(6.dp)
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp)
         ) {
             values.forEach { word ->
                 val matchingKey = relatedWords.keys.firstOrNull { it.equals(word, ignoreCase = true) }
@@ -127,9 +128,11 @@ internal fun EntryList(
                     text = word,
                     containerColor = containerColor,
                     contentColor = contentColor,
+                    shape = RoundedCornerShape(50),
                     isClickable = isClickable,
                     isOnline = matchingKey?.let { relatedWords[it]?.online },
                     isFavorite = favoriteLemmas.any { it.equals(resolvedLemma, ignoreCase = true) },
+                    border = chipBorder,
                     onClick = if (isClickable) {
                         { onWordClick(resolvedLemma) }
                     } else null
@@ -219,13 +222,14 @@ internal fun Badge(
     isClickable: Boolean = false,
     isOnline: Boolean? = null,
     isFavorite: Boolean = false,
+    border: BorderStroke? = if (isClickable) BorderStroke(0.5.dp, contentColor.copy(alpha = 0.18f)) else null,
     onClick: (() -> Unit)? = null
 ) {
     Surface(
         color = containerColor,
         contentColor = contentColor,
         shape = shape,
-        border = if (isClickable) BorderStroke(0.5.dp, contentColor.copy(alpha = 0.18f)) else null,
+        border = border,
         modifier = if (onClick != null) {
             Modifier.clickable(onClick = onClick)
         } else Modifier

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/word/WordDetailsComponents.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/word/WordDetailsComponents.kt
@@ -19,6 +19,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import com.slovy.slovymovyapp.ui.theme.serifFontFamily
 import androidx.compose.ui.text.style.TextDecoration
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.slovy.slovymovyapp.data.remote.RelatedWord
@@ -109,16 +110,18 @@ internal fun EntryList(
     contentColor: Color,
     relatedWords: Map<String, RelatedWord> = emptyMap(),
     onWordClick: (String) -> Unit = {},
-    favoriteLemmas: Set<String> = emptySet()
+    favoriteLemmas: Set<String> = emptySet(),
+    chipShape: Shape = RoundedCornerShape(14.dp),
+    chipBorder: BorderStroke? = null,
+    chipSpacing: Dp = 6.dp
 ) {
     if (values.isEmpty()) return
-    val chipBorder = BorderStroke(1.dp, MaterialTheme.colorScheme.outlineVariant)
     Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
         SectionLabel(label)
         FlowRow(
             modifier = Modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.spacedBy(8.dp),
-            verticalArrangement = Arrangement.spacedBy(8.dp)
+            horizontalArrangement = Arrangement.spacedBy(chipSpacing),
+            verticalArrangement = Arrangement.spacedBy(chipSpacing)
         ) {
             values.forEach { word ->
                 val matchingKey = relatedWords.keys.firstOrNull { it.equals(word, ignoreCase = true) }
@@ -128,11 +131,11 @@ internal fun EntryList(
                     text = word,
                     containerColor = containerColor,
                     contentColor = contentColor,
-                    shape = RoundedCornerShape(50),
+                    shape = chipShape,
                     isClickable = isClickable,
                     isOnline = matchingKey?.let { relatedWords[it]?.online },
                     isFavorite = favoriteLemmas.any { it.equals(resolvedLemma, ignoreCase = true) },
-                    border = chipBorder,
+                    border = chipBorder ?: if (isClickable) BorderStroke(0.5.dp, contentColor.copy(alpha = 0.18f)) else null,
                     onClick = if (isClickable) {
                         { onWordClick(resolvedLemma) }
                     } else null

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/word/WordDetailsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/word/WordDetailsScreen.kt
@@ -1178,8 +1178,8 @@ private fun WordDetailContent(
                 EntryList(
                     label = stringResource(Res.string.word_details_word_family),
                     values = card.wordFamily,
-                    containerColor = MaterialTheme.colorScheme.primaryContainer,
-                    contentColor = MaterialTheme.colorScheme.onPrimaryContainer,
+                    containerColor = MaterialTheme.colorScheme.surfaceContainerHighest,
+                    contentColor = MaterialTheme.colorScheme.onSurface,
                     relatedWords = card.relatedWords,
                     onWordClick = onWordClick,
                     favoriteLemmas = favoriteLemmas

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/word/WordDetailsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/word/WordDetailsScreen.kt
@@ -1,7 +1,9 @@
 package com.slovy.slovymovyapp.ui.word
 
+import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.ScrollState
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
@@ -1182,7 +1184,10 @@ private fun WordDetailContent(
                     contentColor = MaterialTheme.colorScheme.onSurface,
                     relatedWords = card.relatedWords,
                     onWordClick = onWordClick,
-                    favoriteLemmas = favoriteLemmas
+                    favoriteLemmas = favoriteLemmas,
+                    chipShape = RoundedCornerShape(50),
+                    chipBorder = BorderStroke(1.dp, MaterialTheme.colorScheme.outlineVariant),
+                    chipSpacing = 8.dp
                 )
             }
         }


### PR DESCRIPTION
## Summary
- `colorForLemma` now restricts hue to 200–320° (blue→purple) in dark mode and lifts lightness to 0.55–0.75 so tinted card backgrounds are visible on dark surfaces
- Word family chips redesigned: fully rounded pill, `surfaceContainerHighest` fill, `outlineVariant` hairline border, 8dp gap
- `Badge` gets an explicit `border` param (backward-compatible default) so callers can override the border independently of `isClickable`

## Test plan
- [ ] Open word details in light theme — word family chips should be warm cream pills with a hairline border
- [ ] Open word details in dark theme — chips should have a slightly elevated fill with a subtle border
- [ ] Check tinted sense cards in dark theme — hues should stay in blue/purple range and be clearly visible
- [ ] Verify language indicator badge in search results is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)