### PR TITLE
feat: mandatory re-download screen on dictionary version update (#542)

### DIFF
--- a/composeApp/src/commonMain/composeResources/values-nl/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-nl/strings.xml
@@ -95,8 +95,6 @@
     <string name="feedback_dialog_title">App-feedback</string>
     <string name="feedback_dialog_placeholder">Deel je gedachten...</string>
 
-    <string name="app_data_version_mismatch_message">We hebben het woordenboekformaat bijgewerkt. Je moet je woordenboeken opnieuw downloaden — je opgeslagen woorden zijn veilig.</string>
-
     <string name="word_details_title">Woorddetails</string>
     <string name="word_details_action_stop">Stoppen</string>
     <string name="word_details_action_play_word">Woord afspelen</string>

--- a/composeApp/src/commonMain/composeResources/values-nl/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-nl/strings.xml
@@ -54,6 +54,8 @@
     <string name="download_subtitle_downloading">Je bibliotheek wordt voorbereid.\nDit kan even duren.</string>
     <string name="download_title_setting_up">Instellen</string>
     <string name="download_subtitle_setting_up">Je bibliotheek wordt voorbereid.\nDit duurt even.</string>
+    <string name="download_title_update_required">Woordenboek bijwerken</string>
+    <string name="download_subtitle_update_required">Een verbeterde versie is klaar om te downloaden. Je opgeslagen woorden blijven precies waar je ze hebt achtergelaten.</string>
     <string name="download_content_desc_loading_info">Downloadinformatie laden</string>
     <string name="download_content_desc_preparing">Download voorbereiden</string>
     <string name="download_preparing">Voorbereiden...</string>

--- a/composeApp/src/commonMain/composeResources/values-pl/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-pl/strings.xml
@@ -54,6 +54,8 @@
     <string name="download_subtitle_downloading">Przygotowujemy Twoją bibliotekę.\nTo może chwilę potrwać.</string>
     <string name="download_title_setting_up">Konfigurowanie...</string>
     <string name="download_subtitle_setting_up">Przygotowujemy Twoją bibliotekę.\nTo potrwa tylko chwilę.</string>
+    <string name="download_title_update_required">Zaktualizuj słownik</string>
+    <string name="download_subtitle_update_required">Ulepszona wersja jest gotowa do pobrania. Twoje zapisane słowa pozostaną dokładnie tam, gdzie je zostawiłeś.</string>
     <string name="download_content_desc_loading_info">Ładowanie informacji o pobieraniu</string>
     <string name="download_content_desc_preparing">Przygotowywanie pobierania</string>
     <string name="download_preparing">Przygotowywanie...</string>

--- a/composeApp/src/commonMain/composeResources/values-pl/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-pl/strings.xml
@@ -95,8 +95,6 @@
     <string name="feedback_dialog_title">Opinia o aplikacji</string>
     <string name="feedback_dialog_placeholder">Napisz, co myślisz...</string>
 
-    <string name="app_data_version_mismatch_message">Zaktualizowaliśmy format słowników. Musisz pobrać je ponownie — Twoje zapisane słowa są bezpieczne.</string>
-
     <string name="word_details_title">O słowie</string>
     <string name="word_details_action_stop">Zatrzymaj</string>
     <string name="word_details_action_play_word">Odtwórz</string>

--- a/composeApp/src/commonMain/composeResources/values-ru/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-ru/strings.xml
@@ -95,8 +95,6 @@
     <string name="feedback_dialog_title">Отзыв о приложении</string>
     <string name="feedback_dialog_placeholder">Напишите, что вы думаете...</string>
 
-    <string name="app_data_version_mismatch_message">Мы обновили формат словарей. Их нужно скачать заново — ваши сохранённые слова в безопасности.</string>
-
     <string name="word_details_title">О слове</string>
     <string name="word_details_action_stop">Стоп</string>
     <string name="word_details_action_play_word">Прослушать</string>

--- a/composeApp/src/commonMain/composeResources/values-ru/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-ru/strings.xml
@@ -54,6 +54,8 @@
     <string name="download_subtitle_downloading">Готовим вашу библиотеку.\nЭто займёт пару минут.</string>
     <string name="download_title_setting_up">Настройка...</string>
     <string name="download_subtitle_setting_up">Готовим вашу библиотеку.\nЭто займёт пару минут.</string>
+    <string name="download_title_update_required">Обновите словарь</string>
+    <string name="download_subtitle_update_required">Улучшенная версия готова к скачиванию. Ваши сохранённые слова останутся на месте.</string>
     <string name="download_content_desc_loading_info">Получение данных...</string>
     <string name="download_content_desc_preparing">Подготовка к скачиванию</string>
     <string name="download_preparing">Подготовка...</string>

--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -95,8 +95,6 @@
     <string name="feedback_dialog_title">App feedback</string>
     <string name="feedback_dialog_placeholder">Share your thoughts…</string>
 
-    <string name="app_data_version_mismatch_message">We've updated the dictionary format. You'll need to re-download your dictionaries — your saved words are safe.</string>
-
     <string name="word_details_title">Word Details</string>
     <string name="word_details_action_stop">Stop</string>
     <string name="word_details_action_play_word">Play word</string>

--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -54,6 +54,8 @@
     <string name="download_subtitle_downloading">Getting your library ready.\nThis may take a moment.</string>
     <string name="download_title_setting_up">Setting Up</string>
     <string name="download_subtitle_setting_up">Getting your library ready.\nWill take a moment.</string>
+    <string name="download_title_update_required">Update Your Dictionary</string>
+    <string name="download_subtitle_update_required">Improved version is ready for download. Your saved words will remain exactly where you left them.</string>
     <string name="download_content_desc_loading_info">Loading download information</string>
     <string name="download_content_desc_preparing">Preparing download</string>
     <string name="download_preparing">Preparing...</string>

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/App.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/App.kt
@@ -71,7 +71,7 @@ private sealed interface AppDestination {
     data class Error(val message: String) : AppDestination
 
     @Serializable
-    data object DataVersionMismatch : AppDestination
+    data object DataVersionUpdateDownload : AppDestination
 }
 
 @Composable
@@ -85,6 +85,7 @@ fun App(
     var pendingSearchQuery by remember { mutableStateOf<String?>(null) }
     var nativeLanguages by remember { mutableStateOf<List<Language>>(emptyList()) }
     var dictionaryLanguage by remember { mutableStateOf<Language?>(null) }
+    var versionUpdateTargets by remember { mutableStateOf<List<DatabaseFileInfo>?>(null) }
     val favoritesRepository = remember(dataManager) {
         FavoritesRepository(DataDbManager.openAppDatabase(platform))
     }
@@ -148,9 +149,10 @@ fun App(
         // Check if data version is current (before welcome, so existing users see mismatch)
         if (!dataManager.hasRequiredVersion()) {
             val savedVersion = settingsRepository.getById(Setting.Name.DATA_VERSION)?.value?.jsonPrimitive?.content
-            // If version exists but is outdated, show error before deleting
+            // If version exists but is outdated, capture what's downloaded and go straight to re-download
             if (savedVersion != null) {
-                return AppDestination.DataVersionMismatch
+                versionUpdateTargets = dataManager.listDownloadedDatabases()
+                return AppDestination.DataVersionUpdateDownload
             }
         }
 
@@ -200,7 +202,6 @@ fun App(
     }
 
     val resolvedStart = startDestination ?: return
-    val dataVersionMismatchMessage = stringResource(Res.string.app_data_version_mismatch_message)
 
     AppTheme {
         NavHost(
@@ -571,27 +572,70 @@ fun App(
                     }
                 )
             }
-            composable<AppDestination.DataVersionMismatch> { backStackEntry ->
-                val coroutineScope = rememberCoroutineScope()
-                val viewModel = viewModel(
-                    viewModelStoreOwner = backStackEntry
-                ) {
-                    ErrorViewModel(dataVersionMismatchMessage)
-                }
+            composable<AppDestination.DataVersionUpdateDownload> { backStackEntry ->
+                val targets = versionUpdateTargets ?: emptyList()
+                val dictTargets = targets.filterIsInstance<DatabaseFileInfo.Dictionary>()
+                val transTargets = targets.filterIsInstance<DatabaseFileInfo.Translation>()
+                val totalItems = dictTargets.size + transTargets.size
 
-                ErrorScreen(
-                    viewModel = viewModel,
-                    onOkay = {
-                        coroutineScope.launch {
+                val viewModel = viewModel(viewModelStoreOwner = backStackEntry) {
+                    DownloadViewModel(
+                        downloadCoordinator = downloadCoordinator,
+                        downloadKey = "version_update",
+                        download = { onProgress, cancel ->
+                            dictTargets.forEachIndexed { index, dict ->
+                                val fileName = "${dict.language.selfName} Dictionary"
+                                dataManager.ensureDictionary(dict.language, { p ->
+                                    val base = (index.toFloat() / totalItems) * 100
+                                    val current = if (p.percent >= 0) p.percent.toFloat() / totalItems else 0f
+                                    onProgress(object : DownloadProgress(p.bytesDownloaded, p.totalBytes) {
+                                        override val percent: Int = (base + current).toInt()
+                                        override val currentFile: String = fileName
+                                    })
+                                }, cancel)
+                            }
+                            transTargets.forEachIndexed { index, trans ->
+                                val itemIndex = dictTargets.size + index
+                                val fileName = "${trans.sourceLanguage.selfName} → ${trans.targetLanguage.selfName}"
+                                dataManager.ensureTranslation(trans.sourceLanguage, trans.targetLanguage, { p ->
+                                    val base = (itemIndex.toFloat() / totalItems) * 100
+                                    val current = if (p.percent >= 0) p.percent.toFloat() / totalItems else 0f
+                                    onProgress(object : DownloadProgress(p.bytesDownloaded, p.totalBytes) {
+                                        override val percent: Int = (base + current).toInt()
+                                        override val currentFile: String = fileName
+                                    })
+                                }, cancel)
+                            }
+                        },
+                        onSuccess = {
+                            val dest = selectInitialDestination()
+                            navController.navigate(dest) {
+                                popUpTo<AppDestination.DataVersionUpdateDownload> { inclusive = true }
+                            }
+                        },
+                        onCancel = {},
+                        onError = {},
+                        loadItems = {
                             dataManager.deleteAllDownloadedData()
                             localDbManager.deleteAll()
                             dictionaryRepository.clearSenseCache()
-                            val target = selectInitialDestination()
-                            navController.navigate(target) {
-                                popUpTo<AppDestination.DataVersionMismatch> { inclusive = true }
+
+                            val items = mutableListOf<DownloadItem>()
+                            for (dict in dictTargets) {
+                                items.add(DownloadItem("${dict.language.selfName} Dictionary", dict.sizeBytes, dict.language.flag))
                             }
+                            for (trans in transTargets) {
+                                items.add(DownloadItem("${trans.sourceLanguage.selfName} → ${trans.targetLanguage.selfName}", trans.sizeBytes, trans.targetLanguage.flag))
+                            }
+                            items
                         }
-                    }
+                    )
+                }
+
+                DownloadScreen(
+                    viewModel = viewModel,
+                    description = stringResource(Res.string.download_title_downloading),
+                    isMandatory = true
                 )
             }
             composable<AppDestination.Error> { backStackEntry ->

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/App.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/App.kt
@@ -151,8 +151,13 @@ fun App(
             val savedVersion = settingsRepository.getById(Setting.Name.DATA_VERSION)?.value?.jsonPrimitive?.content
             // If version exists but is outdated, capture what's downloaded and go straight to re-download
             if (savedVersion != null) {
-                versionUpdateTargets = dataManager.listDownloadedDatabases()
-                return AppDestination.DataVersionUpdateDownload
+                val downloaded = dataManager.listDownloadedDatabases()
+                if (downloaded.isNotEmpty()) {
+                    versionUpdateTargets = downloaded
+                    return AppDestination.DataVersionUpdateDownload
+                }
+                // Nothing to re-download; clear the stale version and fall through to normal routing
+                dataManager.clearVersion()
             }
         }
 

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/App.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/App.kt
@@ -588,6 +588,10 @@ fun App(
                         downloadCoordinator = downloadCoordinator,
                         downloadKey = "version_update",
                         download = { onProgress, cancel ->
+                            dataManager.deleteAllDownloadedData()
+                            localDbManager.deleteAll()
+                            dictionaryRepository.clearSenseCache()
+
                             dictTargets.forEachIndexed { index, dict ->
                                 val fileName = "${dict.language.selfName} Dictionary"
                                 dataManager.ensureDictionary(dict.language, { p ->
@@ -597,7 +601,7 @@ fun App(
                                         override val percent: Int = (base + current).toInt()
                                         override val currentFile: String = fileName
                                     })
-                                }, cancel)
+                                }, cancel, skipVersionUpdate = true)
                             }
                             transTargets.forEachIndexed { index, trans ->
                                 val itemIndex = dictTargets.size + index
@@ -609,10 +613,11 @@ fun App(
                                         override val percent: Int = (base + current).toInt()
                                         override val currentFile: String = fileName
                                     })
-                                }, cancel)
+                                }, cancel, skipVersionUpdate = true)
                             }
                         },
                         onSuccess = {
+                            dataManager.setDownloadedVersion()
                             val dest = selectInitialDestination()
                             navController.navigate(dest) {
                                 popUpTo<AppDestination.DataVersionUpdateDownload> { inclusive = true }
@@ -621,10 +626,6 @@ fun App(
                         onCancel = {},
                         onError = {},
                         loadItems = {
-                            dataManager.deleteAllDownloadedData()
-                            localDbManager.deleteAll()
-                            dictionaryRepository.clearSenseCache()
-
                             val items = mutableListOf<DownloadItem>()
                             for (dict in dictTargets) {
                                 items.add(DownloadItem("${dict.language.selfName} Dictionary", dict.sizeBytes, dict.language.flag))

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/data/remote/DataDbManager.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/data/remote/DataDbManager.kt
@@ -63,10 +63,11 @@ class DataDbManager(
     suspend fun ensureDictionary(
         lang: Language,
         onProgress: (DownloadProgress) -> Unit = {},
-        cancelToken: CancelToken? = null
+        cancelToken: CancelToken? = null,
+        skipVersionUpdate: Boolean = false
     ): Path {
         val name = dictionaryFileName(lang)
-        return ensureFile(name, onProgress, cancelToken)
+        return ensureFile(name, onProgress, cancelToken, skipVersionUpdate)
     }
 
     suspend fun deleteDictionary(lang: Language) {
@@ -94,10 +95,11 @@ class DataDbManager(
         src: Language,
         tgt: Language,
         onProgress: (DownloadProgress) -> Unit = {},
-        cancelToken: CancelToken? = null
+        cancelToken: CancelToken? = null,
+        skipVersionUpdate: Boolean = false
     ): Path {
         val name = translationFileName(src, tgt)
-        return ensureFile(name, onProgress, cancelToken)
+        return ensureFile(name, onProgress, cancelToken, skipVersionUpdate)
     }
 
     suspend fun deleteTranslation(src: Language, tgt: Language) {
@@ -277,6 +279,7 @@ class DataDbManager(
         name: String,
         onProgress: (DownloadProgress) -> Unit,
         cancelToken: CancelToken?,
+        skipVersionUpdate: Boolean = false,
     ): Path = withContext(Dispatchers.Default) {
         val path = platform.getDatabasePath(name)
         val file = Path(path)
@@ -285,8 +288,9 @@ class DataDbManager(
             platform.ensureDatabasesDir()
             downloadToFile(url, remoteDataProvider.headersForHttp(), path, onProgress, cancelToken ?: CancelToken())
             platform.markNoBackup(path)
-            // After first successful download, save version
-            setDownloadedVersion()
+            if (!skipVersionUpdate) {
+                setDownloadedVersion()
+            }
         }
         file
     }

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/data/remote/DataDbManager.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/data/remote/DataDbManager.kt
@@ -127,7 +127,6 @@ class DataDbManager(
                 platform.deleteFile(file)
             }
         }
-        clearVersion()
     }
 
     /**
@@ -254,7 +253,7 @@ class DataDbManager(
         val files = platform.listFiles(databasesDir)
         return files.mapNotNull { file ->
             val fileName = file.name
-            val size = platform.getFileSize(file) ?: return@mapNotNull null
+            val size = platform.getFileSize(file) ?: 0L
             when {
                 fileName.startsWith(DICTIONARY_PREFIX) && fileName.endsWith(DB_EXTENSION) -> {
                     val langCode = fileName.removePrefix(DICTIONARY_PREFIX).removeSuffix(DB_EXTENSION)

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/DownloadScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/DownloadScreen.kt
@@ -205,6 +205,7 @@ class DownloadViewModel(
 fun DownloadScreen(
     viewModel: DownloadViewModel,
     description: String? = null,
+    isMandatory: Boolean = false,
     onLaterClick: () -> Unit = {}
 ) {
     DownloadScreenContent(
@@ -212,6 +213,7 @@ fun DownloadScreen(
         scrollState = viewModel.scrollState,
         description = description,
         hadConfirmation = viewModel.hadConfirmation,
+        isMandatory = isMandatory,
         onDownloadClick = { viewModel.startDownload() },
         onLaterClick = onLaterClick,
         onCancelClick = { viewModel.cancelDownload() },
@@ -228,6 +230,7 @@ fun DownloadScreenContent(
     scrollState: ScrollState = ScrollState(0),
     description: String? = null,
     hadConfirmation: Boolean = false,
+    isMandatory: Boolean = false,
     onDownloadClick: () -> Unit = {},
     onLaterClick: () -> Unit = {},
     onCancelClick: () -> Unit = {},
@@ -237,7 +240,7 @@ fun DownloadScreenContent(
 ) {
     val descriptionText = description ?: stringResource(Res.string.download_description_setting_up_library)
     val hasActions = state is DownloadUiState.ReadyToDownload ||
-            state is DownloadUiState.Running ||
+            (!isMandatory && state is DownloadUiState.Running) ||
             state is DownloadUiState.Failed ||
             state is DownloadUiState.Cancelled
 
@@ -271,13 +274,15 @@ fun DownloadScreenContent(
                                 )
                             }
 
-                            Spacer(Modifier.height(AppSpacing.sm))
+                            if (!isMandatory) {
+                                Spacer(Modifier.height(AppSpacing.sm))
 
-                            TextButton(onClick = onLaterClick) {
-                                Text(
-                                    stringResource(Res.string.common_later),
-                                    color = MaterialTheme.colorScheme.onSurfaceVariant
-                                )
+                                TextButton(onClick = onLaterClick) {
+                                    Text(
+                                        stringResource(Res.string.common_later),
+                                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                                    )
+                                }
                             }
                         }
 
@@ -295,22 +300,30 @@ fun DownloadScreenContent(
                                 Text(stringResource(Res.string.common_retry))
                             }
 
-                            Spacer(Modifier.height(AppSpacing.sm))
+                            if (!isMandatory) {
+                                Spacer(Modifier.height(AppSpacing.sm))
 
-                            TextButton(onClick = onErrorLaterClick) {
-                                Text(
-                                    stringResource(Res.string.common_later),
-                                    color = MaterialTheme.colorScheme.onSurfaceVariant
-                                )
+                                TextButton(onClick = onErrorLaterClick) {
+                                    Text(
+                                        stringResource(Res.string.common_later),
+                                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                                    )
+                                }
                             }
                         }
 
                         is DownloadUiState.Cancelled -> {
-                            TextButton(onClick = onCloseClick) {
-                                Text(
-                                    stringResource(Res.string.common_close),
-                                    color = MaterialTheme.colorScheme.onSurfaceVariant
-                                )
+                            if (isMandatory) {
+                                OutlinedButton(onClick = onRetryClick) {
+                                    Text(stringResource(Res.string.common_retry))
+                                }
+                            } else {
+                                TextButton(onClick = onCloseClick) {
+                                    Text(
+                                        stringResource(Res.string.common_close),
+                                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                                    )
+                                }
                             }
                         }
                     }
@@ -330,7 +343,11 @@ fun DownloadScreenContent(
 
             val (title, subtitle) = when (state) {
                 is DownloadUiState.ReadyToDownload ->
-                    stringResource(Res.string.download_title_ready) to stringResource(Res.string.download_subtitle_ready)
+                    if (isMandatory) {
+                        stringResource(Res.string.download_title_update_required) to stringResource(Res.string.download_subtitle_update_required)
+                    } else {
+                        stringResource(Res.string.download_title_ready) to stringResource(Res.string.download_subtitle_ready)
+                    }
 
                 is DownloadUiState.Failed ->
                     stringResource(Res.string.download_title_failed) to stringResource(Res.string.download_subtitle_failed)
@@ -561,6 +578,25 @@ private fun DownloadScreenPreviewReadyToDownload(
                     DownloadItem("Nederlands \u2192 Русский", 38_000_000L, "\uD83C\uDDF7\uD83C\uDDFA")
                 )
             )
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun DownloadScreenPreviewUpdateRequired(
+    @PreviewParameter(ThemePreviewProvider::class) isDark: Boolean
+) {
+    ThemedPreview(darkTheme = isDark) {
+        DownloadScreenContent(
+            state = DownloadUiState.ReadyToDownload(
+                items = listOf(
+                    DownloadItem("Nederlands Dictionary", 156_000_000L, "🇳🇱"),
+                    DownloadItem("Nederlands → English", 42_000_000L, "🇬🇧"),
+                    DownloadItem("Nederlands → Русский", 38_000_000L, "🇷🇺")
+                )
+            ),
+            isMandatory = true
         )
     }
 }

--- a/composeApp/src/commonTest/kotlin/com/slovy/slovymovyapp/db/DataDbManagerTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/slovy/slovymovyapp/db/DataDbManagerTest.kt
@@ -298,9 +298,9 @@ class DataDbManagerTest : BaseTest() {
     }
 
     @Test
-    fun deleteAllDownloadedData_clears_version_setting() {
+    fun deleteAllDownloadedData_preserves_version_setting() {
         val platform = testPlatformDbSupport()
-        val appDbPath = platform.getDatabasePath("test_delete_clears_version.db")
+        val appDbPath = platform.getDatabasePath("test_delete_preserves_version.db")
         if (platform.fileExists(appDbPath)) {
             platform.deleteFile(appDbPath)
         }
@@ -326,7 +326,7 @@ class DataDbManagerTest : BaseTest() {
                 mgr.deleteAllDownloadedData()
 
                 val versionAfter = settingsRepo.getById(Setting.Name.DATA_VERSION)
-                assertTrue(versionAfter == null, "Version should be cleared after deleteAllDownloadedData")
+                assertTrue(versionAfter != null, "Version should be preserved after deleteAllDownloadedData for crash-safe re-download detection")
             }
         } finally {
             appDriver.close()


### PR DESCRIPTION

<img width="300" height="650" alt="IMG_7950" src="https://github.com/user-attachments/assets/1f19200a-920c-4271-bde6-0585f3c90068" />



## Summary

- Replaces the two-step version-mismatch flow (ErrorScreen → "Got it" → DownloadSetup) with a single mandatory download screen
- On version mismatch, `selectInitialDestination()` captures all previously downloaded databases before any deletion, then navigates directly to `DataVersionUpdateDownload`
- The loading phase deletes stale data and lists all previously downloaded DBs using their on-disk sizes (no extra network call)
- Download is mandatory — no Cancel during download, no Later on the ready/error states
- On completion, re-runs `selectInitialDestination()` so routing reflects actual post-download state (fixes the empty-targets edge case identified in CR)
- Onboarding `DownloadSetup` flow is unchanged

## Test plan

- [ ] Existing user with downloaded dictionaries + outdated `DATA_VERSION`: update screen appears with all databases listed and real sizes; only Download button visible
- [ ] Download completes → routed correctly (Search if dictionaries present, DownloadSetup if not)
- [ ] No Cancel button during download; no Later on ready or error states; Retry shown on failure and cancelled states
- [ ] Fresh install (no prior version): update screen never shown, normal onboarding proceeds
- [ ] User who deleted all DBs via Settings but version still set: completes mandatory flow, `selectInitialDestination()` routes correctly after

> **Note:** To trigger the update flow in testing, bump `DataDbManager.VERSION` one step and ensure matching DB files are uploaded to the GCS bucket under the new version prefix (`gsutil -m cp gs://slovymovy/vN/* gs://slovymovy/vN+1/`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)