### PR TITLE
feat: TTS playback indicators in study session

### DIFF
--- a/composeApp/src/androidMain/kotlin/com/slovy/slovymovyapp/speech/Speech.android.kt
+++ b/composeApp/src/androidMain/kotlin/com/slovy/slovymovyapp/speech/Speech.android.kt
@@ -21,7 +21,7 @@ actual class TextToSpeechManager actual constructor(androidContext: Any?) {
     private lateinit var tts: TextToSpeech
 
     private var onWordBoundary: ((IntRange) -> Unit)? = null
-    private var onStatusChange: ((TTSStatus) -> Unit)? = null
+    private val statusListeners = mutableMapOf<Any, (TTSStatus) -> Unit>()
 
     init {
         initializeTTS()
@@ -38,21 +38,21 @@ actual class TextToSpeechManager actual constructor(androidContext: Any?) {
     private fun setupUtteranceProgressListener() {
         tts.setOnUtteranceProgressListener(object : UtteranceProgressListener() {
             override fun onStart(utteranceId: String?) {
-                onStatusChange?.invoke(TTSStatus.SPEAKING)
+                statusListeners.values.forEach { it(TTSStatus.SPEAKING) }
             }
 
             override fun onDone(utteranceId: String?) {
-                onStatusChange?.invoke(TTSStatus.IDLE)
+                statusListeners.values.forEach { it(TTSStatus.IDLE) }
             }
 
             @Suppress("OVERRIDE_DEPRECATION")
             @Deprecated("Deprecated in Java")
             override fun onError(utteranceId: String?) {
-                onStatusChange?.invoke(TTSStatus.IDLE)
+                statusListeners.values.forEach { it(TTSStatus.IDLE) }
             }
 
             override fun onError(utteranceId: String?, errorCode: Int) {
-                onStatusChange?.invoke(TTSStatus.IDLE)
+                statusListeners.values.forEach { it(TTSStatus.IDLE) }
             }
 
             override fun onRangeStart(
@@ -72,6 +72,11 @@ actual class TextToSpeechManager actual constructor(androidContext: Any?) {
             putString(TextToSpeech.Engine.KEY_PARAM_UTTERANCE_ID, id)
         }
         tts.speak(text, TextToSpeech.QUEUE_FLUSH, params, id)
+    }
+
+    actual fun speak(text: String, language: Language) {
+        tts.setLanguage(toLocale(language))
+        speak(text)
     }
 
     actual suspend fun getAvailableLanguages(): List<Text2SpeechLanguage> = withContext(Dispatchers.IO) {
@@ -150,14 +155,18 @@ actual class TextToSpeechManager actual constructor(androidContext: Any?) {
 
     actual fun stop() {
         tts.stop()
-        onStatusChange?.invoke(TTSStatus.IDLE)
+        statusListeners.values.forEach { it(TTSStatus.IDLE) }
     }
 
     actual fun setOnWordBoundaryListener(listener: (wordRange: IntRange) -> Unit) {
         onWordBoundary = listener
     }
 
-    actual fun setOnStatusChangeListener(listener: (status: TTSStatus) -> Unit) {
-        onStatusChange = listener
+    actual fun addOnStatusChangeListener(key: Any, listener: (TTSStatus) -> Unit) {
+        statusListeners[key] = listener
+    }
+
+    actual fun removeOnStatusChangeListener(key: Any) {
+        statusListeners.remove(key)
     }
 }

--- a/composeApp/src/androidMain/kotlin/com/slovy/slovymovyapp/speech/Speech.android.kt
+++ b/composeApp/src/androidMain/kotlin/com/slovy/slovymovyapp/speech/Speech.android.kt
@@ -71,7 +71,10 @@ actual class TextToSpeechManager actual constructor(androidContext: Any?) {
         val params = Bundle().apply {
             putString(TextToSpeech.Engine.KEY_PARAM_UTTERANCE_ID, id)
         }
-        tts.speak(text, TextToSpeech.QUEUE_FLUSH, params, id)
+        val result = tts.speak(text, TextToSpeech.QUEUE_FLUSH, params, id)
+        if (result == TextToSpeech.ERROR) {
+            statusListeners.values.toList().forEach { it(TTSStatus.IDLE) }
+        }
     }
 
     actual fun speak(text: String, language: Language) {

--- a/composeApp/src/androidMain/kotlin/com/slovy/slovymovyapp/speech/Speech.android.kt
+++ b/composeApp/src/androidMain/kotlin/com/slovy/slovymovyapp/speech/Speech.android.kt
@@ -38,21 +38,21 @@ actual class TextToSpeechManager actual constructor(androidContext: Any?) {
     private fun setupUtteranceProgressListener() {
         tts.setOnUtteranceProgressListener(object : UtteranceProgressListener() {
             override fun onStart(utteranceId: String?) {
-                statusListeners.values.forEach { it(TTSStatus.SPEAKING) }
+                statusListeners.values.toList().forEach { it(TTSStatus.SPEAKING) }
             }
 
             override fun onDone(utteranceId: String?) {
-                statusListeners.values.forEach { it(TTSStatus.IDLE) }
+                statusListeners.values.toList().forEach { it(TTSStatus.IDLE) }
             }
 
             @Suppress("OVERRIDE_DEPRECATION")
             @Deprecated("Deprecated in Java")
             override fun onError(utteranceId: String?) {
-                statusListeners.values.forEach { it(TTSStatus.IDLE) }
+                statusListeners.values.toList().forEach { it(TTSStatus.IDLE) }
             }
 
             override fun onError(utteranceId: String?, errorCode: Int) {
-                statusListeners.values.forEach { it(TTSStatus.IDLE) }
+                statusListeners.values.toList().forEach { it(TTSStatus.IDLE) }
             }
 
             override fun onRangeStart(
@@ -155,7 +155,7 @@ actual class TextToSpeechManager actual constructor(androidContext: Any?) {
 
     actual fun stop() {
         tts.stop()
-        statusListeners.values.forEach { it(TTSStatus.IDLE) }
+        statusListeners.values.toList().forEach { it(TTSStatus.IDLE) }
     }
 
     actual fun setOnWordBoundaryListener(listener: (wordRange: IntRange) -> Unit) {

--- a/composeApp/src/commonMain/composeResources/values-nl/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-nl/strings.xml
@@ -455,6 +455,7 @@
     <string name="study_fill_blank">Vul de lege plek in</string>
     <string name="study_play_word_audio">Woord afspelen</string>
     <string name="study_play_prompt_audio">Opdracht afspelen</string>
+    <string name="study_stop_audio">Audio stoppen</string>
     <string name="study_listen_prompt">Tik om af te spelen. Welk woord hoor je?</string>
     <string name="study_rating_again">Opnieuw</string>
     <string name="study_rating_hard">Moeilijk</string>

--- a/composeApp/src/commonMain/composeResources/values-pl/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-pl/strings.xml
@@ -455,6 +455,7 @@
     <string name="study_fill_blank">Uzupełnij lukę</string>
     <string name="study_play_word_audio">Odtwórz słowo</string>
     <string name="study_play_prompt_audio">Odtwórz zadanie</string>
+    <string name="study_stop_audio">Zatrzymaj audio</string>
     <string name="study_listen_prompt">Dotknij, aby odtworzyć. Jakie słowo słyszysz?</string>
     <string name="study_rating_again">Jeszcze raz</string>
     <string name="study_rating_hard">Trudne</string>

--- a/composeApp/src/commonMain/composeResources/values-ru/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-ru/strings.xml
@@ -455,6 +455,7 @@
     <string name="study_fill_blank">Заполните пропуск</string>
     <string name="study_play_word_audio">Воспроизвести слово</string>
     <string name="study_play_prompt_audio">Воспроизвести задание</string>
+    <string name="study_stop_audio">Остановить аудио</string>
     <string name="study_listen_prompt">Нажмите для воспроизведения. Какое слово вы слышите?</string>
     <string name="study_rating_again">Снова</string>
     <string name="study_rating_hard">Трудно</string>

--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -455,6 +455,7 @@
     <string name="study_fill_blank">Fill in the blank</string>
     <string name="study_play_word_audio">Play word audio</string>
     <string name="study_play_prompt_audio">Play prompt audio</string>
+    <string name="study_stop_audio">Stop audio</string>
     <string name="study_listen_prompt">Tap to play. What word do you hear?</string>
     <string name="study_rating_again">Again</string>
     <string name="study_rating_hard">Hard</string>

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/App.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/App.kt
@@ -546,6 +546,7 @@ fun App(
                         sessionService = sessionService,
                         statsService = statsService,
                         clock = Clock.System,
+                        ttsManager = ttsManager,
                     )
                 }
                 StudySessionScreen(
@@ -554,9 +555,6 @@ fun App(
                         if (!navController.popBackStack()) {
                             navController.navigate(AppDestination.Favorites)
                         }
-                    },
-                    onPlayAudio = { text ->
-                        ttsManager.speak(text)
                     },
                 )
             }

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/speech/Speech.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/speech/Speech.kt
@@ -4,6 +4,7 @@ import com.slovy.slovymovyapp.data.Language
 
 expect class TextToSpeechManager(androidContext: Any? = null) {
     fun speak(text: String)
+    fun speak(text: String, language: Language)
     fun stop()
     suspend fun getAvailableLanguages(): List<Text2SpeechLanguage>
     suspend fun getVoicesForLanguage(language: Text2SpeechLanguage): List<Text2SpeechVoice>
@@ -11,7 +12,8 @@ expect class TextToSpeechManager(androidContext: Any? = null) {
     fun openSettings()
 
     fun setOnWordBoundaryListener(listener: (wordRange: IntRange) -> Unit)
-    fun setOnStatusChangeListener(listener: (status: TTSStatus) -> Unit)
+    fun addOnStatusChangeListener(key: Any, listener: (TTSStatus) -> Unit)
+    fun removeOnStatusChangeListener(key: Any)
 }
 
 data class Text2SpeechLanguage(

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/SettingsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/SettingsScreen.kt
@@ -135,7 +135,7 @@ class SettingsViewModel(
     }
 
     private fun setupTTSListeners() {
-        ttsManager.setOnStatusChangeListener { status ->
+        ttsManager.addOnStatusChangeListener(this) { status ->
             state = state.copy(
                 ttsStatus = status,
                 testingVoice = if (status == TTSStatus.IDLE) null else state.testingVoice
@@ -798,6 +798,7 @@ class SettingsViewModel(
 
     override fun onCleared() {
         super.onCleared()
+        ttsManager.removeOnStatusChangeListener(this)
         ttsManager.stop()
     }
 

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/study/StudySessionModels.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/study/StudySessionModels.kt
@@ -20,6 +20,8 @@ sealed interface StudySessionUiState {
         val side: StudyCardSide,
         val ratingOptions: List<StudyRatingUiState> = emptyList(),
         val isSubmittingReview: Boolean = false,
+        val isPlayingAudio: Boolean = false,
+        val isPreparingAudio: Boolean = false,
     ) : StudySessionUiState
 
     data class Complete(

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/study/StudySessionScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/study/StudySessionScreen.kt
@@ -24,6 +24,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.VolumeUp
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.MoreVert
+import androidx.compose.material.icons.filled.StopCircle
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.FilledTonalButton
 import androidx.compose.material3.Icon
@@ -87,7 +88,6 @@ import slovymovyapp.composeapp.generated.resources.study_tap_to_flip
 fun StudySessionScreen(
     viewModel: StudySessionViewModel,
     onClose: () -> Unit,
-    onPlayAudio: (String) -> Unit = {},
     onMoreOptions: () -> Unit = {},
 ) {
     StudySessionScreenContent(
@@ -96,7 +96,8 @@ fun StudySessionScreen(
         onMoreOptions = onMoreOptions,
         onReveal = viewModel::reveal,
         onRate = viewModel::rate,
-        onPlayAudio = onPlayAudio,
+        onPlayAudio = viewModel::playAudio,
+        onStopAudio = viewModel::stopAudio,
         onRetry = viewModel::retry,
     )
 }
@@ -109,6 +110,7 @@ fun StudySessionScreenContent(
     onReveal: () -> Unit = {},
     onRate: (StudyRating) -> Unit = {},
     onPlayAudio: (String) -> Unit = {},
+    onStopAudio: () -> Unit = {},
     onRetry: () -> Unit = {},
     modifier: Modifier = Modifier,
 ) {
@@ -187,6 +189,7 @@ fun StudySessionScreenContent(
             onReveal = onReveal,
             onRate = onRate,
             onPlayAudio = onPlayAudio,
+            onStopAudio = onStopAudio,
             modifier = modifier,
         )
 
@@ -318,6 +321,7 @@ private fun StudySessionActiveContent(
     onReveal: () -> Unit,
     onRate: (StudyRating) -> Unit,
     onPlayAudio: (String) -> Unit,
+    onStopAudio: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Scaffold(
@@ -341,7 +345,10 @@ private fun StudySessionActiveContent(
             StudyCardSurface(
                 card = state.card,
                 side = state.side,
+                isPlayingAudio = state.isPlayingAudio,
+                isPreparingAudio = state.isPreparingAudio,
                 onPlayAudio = onPlayAudio,
+                onStopAudio = onStopAudio,
                 modifier = Modifier
                     .fillMaxWidth()
                     .weight(1f),
@@ -463,7 +470,10 @@ private fun StudySegmentProgress(
 private fun StudyCardSurface(
     card: StudyCardUiState,
     side: StudyCardSide,
+    isPlayingAudio: Boolean,
+    isPreparingAudio: Boolean,
     onPlayAudio: (String) -> Unit,
+    onStopAudio: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Surface(
@@ -484,7 +494,10 @@ private fun StudyCardSurface(
             if (side == StudyCardSide.FRONT) {
                 StudyCardFront(
                     card = card,
+                    isPlayingAudio = isPlayingAudio,
+                    isPreparingAudio = isPreparingAudio,
                     onPlayAudio = onPlayAudio,
+                    onStopAudio = onStopAudio,
                     modifier = Modifier
                         .fillMaxWidth()
                         .heightIn(min = 360.dp),
@@ -492,7 +505,10 @@ private fun StudyCardSurface(
             } else {
                 StudyCardBack(
                     back = card.back,
+                    isPlayingAudio = isPlayingAudio,
+                    isPreparingAudio = isPreparingAudio,
                     onPlayAudio = onPlayAudio,
+                    onStopAudio = onStopAudio,
                 )
             }
         }
@@ -522,13 +538,19 @@ private fun StudyChip(
 @Composable
 private fun StudyCardFront(
     card: StudyCardUiState,
+    isPlayingAudio: Boolean,
+    isPreparingAudio: Boolean,
     onPlayAudio: (String) -> Unit,
+    onStopAudio: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     when (card) {
         is StudyCardUiState.Recognition -> RecognitionFront(
             card = card,
+            isPlayingAudio = isPlayingAudio,
+            isPreparingAudio = isPreparingAudio,
             onPlayAudio = onPlayAudio,
+            onStopAudio = onStopAudio,
             modifier = modifier,
         )
 
@@ -544,7 +566,10 @@ private fun StudyCardFront(
 
         is StudyCardUiState.Listening -> ListeningFront(
             card = card,
+            isPlayingAudio = isPlayingAudio,
+            isPreparingAudio = isPreparingAudio,
             onPlayAudio = onPlayAudio,
+            onStopAudio = onStopAudio,
             modifier = modifier,
         )
     }
@@ -553,7 +578,10 @@ private fun StudyCardFront(
 @Composable
 private fun RecognitionFront(
     card: StudyCardUiState.Recognition,
+    isPlayingAudio: Boolean,
+    isPreparingAudio: Boolean,
     onPlayAudio: (String) -> Unit,
+    onStopAudio: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Box(
@@ -576,7 +604,10 @@ private fun RecognitionFront(
                 StudySpeakerButton(
                     audioText = audioText,
                     contentDescription = stringResource(Res.string.study_play_word_audio),
+                    isPlayingAudio = isPlayingAudio,
+                    isPreparingAudio = isPreparingAudio,
                     onPlayAudio = onPlayAudio,
+                    onStopAudio = onStopAudio,
                 )
             }
         }
@@ -667,7 +698,10 @@ private fun ClozeFront(
 @Composable
 private fun ListeningFront(
     card: StudyCardUiState.Listening,
+    isPlayingAudio: Boolean,
+    isPreparingAudio: Boolean,
     onPlayAudio: (String) -> Unit,
+    onStopAudio: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Box(
@@ -682,17 +716,31 @@ private fun ListeningFront(
                 modifier = Modifier
                     .size(132.dp)
                     .clip(CircleShape)
-                    .clickable(role = Role.Button) { onPlayAudio(card.promptAudioText) },
+                    .clickable(enabled = !isPreparingAudio, role = Role.Button) {
+                        if (isPlayingAudio) onStopAudio() else onPlayAudio(card.promptAudioText)
+                    },
                 shape = CircleShape,
                 color = MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.45f),
                 contentColor = MaterialTheme.colorScheme.primary,
             ) {
                 Box(contentAlignment = Alignment.Center) {
-                    Icon(
-                        imageVector = Icons.AutoMirrored.Filled.VolumeUp,
-                        contentDescription = stringResource(Res.string.study_play_prompt_audio),
-                        modifier = Modifier.size(56.dp),
-                    )
+                    when {
+                        isPreparingAudio -> CircularProgressIndicator(
+                            modifier = Modifier.size(48.dp),
+                            strokeWidth = 3.dp,
+                            color = MaterialTheme.colorScheme.primary,
+                        )
+                        isPlayingAudio -> Icon(
+                            imageVector = Icons.Filled.StopCircle,
+                            contentDescription = stringResource(Res.string.study_play_prompt_audio),
+                            modifier = Modifier.size(56.dp),
+                        )
+                        else -> Icon(
+                            imageVector = Icons.AutoMirrored.Filled.VolumeUp,
+                            contentDescription = stringResource(Res.string.study_play_prompt_audio),
+                            modifier = Modifier.size(56.dp),
+                        )
+                    }
                 }
             }
             Text(
@@ -708,7 +756,10 @@ private fun ListeningFront(
 @Composable
 private fun StudyCardBack(
     back: StudyCardBackUiState,
+    isPlayingAudio: Boolean,
+    isPreparingAudio: Boolean,
     onPlayAudio: (String) -> Unit,
+    onStopAudio: () -> Unit,
 ) {
     Column(
         modifier = Modifier.fillMaxWidth(),
@@ -742,7 +793,10 @@ private fun StudyCardBack(
                 StudySpeakerButton(
                     audioText = audioText,
                     contentDescription = stringResource(Res.string.study_play_word_audio),
+                    isPlayingAudio = isPlayingAudio,
+                    isPreparingAudio = isPreparingAudio,
                     onPlayAudio = onPlayAudio,
+                    onStopAudio = onStopAudio,
                 )
             }
         }
@@ -775,24 +829,41 @@ private fun StudyCardBack(
 private fun StudySpeakerButton(
     audioText: String,
     contentDescription: String,
+    isPlayingAudio: Boolean,
+    isPreparingAudio: Boolean,
     onPlayAudio: (String) -> Unit,
+    onStopAudio: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Surface(
         modifier = modifier
             .size(36.dp)
             .clip(CircleShape)
-            .clickable(role = Role.Button) { onPlayAudio(audioText) },
+            .clickable(enabled = !isPreparingAudio, role = Role.Button) {
+                if (isPlayingAudio) onStopAudio() else onPlayAudio(audioText)
+            },
         shape = CircleShape,
         color = MaterialTheme.colorScheme.surfaceContainerHighest,
         contentColor = MaterialTheme.colorScheme.onSurfaceVariant,
     ) {
         Box(contentAlignment = Alignment.Center) {
-            Icon(
-                imageVector = Icons.AutoMirrored.Filled.VolumeUp,
-                contentDescription = contentDescription,
-                modifier = Modifier.size(20.dp),
-            )
+            when {
+                isPreparingAudio -> CircularProgressIndicator(
+                    modifier = Modifier.size(20.dp),
+                    strokeWidth = 2.dp,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                isPlayingAudio -> Icon(
+                    imageVector = Icons.Filled.StopCircle,
+                    contentDescription = contentDescription,
+                    modifier = Modifier.size(20.dp),
+                )
+                else -> Icon(
+                    imageVector = Icons.AutoMirrored.Filled.VolumeUp,
+                    contentDescription = contentDescription,
+                    modifier = Modifier.size(20.dp),
+                )
+            }
         }
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/study/StudySessionScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/study/StudySessionScreen.kt
@@ -75,6 +75,7 @@ import slovymovyapp.composeapp.generated.resources.study_listen_prompt
 import slovymovyapp.composeapp.generated.resources.study_loading
 import slovymovyapp.composeapp.generated.resources.study_play_prompt_audio
 import slovymovyapp.composeapp.generated.resources.study_play_word_audio
+import slovymovyapp.composeapp.generated.resources.study_stop_audio
 import slovymovyapp.composeapp.generated.resources.study_prompt_translate_to
 import slovymovyapp.composeapp.generated.resources.study_progress_count
 import slovymovyapp.composeapp.generated.resources.study_rating_again
@@ -603,7 +604,8 @@ private fun RecognitionFront(
             card.promptAudioText?.let { audioText ->
                 StudySpeakerButton(
                     audioText = audioText,
-                    contentDescription = stringResource(Res.string.study_play_word_audio),
+                    playContentDescription = stringResource(Res.string.study_play_word_audio),
+                    stopContentDescription = stringResource(Res.string.study_stop_audio),
                     isPlayingAudio = isPlayingAudio,
                     isPreparingAudio = isPreparingAudio,
                     onPlayAudio = onPlayAudio,
@@ -732,7 +734,7 @@ private fun ListeningFront(
                         )
                         isPlayingAudio -> Icon(
                             imageVector = Icons.Filled.StopCircle,
-                            contentDescription = stringResource(Res.string.study_play_prompt_audio),
+                            contentDescription = stringResource(Res.string.study_stop_audio),
                             modifier = Modifier.size(56.dp),
                         )
                         else -> Icon(
@@ -792,7 +794,8 @@ private fun StudyCardBack(
             back.audioText?.let { audioText ->
                 StudySpeakerButton(
                     audioText = audioText,
-                    contentDescription = stringResource(Res.string.study_play_word_audio),
+                    playContentDescription = stringResource(Res.string.study_play_word_audio),
+                    stopContentDescription = stringResource(Res.string.study_stop_audio),
                     isPlayingAudio = isPlayingAudio,
                     isPreparingAudio = isPreparingAudio,
                     onPlayAudio = onPlayAudio,
@@ -828,7 +831,8 @@ private fun StudyCardBack(
 @Composable
 private fun StudySpeakerButton(
     audioText: String,
-    contentDescription: String,
+    playContentDescription: String,
+    stopContentDescription: String,
     isPlayingAudio: Boolean,
     isPreparingAudio: Boolean,
     onPlayAudio: (String) -> Unit,
@@ -855,12 +859,12 @@ private fun StudySpeakerButton(
                 )
                 isPlayingAudio -> Icon(
                     imageVector = Icons.Filled.StopCircle,
-                    contentDescription = contentDescription,
+                    contentDescription = stopContentDescription,
                     modifier = Modifier.size(20.dp),
                 )
                 else -> Icon(
                     imageVector = Icons.AutoMirrored.Filled.VolumeUp,
-                    contentDescription = contentDescription,
+                    contentDescription = playContentDescription,
                     modifier = Modifier.size(20.dp),
                 )
             }

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/study/StudySessionViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/study/StudySessionViewModel.kt
@@ -5,6 +5,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.slovy.slovymovyapp.data.Language
 import com.slovy.slovymovyapp.data.learning.GradeOutcome
 import com.slovy.slovymovyapp.data.learning.intake.IntakeService
 import com.slovy.slovymovyapp.data.learning.session.SessionCard
@@ -12,6 +13,8 @@ import com.slovy.slovymovyapp.data.learning.session.SessionCardLoadState
 import com.slovy.slovymovyapp.data.learning.session.SessionService
 import com.slovy.slovymovyapp.data.learning.stats.StatsService
 import com.slovy.slovymovyapp.i18n.UiText
+import com.slovy.slovymovyapp.speech.TTSStatus
+import com.slovy.slovymovyapp.speech.TextToSpeechManager
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.launch
 import kotlin.time.Clock
@@ -30,11 +33,13 @@ class StudySessionViewModel(
     private val sessionService: SessionService,
     private val statsService: StatsService,
     private val clock: Clock,
+    private val ttsManager: TextToSpeechManager,
 ) : ViewModel() {
 
     var state by mutableStateOf<StudySessionUiState>(StudySessionUiState.Loading())
         private set
 
+    private val language: Language? = Language.fromCodeOrNull(langCode)
     private val sessionStartedAt: Instant = clock.now()
     private var cardShownAt: Instant = sessionStartedAt
     private var currentCard: SessionCard? = null
@@ -43,7 +48,28 @@ class StudySessionViewModel(
     private var sessionTotal: Int = 0
 
     init {
+        ttsManager.addOnStatusChangeListener(this) { status ->
+            val active = state as? StudySessionUiState.Active ?: return@addOnStatusChangeListener
+            state = when (status) {
+                TTSStatus.SPEAKING -> active.copy(isPreparingAudio = false, isPlayingAudio = true)
+                TTSStatus.IDLE -> active.copy(isPreparingAudio = false, isPlayingAudio = false)
+            }
+        }
         start()
+    }
+
+    fun playAudio(text: String) {
+        val active = state as? StudySessionUiState.Active ?: return
+        state = active.copy(isPreparingAudio = true, isPlayingAudio = false)
+        if (language != null) {
+            ttsManager.speak(text, language)
+        } else {
+            ttsManager.speak(text)
+        }
+    }
+
+    fun stopAudio() {
+        ttsManager.stop()
     }
 
     fun retry() {
@@ -116,6 +142,7 @@ class StudySessionViewModel(
     }
 
     private fun loadNextCard() {
+        ttsManager.stop()
         state = StudySessionUiState.Loading(nextCardProgress())
         viewModelScope.launch {
             runCatching {
@@ -174,4 +201,10 @@ class StudySessionViewModel(
             current = reviewedCount + 1,
             total = maxOf(sessionTotal, reviewedCount + 1),
         )
+
+    override fun onCleared() {
+        super.onCleared()
+        ttsManager.removeOnStatusChangeListener(this)
+        ttsManager.stop()
+    }
 }

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/word/WordDetailsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/word/WordDetailsScreen.kt
@@ -338,20 +338,27 @@ class WordDetailViewModel(
             }
         }
 
-        // Setup TTS status listener
-        ttsManager.setOnStatusChangeListener { status ->
+    }
+
+    fun attachTtsListener() {
+        ttsManager.addOnStatusChangeListener(this) { status ->
             when (status) {
                 TTSStatus.SPEAKING -> {
                     isPreparing = false
                     isPlaying = true
                 }
-
                 TTSStatus.IDLE -> {
                     isPreparing = false
                     isPlaying = false
                 }
             }
         }
+    }
+
+    fun detachTtsListener() {
+        ttsManager.removeOnStatusChangeListener(this)
+        isPlaying = false
+        isPreparing = false
     }
 
     private fun updateStateFromResult(result: WordResult) {
@@ -713,10 +720,12 @@ class WordDetailViewModel(
 
     override fun onCleared() {
         super.onCleared()
+        ttsManager.removeOnStatusChangeListener(this)
         ttsManager.stop()
     }
 
     fun dispose() {
+        ttsManager.removeOnStatusChangeListener(this)
         ttsManager.stop()
         viewModelScope.cancel()
     }
@@ -744,6 +753,11 @@ fun WordDetailScreen(
     onNavigateToSettings: () -> Unit = {},
     onNavigateToWordDetail: (Language, String) -> Unit = { _, _ -> }
 ) {
+    DisposableEffect(viewModel) {
+        viewModel.attachTtsListener()
+        onDispose { viewModel.detachTtsListener() }
+    }
+
     // Restore scroll position after process death
     val savedScrollPosition = rememberSaveable { viewModel.scrollState.value }
 

--- a/composeApp/src/desktopMain/kotlin/com/slovy/slovymovyapp/speech/Speech.desktop.kt
+++ b/composeApp/src/desktopMain/kotlin/com/slovy/slovymovyapp/speech/Speech.desktop.kt
@@ -1,7 +1,16 @@
 package com.slovy.slovymovyapp.speech
 
+import com.slovy.slovymovyapp.data.Language
+
 actual class TextToSpeechManager actual constructor(androidContext: Any?) {
+    private val statusListeners = mutableMapOf<Any, (TTSStatus) -> Unit>()
+
     actual fun speak(text: String) {
+        statusListeners.values.forEach { it(TTSStatus.IDLE) }
+    }
+
+    actual fun speak(text: String, language: Language) {
+        statusListeners.values.forEach { it(TTSStatus.IDLE) }
     }
 
     actual fun stop() {
@@ -24,6 +33,11 @@ actual class TextToSpeechManager actual constructor(androidContext: Any?) {
     actual fun setOnWordBoundaryListener(listener: (wordRange: IntRange) -> Unit) {
     }
 
-    actual fun setOnStatusChangeListener(listener: (status: TTSStatus) -> Unit) {
+    actual fun addOnStatusChangeListener(key: Any, listener: (TTSStatus) -> Unit) {
+        statusListeners[key] = listener
+    }
+
+    actual fun removeOnStatusChangeListener(key: Any) {
+        statusListeners.remove(key)
     }
 }

--- a/composeApp/src/iosMain/kotlin/com/slovy/slovymovyapp/speech/Speech.ios.kt
+++ b/composeApp/src/iosMain/kotlin/com/slovy/slovymovyapp/speech/Speech.ios.kt
@@ -22,7 +22,7 @@ actual class TextToSpeechManager actual constructor(androidContext: Any?) {
     private var currentVoice: AVSpeechSynthesisVoice? = null
 
     private var onWordBoundary: ((IntRange) -> Unit)? = null
-    private var onStatusChange: ((TTSStatus) -> Unit)? = null
+    private val statusListeners = mutableMapOf<Any, (TTSStatus) -> Unit>()
 
     // Generation counter to track speech requests and ignore stale callbacks
     private var speechGeneration: Long = 0
@@ -30,12 +30,12 @@ actual class TextToSpeechManager actual constructor(androidContext: Any?) {
     init {
         synthesizer.delegate = delegate
         delegate.setCallbacks(
-            onStart = { onStatusChange?.invoke(TTSStatus.SPEAKING) },
+            onStart = { statusListeners.values.forEach { it(TTSStatus.SPEAKING) } },
             onSpeechEnded = { generation ->
                 // Only deactivate if this callback is for the current generation
                 if (generation == speechGeneration) {
                     deactivateAudioSession()
-                    onStatusChange?.invoke(TTSStatus.IDLE)
+                    statusListeners.values.forEach { it(TTSStatus.IDLE) }
                 }
             },
             onWordBoundary = { range -> onWordBoundary?.invoke(range) }
@@ -71,6 +71,17 @@ actual class TextToSpeechManager actual constructor(androidContext: Any?) {
         } catch (e: Exception) {
             // Audio session deactivation failed
         }
+    }
+
+    actual fun speak(text: String, language: Language) {
+        val voices = AVSpeechSynthesisVoice.speechVoices()
+        val voiceForLanguage = (voices as List<*>)
+            .filterIsInstance<AVSpeechSynthesisVoice>()
+            .firstOrNull { it.language.startsWith(language.code) }
+        if (voiceForLanguage != null) {
+            currentVoice = voiceForLanguage
+        }
+        speak(text)
     }
 
     actual fun speak(text: String) {
@@ -164,15 +175,19 @@ actual class TextToSpeechManager actual constructor(androidContext: Any?) {
         synthesizer.stopSpeakingAtBoundary(AVSpeechBoundary.AVSpeechBoundaryImmediate)
         // Deactivate session and set idle state
         deactivateAudioSession()
-        onStatusChange?.invoke(TTSStatus.IDLE)
+        statusListeners.values.forEach { it(TTSStatus.IDLE) }
     }
 
     actual fun setOnWordBoundaryListener(listener: (wordRange: IntRange) -> Unit) {
         onWordBoundary = listener
     }
 
-    actual fun setOnStatusChangeListener(listener: (status: TTSStatus) -> Unit) {
-        onStatusChange = listener
+    actual fun addOnStatusChangeListener(key: Any, listener: (TTSStatus) -> Unit) {
+        statusListeners[key] = listener
+    }
+
+    actual fun removeOnStatusChangeListener(key: Any) {
+        statusListeners.remove(key)
     }
 }
 

--- a/composeApp/src/iosMain/kotlin/com/slovy/slovymovyapp/speech/Speech.ios.kt
+++ b/composeApp/src/iosMain/kotlin/com/slovy/slovymovyapp/speech/Speech.ios.kt
@@ -30,12 +30,12 @@ actual class TextToSpeechManager actual constructor(androidContext: Any?) {
     init {
         synthesizer.delegate = delegate
         delegate.setCallbacks(
-            onStart = { statusListeners.values.forEach { it(TTSStatus.SPEAKING) } },
+            onStart = { statusListeners.values.toList().forEach { it(TTSStatus.SPEAKING) } },
             onSpeechEnded = { generation ->
                 // Only deactivate if this callback is for the current generation
                 if (generation == speechGeneration) {
                     deactivateAudioSession()
-                    statusListeners.values.forEach { it(TTSStatus.IDLE) }
+                    statusListeners.values.toList().forEach { it(TTSStatus.IDLE) }
                 }
             },
             onWordBoundary = { range -> onWordBoundary?.invoke(range) }
@@ -78,9 +78,11 @@ actual class TextToSpeechManager actual constructor(androidContext: Any?) {
         val voiceForLanguage = (voices as List<*>)
             .filterIsInstance<AVSpeechSynthesisVoice>()
             .firstOrNull { it.language.startsWith(language.code) }
-        if (voiceForLanguage != null) {
-            currentVoice = voiceForLanguage
+        if (voiceForLanguage == null) {
+            statusListeners.values.toList().forEach { it(TTSStatus.IDLE) }
+            return
         }
+        currentVoice = voiceForLanguage
         speak(text)
     }
 
@@ -175,7 +177,7 @@ actual class TextToSpeechManager actual constructor(androidContext: Any?) {
         synthesizer.stopSpeakingAtBoundary(AVSpeechBoundary.AVSpeechBoundaryImmediate)
         // Deactivate session and set idle state
         deactivateAudioSession()
-        statusListeners.values.forEach { it(TTSStatus.IDLE) }
+        statusListeners.values.toList().forEach { it(TTSStatus.IDLE) }
     }
 
     actual fun setOnWordBoundaryListener(listener: (wordRange: IntRange) -> Unit) {


### PR DESCRIPTION
## Summary

- Fix study session speaker button having no effect (iOS needed a voice set first; Android used device locale instead of card language)
- Add `speak(text, language)` overload to `TextToSpeechManager` so the study session always speaks in the correct language
- Study session speaker buttons now show a spinner while preparing, stop icon while playing, and speaker icon at rest — matching the word details screen behaviour
- Replace single-slot `setOnStatusChangeListener` with keyed `addOnStatusChangeListener` / `removeOnStatusChangeListener` so multiple ViewModels can hold independent listeners without overwriting each other
- `WordDetailViewModel` registers its TTS listener via `DisposableEffect` (attach on compose, detach on dispose) so cached off-screen instances don't receive spurious events from other screens

## Test plan

- [ ] Open a study session for a non-English language — tap the speaker icon on a recognition card front; confirm audio plays in the correct language
- [ ] Tap speaker while audio is playing — confirm it stops; tap again — confirm it plays again
- [ ] Observe spinner while TTS is initialising, stop icon while speaking
- [ ] Open a word detail screen and play audio, then navigate to study session and play audio — confirm word detail play state resets correctly on return
- [ ] Open Settings → voice test — confirm TTS status indicator still works after visiting study session
- [ ] Desktop: tap speaker — confirm button does not get stuck in spinner state

🤖 Generated with [Claude Code](https://claude.com/claude-code)