### PR TITLE
ui: rename Favourites to My words and redesign study due card

### DIFF
--- a/composeApp/src/commonMain/composeResources/values-nl/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-nl/strings.xml
@@ -470,7 +470,12 @@
     <string name="study_rating_good">Goed</string>
     <string name="study_rating_easy">Makkelijk</string>
     <string name="favorites_study_due_title">VANDAAG TE HERHALEN</string>
-    <string name="favorites_study_due_count">%1$d kaarten</string>
+    <plurals name="favorites_study_due_count">
+        <item quantity="one">%1$d kaart</item>
+        <item quantity="few">%1$d kaarten</item>
+        <item quantity="many">%1$d kaarten</item>
+        <item quantity="other">%1$d kaarten</item>
+    </plurals>
     <string name="favorites_study_due_subtitle">Ongeveer %1$d min</string>
     <string name="favorites_study_due_action">Herhaling starten</string>
 </resources>

--- a/composeApp/src/commonMain/composeResources/values-nl/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-nl/strings.xml
@@ -3,7 +3,7 @@
     <string name="common_app_name">OpenWords</string>
 
     <string name="nav_search">Zoeken</string>
-    <string name="nav_favorites">Favorieten</string>
+    <string name="nav_favorites">Mijn woorden</string>
     <string name="nav_word_detail">Woord</string>
     <string name="nav_settings">Instellingen</string>
 
@@ -64,15 +64,17 @@
     <string name="download_state_completed">Download voltooid</string>
 
     <string name="favorites_title">Mijn woorden</string>
-    <string name="favorites_loading">Favorieten laden...</string>
+    <string name="favorites_loading">Laden...</string>
     <string name="favorites_search_placeholder">Typ een woord...</string>
-    <string name="favorites_empty_title">Nog geen favorieten</string>
-    <string name="favorites_empty_description">Sla woorden op die je wilt onthouden</string>
+    <string name="favorites_empty_title">Je eigen woordenlijst begint hier.</string>
+    <string name="favorites_empty_description">Zoek een woord en tik op het hartje om het op te slaan voor later.</string>
     <string name="favorites_empty_action_start_searching">Begin met zoeken</string>
-    <string name="favorites_no_results_title">Geen overeenkomende favorieten voor "%1$s"</string>
+    <string name="favorites_no_results_title">Geen opgeslagen woorden voor "%1$s"</string>
     <string name="favorites_no_results_description">Probeer een andere spelling of zoek in het woordenboek</string>
     <string name="favorites_no_results_action_search_dictionary">Zoek in woordenboek</string>
     <string name="favorites_stats">%1$d betekenissen · %2$d woorden</string>
+    <string name="favorites_removed_message">Woord verwijderd</string>
+    <string name="favorites_removed_undo">Ongedaan maken</string>
 
     <string name="language_setup_title">Selecteer talen</string>
     <string name="language_setup_subtitle">Kies wat je leert en je vertaalvoorkeuren.</string>
@@ -467,7 +469,8 @@
     <string name="study_rating_hard">Moeilijk</string>
     <string name="study_rating_good">Goed</string>
     <string name="study_rating_easy">Makkelijk</string>
-    <string name="favorites_study_due_title">Vandaag te herhalen</string>
-    <string name="favorites_study_due_subtitle">%1$d kaarten · ongeveer %2$d min</string>
-    <string name="favorites_study_due_action">Studeren</string>
+    <string name="favorites_study_due_title">VANDAAG TE HERHALEN</string>
+    <string name="favorites_study_due_count">%1$d kaarten</string>
+    <string name="favorites_study_due_subtitle">Ongeveer %1$d min</string>
+    <string name="favorites_study_due_action">Herhaling starten</string>
 </resources>

--- a/composeApp/src/commonMain/composeResources/values-pl/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-pl/strings.xml
@@ -3,7 +3,7 @@
     <string name="common_app_name">OpenWords</string>
 
     <string name="nav_search">Szukaj</string>
-    <string name="nav_favorites">Ulubione</string>
+    <string name="nav_favorites">Moje słowa</string>
     <string name="nav_word_detail">Słowo</string>
     <string name="nav_settings">Ustawienia</string>
 
@@ -66,13 +66,15 @@
     <string name="favorites_title">Moje słowa</string>
     <string name="favorites_loading">Ładowanie...</string>
     <string name="favorites_search_placeholder">Wyszukaj słowo...</string>
-    <string name="favorites_empty_title">Brak ulubionych</string>
-    <string name="favorites_empty_description">Zapisuj słowa, które chcesz zapamiętać.</string>
+    <string name="favorites_empty_title">Twoja lista słówek zaczyna się tutaj.</string>
+    <string name="favorites_empty_description">Wyszukaj dowolne słowo i kliknij serduszko, aby zapisać je do nauki.</string>
     <string name="favorites_empty_action_start_searching">Zacznij szukać</string>
     <string name="favorites_no_results_title">Brak wyników dla „%1$s"</string>
     <string name="favorites_no_results_description">Sprawdź pisownię lub wyszukaj w całym słowniku.</string>
     <string name="favorites_no_results_action_search_dictionary">Szukaj w słowniku</string>
     <string name="favorites_stats">%1$d znaczeń • %2$d słów</string>
+    <string name="favorites_removed_message">Słowo usunięte</string>
+    <string name="favorites_removed_undo">Cofnij</string>
 
     <string name="language_setup_title">Wybierz języki</string>
     <string name="language_setup_subtitle">Wybierz język, którego się uczysz, i preferencje tłumaczeń.</string>
@@ -467,7 +469,8 @@
     <string name="study_rating_hard">Trudne</string>
     <string name="study_rating_good">Dobrze</string>
     <string name="study_rating_easy">Łatwe</string>
-    <string name="favorites_study_due_title">Do powtórki dzisiaj</string>
-    <string name="favorites_study_due_subtitle">%1$d kart · około %2$d min</string>
-    <string name="favorites_study_due_action">Ucz się</string>
+    <string name="favorites_study_due_title">DO POWTÓRKI DZISIAJ</string>
+    <string name="favorites_study_due_count">%1$d kart</string>
+    <string name="favorites_study_due_subtitle">Około %1$d min</string>
+    <string name="favorites_study_due_action">Rozpocznij powtórkę</string>
 </resources>

--- a/composeApp/src/commonMain/composeResources/values-pl/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-pl/strings.xml
@@ -470,7 +470,12 @@
     <string name="study_rating_good">Dobrze</string>
     <string name="study_rating_easy">Łatwe</string>
     <string name="favorites_study_due_title">DO POWTÓRKI DZISIAJ</string>
-    <string name="favorites_study_due_count">%1$d kart</string>
+    <plurals name="favorites_study_due_count">
+        <item quantity="one">%1$d karta</item>
+        <item quantity="few">%1$d karty</item>
+        <item quantity="many">%1$d kart</item>
+        <item quantity="other">%1$d kart</item>
+    </plurals>
     <string name="favorites_study_due_subtitle">Około %1$d min</string>
     <string name="favorites_study_due_action">Rozpocznij powtórkę</string>
 </resources>

--- a/composeApp/src/commonMain/composeResources/values-ru/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-ru/strings.xml
@@ -470,7 +470,12 @@
     <string name="study_rating_good">Хорошо</string>
     <string name="study_rating_easy">Легко</string>
     <string name="favorites_study_due_title">СЕГОДНЯ НУЖНО ПОВТОРИТЬ</string>
-    <string name="favorites_study_due_count">%1$d карточек</string>
+    <plurals name="favorites_study_due_count">
+        <item quantity="one">%1$d карточка</item>
+        <item quantity="few">%1$d карточки</item>
+        <item quantity="many">%1$d карточек</item>
+        <item quantity="other">%1$d карточек</item>
+    </plurals>
     <string name="favorites_study_due_subtitle">около %1$d мин</string>
     <string name="favorites_study_due_action">Начать повторение</string>
 </resources>

--- a/composeApp/src/commonMain/composeResources/values-ru/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-ru/strings.xml
@@ -3,7 +3,7 @@
     <string name="common_app_name">OpenWords</string>
 
     <string name="nav_search">Поиск</string>
-    <string name="nav_favorites">Избранное</string>
+    <string name="nav_favorites">Мои слова</string>
     <string name="nav_word_detail">Слово</string>
     <string name="nav_settings">Настройки</string>
 
@@ -66,13 +66,15 @@
     <string name="favorites_title">Мои слова</string>
     <string name="favorites_loading">Загрузка...</string>
     <string name="favorites_search_placeholder">Найти слово...</string>
-    <string name="favorites_empty_title">Здесь пока пусто</string>
-    <string name="favorites_empty_description">Сохраняйте слова, которые хотите выучить или всегда иметь под рукой.</string>
-    <string name="favorites_empty_action_start_searching">Найти слово</string>
+    <string name="favorites_empty_title">Ваш список слов начинается здесь.</string>
+    <string name="favorites_empty_description">Найдите нужное слово и нажмите на сердечко, чтобы сохранить его для изучения.</string>
+    <string name="favorites_empty_action_start_searching">Начать поиск</string>
     <string name="favorites_no_results_title">В списке нет "%1$s"</string>
     <string name="favorites_no_results_description">Проверьте написание или поищите это слово во всём словаре.</string>
     <string name="favorites_no_results_action_search_dictionary">Искать в словаре</string>
     <string name="favorites_stats">%1$d значений · %2$d слов</string>
+    <string name="favorites_removed_message">Слово удалено</string>
+    <string name="favorites_removed_undo">Отменить</string>
 
     <string name="language_setup_title">Выбор языков</string>
     <string name="language_setup_subtitle">Укажите язык, который вы учите, и на каком показывать перевод.</string>
@@ -467,7 +469,8 @@
     <string name="study_rating_hard">Трудно</string>
     <string name="study_rating_good">Хорошо</string>
     <string name="study_rating_easy">Легко</string>
-    <string name="favorites_study_due_title">Сегодня нужно повторить</string>
-    <string name="favorites_study_due_subtitle">%1$d карточек · около %2$d мин</string>
-    <string name="favorites_study_due_action">Учить</string>
+    <string name="favorites_study_due_title">СЕГОДНЯ НУЖНО ПОВТОРИТЬ</string>
+    <string name="favorites_study_due_count">%1$d карточек</string>
+    <string name="favorites_study_due_subtitle">около %1$d мин</string>
+    <string name="favorites_study_due_action">Начать повторение</string>
 </resources>

--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -3,7 +3,7 @@
     <string name="common_app_name">OpenWords</string>
 
     <string name="nav_search">Search</string>
-    <string name="nav_favorites">Favorites</string>
+    <string name="nav_favorites">My words</string>
     <string name="nav_word_detail">Word Detail</string>
     <string name="nav_settings">Settings</string>
 
@@ -64,15 +64,17 @@
     <string name="download_state_completed">Download completed</string>
 
     <string name="favorites_title">My words</string>
-    <string name="favorites_loading">Loading favorites...</string>
+    <string name="favorites_loading">Loading...</string>
     <string name="favorites_search_placeholder">Type a word...</string>
-    <string name="favorites_empty_title">No Favorites Yet</string>
-    <string name="favorites_empty_description">Save words you want to remember</string>
+    <string name="favorites_empty_title">Your learning list starts here.</string>
+    <string name="favorites_empty_description">Search for any word and tap the heart icon to save it here for later study.</string>
     <string name="favorites_empty_action_start_searching">Start searching</string>
-    <string name="favorites_no_results_title">No matching favorites for "%1$s"</string>
+    <string name="favorites_no_results_title">No saved words matching "%1$s"</string>
     <string name="favorites_no_results_description">Try a different spelling or search the dictionary instead</string>
     <string name="favorites_no_results_action_search_dictionary">Search dictionary</string>
     <string name="favorites_stats">%1$d meanings · %2$d words</string>
+    <string name="favorites_removed_message">Word removed</string>
+    <string name="favorites_removed_undo">Undo</string>
 
     <string name="language_setup_title">Select Languages</string>
     <string name="language_setup_subtitle">Choose what you're learning and your translation preferences.</string>
@@ -467,7 +469,8 @@
     <string name="study_rating_hard">Hard</string>
     <string name="study_rating_good">Good</string>
     <string name="study_rating_easy">Easy</string>
-    <string name="favorites_study_due_title">Due for review today</string>
-    <string name="favorites_study_due_subtitle">%1$d cards · about %2$d min</string>
-    <string name="favorites_study_due_action">Study</string>
+    <string name="favorites_study_due_title">DUE FOR REVIEW TODAY</string>
+    <string name="favorites_study_due_count">%1$d cards</string>
+    <string name="favorites_study_due_subtitle">About %1$d min</string>
+    <string name="favorites_study_due_action">Start study session</string>
 </resources>

--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -470,7 +470,12 @@
     <string name="study_rating_good">Good</string>
     <string name="study_rating_easy">Easy</string>
     <string name="favorites_study_due_title">DUE FOR REVIEW TODAY</string>
-    <string name="favorites_study_due_count">%1$d cards</string>
+    <plurals name="favorites_study_due_count">
+        <item quantity="one">%1$d card</item>
+        <item quantity="few">%1$d cards</item>
+        <item quantity="many">%1$d cards</item>
+        <item quantity="other">%1$d cards</item>
+    </plurals>
     <string name="favorites_study_due_subtitle">About %1$d min</string>
     <string name="favorites_study_due_action">Start study session</string>
 </resources>

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/FavoritesScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/FavoritesScreen.kt
@@ -1,11 +1,14 @@
 package com.slovy.slovymovyapp.ui
 
+import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
@@ -13,10 +16,14 @@ import androidx.compose.ui.BiasAlignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.semantics.onClick
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.compose.LifecycleResumeEffect
 import androidx.lifecycle.viewModelScope
@@ -345,7 +352,7 @@ class FavoritesViewModel(
         }
     }
 
-    fun toggleFavorite(senseId: String) {
+    fun toggleFavorite(senseId: String, removedMessage: String, undoLabel: String) {
         val item = findSense(senseId) ?: return
         viewModelScope.launch {
             // Fetch the favorite to get its createdAt before removal
@@ -366,8 +373,8 @@ class FavoritesViewModel(
 
             // Show snackbar with an undo option
             val result = snackbarHostState.showSnackbar(
-                message = "Removed from favorites",
-                actionLabel = "Undo",
+                message = removedMessage,
+                actionLabel = undoLabel,
                 duration = SnackbarDuration.Short
             )
 
@@ -429,6 +436,8 @@ fun FavoritesScreen(
     onStartStudy: (Language) -> Unit = {},
 ) {
     val focusManager = LocalFocusManager.current
+    val removedMessage = stringResource(Res.string.favorites_removed_message)
+    val undoLabel = stringResource(Res.string.favorites_removed_undo)
 
     LifecycleResumeEffect(viewModel) {
         viewModel.loadFavorites()
@@ -457,7 +466,7 @@ fun FavoritesScreen(
         onSearchInDictionary = onSearchInDictionary,
         onQueryChange = { viewModel.updateQuery(it) },
         onSenseToggle = { viewModel.toggleSense(it) },
-        onFavoriteToggle = { viewModel.toggleFavorite(it) },
+        onFavoriteToggle = { viewModel.toggleFavorite(it, removedMessage, undoLabel) },
         onNavigateToWordDetail = onNavigateToWordDetail,
         wordDetailLabel = wordDetailLabel,
         onNavigateToLastWordDetail = onNavigateToLastWordDetail,
@@ -789,60 +798,60 @@ private fun StudyDueCard(
     onStartStudy: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
+    val actionLabel = stringResource(Res.string.favorites_study_due_action)
     Surface(
-        modifier = modifier,
+        onClick = onStartStudy,
+        modifier = modifier.semantics {
+            onClick(label = actionLabel) { onStartStudy(); true }
+        },
         shape = MaterialTheme.shapes.large,
         color = MaterialTheme.colorScheme.primaryContainer,
         contentColor = MaterialTheme.colorScheme.onPrimaryContainer,
-        tonalElevation = 1.dp,
+        border = BorderStroke(0.5.dp, MaterialTheme.colorScheme.primary.copy(alpha = 0.25f)),
     ) {
         Row(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(AppSpacing.lg),
-            horizontalArrangement = Arrangement.spacedBy(AppSpacing.md),
+                .padding(horizontal = 18.dp, vertical = 16.dp),
             verticalAlignment = Alignment.CenterVertically,
         ) {
-            Surface(
-                modifier = Modifier.size(52.dp),
-                shape = MaterialTheme.shapes.medium,
-                color = MaterialTheme.colorScheme.primary,
-                contentColor = MaterialTheme.colorScheme.onPrimary,
+            Column(
+                modifier = Modifier.weight(1f),
+                verticalArrangement = Arrangement.spacedBy(2.dp),
             ) {
-                Box(contentAlignment = Alignment.Center) {
+                Text(
+                    text = stringResource(Res.string.favorites_study_due_title),
+                    fontSize = 10.5.sp,
+                    fontWeight = FontWeight.Bold,
+                    letterSpacing = 1.4.sp,
+                    color = MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.7f),
+                )
+                Row(horizontalArrangement = Arrangement.spacedBy(10.dp)) {
                     Text(
-                        text = study.dueCount.toString(),
-                        style = MaterialTheme.typography.titleLarge,
-                        fontWeight = FontWeight.Bold,
+                        text = stringResource(Res.string.favorites_study_due_count, study.dueCount),
+                        fontFamily = MaterialTheme.serifFontFamily,
+                        fontSize = 26.sp,
+                        fontWeight = FontWeight.Medium,
+                        letterSpacing = (-0.3).sp,
+                        lineHeight = 27.3.sp,
+                        modifier = Modifier.alignByBaseline(),
+                    )
+                    Text(
+                        text = stringResource(Res.string.favorites_study_due_subtitle, study.estimatedMinutes),
+                        fontFamily = MaterialTheme.serifFontFamily,
+                        fontSize = 13.sp,
+                        fontStyle = FontStyle.Italic,
+                        color = MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.75f),
+                        modifier = Modifier.alignByBaseline(),
                     )
                 }
             }
-            Column(modifier = Modifier.weight(1f)) {
-                Text(
-                    text = stringResource(Res.string.favorites_study_due_title),
-                    style = MaterialTheme.typography.titleMedium,
-                    fontWeight = FontWeight.Bold,
-                )
-                Text(
-                    text = stringResource(
-                        Res.string.favorites_study_due_subtitle,
-                        study.dueCount,
-                        study.estimatedMinutes,
-                    ),
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.78f),
-                )
-            }
-            FilledTonalButton(
-                onClick = onStartStudy,
-                colors = ButtonDefaults.filledTonalButtonColors(
-                    containerColor = MaterialTheme.colorScheme.primary,
-                    contentColor = MaterialTheme.colorScheme.onPrimary,
-                ),
-                shape = MaterialTheme.shapes.small,
-            ) {
-                Text(stringResource(Res.string.favorites_study_due_action))
-            }
+            Icon(
+                imageVector = Icons.AutoMirrored.Filled.KeyboardArrowRight,
+                contentDescription = null,
+                modifier = Modifier.size(22.dp),
+                tint = MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.7f),
+            )
         }
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/FavoritesScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/FavoritesScreen.kt
@@ -49,6 +49,7 @@ import kotlinx.datetime.*
 import kotlinx.datetime.TimeZone.Companion.currentSystemDefault
 import kotlinx.datetime.format.char
 import kotlin.time.Duration.Companion.milliseconds
+import org.jetbrains.compose.resources.pluralStringResource
 import org.jetbrains.compose.resources.stringResource
 import slovymovyapp.composeapp.generated.resources.*
 import kotlin.time.Instant
@@ -802,7 +803,7 @@ private fun StudyDueCard(
     Surface(
         onClick = onStartStudy,
         modifier = modifier.semantics {
-            onClick(label = actionLabel) { onStartStudy(); true }
+            onClick(label = actionLabel, action = null)
         },
         shape = MaterialTheme.shapes.large,
         color = MaterialTheme.colorScheme.primaryContainer,
@@ -828,7 +829,7 @@ private fun StudyDueCard(
                 )
                 Row(horizontalArrangement = Arrangement.spacedBy(10.dp)) {
                     Text(
-                        text = stringResource(Res.string.favorites_study_due_count, study.dueCount),
+                        text = pluralStringResource(Res.plurals.favorites_study_due_count, study.dueCount, study.dueCount),
                         fontFamily = MaterialTheme.serifFontFamily,
                         fontSize = 26.sp,
                         fontWeight = FontWeight.Medium,


### PR DESCRIPTION
## Summary

- **Tab rename**: "Favourites" → "My words" across all four locales (EN/RU/NL/PL); empty-state headline, subtext, loading copy, and snackbar message updated to remove favourites language throughout
- **StudyDueCard redesign**: full-width clickable card per design spec — uppercase eyebrow label, large serif headline ("12 cards"), italic serif meta ("About 3 min"), chevron; no inner Study button; uppercase owned by string resources so translators control casing per locale; explicit `onClick` semantics with localized action label restores accessibility
- **Snackbar**: "Removed from favorites" → localized "Word removed" in all four locales; strings resolved at composable boundary and passed into ViewModel

## Test plan

- [ ] Tab label reads "My words" / "Мои слова" / "Mijn woorden" / "Moje słowa" on each locale
- [ ] Empty state shows updated headline and subtext
- [ ] StudyDueCard renders with eyebrow, headline, meta, chevron — tapping navigates to study session
- [ ] TalkBack/VoiceOver announces the card as a button with the localized action label
- [ ] Removing a word shows "Word removed" snackbar with localized Undo
- [ ] `verifyLocalizationKeys` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)