### PR TITLE
ui: refresh welcome screen copy and icons

### DIFF
--- a/composeApp/src/commonMain/composeResources/values-nl/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-nl/strings.xml
@@ -7,14 +7,14 @@
     <string name="nav_word_detail">Woord</string>
     <string name="nav_settings">Instellingen</string>
 
-    <string name="welcome_tagline">Diepgaand woordenboek\nvoor toegewijde taalleerders zoals jij.</string>
-    <string name="welcome_selling_point_translations_title">Meer dan vertalingen met één woord</string>
-    <string name="welcome_selling_point_translations_description">Bekijk alle betekenissen, woordfrequentie, veelgebruikte uitdrukkingen en voorbeelden uit de praktijk.</string>
-    <string name="welcome_selling_point_collection_title">Jouw collectie</string>
-    <string name="welcome_selling_point_collection_description">Sla woorden op in je persoonlijke bibliotheek en bouw lokaal je woordenschat op.</string>
-    <string name="welcome_selling_point_no_ads_title">Geen advertenties, geen abonnement</string>
-    <string name="welcome_selling_point_no_ads_description">Volledige toegang zonder betaalmuur. Belangrijke data blijft op je apparaat.</string>
-    <string name="welcome_cta_explore_now">Begin nu</string>
+    <string name="welcome_tagline">Niet alleen woorden opzoeken, maar ze ook echt leren. Gratis.</string>
+    <string name="welcome_selling_point_translations_title">Zoek elk woord op</string>
+    <string name="welcome_selling_point_translations_description">Voorbeelden, vormen, zinnen en synoniemen — alles handig op één plek.</string>
+    <string name="welcome_selling_point_collection_title">Je eigen woordenlijst</string>
+    <string name="welcome_selling_point_collection_description">Bewaar de woorden die je wilt onthouden. Je lijst blijft gewoon op je eigen toestel staan.</string>
+    <string name="welcome_selling_point_practice_title">Houd je kennis vast</string>
+    <string name="welcome_selling_point_practice_description">Slim herhalen en verschillende oefeningen helpen je om woorden echt te onthouden.</string>
+    <string name="welcome_cta_explore_now">Aan de slag</string>
 
     <string name="search_placeholder">Zoek je woord...</string>
     <string name="search_open_item">Openen %1$s</string>

--- a/composeApp/src/commonMain/composeResources/values-pl/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-pl/strings.xml
@@ -7,14 +7,14 @@
     <string name="nav_word_detail">Słowo</string>
     <string name="nav_settings">Ustawienia</string>
 
-    <string name="welcome_tagline">Poznaj język od podszewki.\nSłownik dla ambitnych uczniów.</string>
-    <string name="welcome_selling_point_translations_title">Więcej niż proste tłumaczenia</string>
-    <string name="welcome_selling_point_translations_description">Wszystkie znaczenia, częstotliwość, typowe zwroty i żywe przykłady.</string>
-    <string name="welcome_selling_point_collection_title">Twoja kolekcja</string>
-    <string name="welcome_selling_point_collection_description">Zapisuj słowa w bibliotece i rozwijaj swoje słownictwo.</string>
-    <string name="welcome_selling_point_no_ads_title">Bez reklam i subskrypcji</string>
-    <string name="welcome_selling_point_no_ads_description">Pełen dostęp bez płatnych blokad. Dane pozostają na Twoim urządzeniu.</string>
-    <string name="welcome_cta_explore_now">Wybierz języki</string>
+    <string name="welcome_tagline">Aplikacja, by nie tylko sprawdzać słowa, ale faktycznie się ich uczyć. Za darmo.</string>
+    <string name="welcome_selling_point_translations_title">Wyszukuj dowolne słowa</string>
+    <string name="welcome_selling_point_translations_description">Przykłady, odmiany, zwroty i synonimy — wszystko w jednym miejscu.</string>
+    <string name="welcome_selling_point_collection_title">Twoja własna lista słówek</string>
+    <string name="welcome_selling_point_collection_description">Zapisuj to, co chcesz zapamiętać. Twoja kolekcja zostaje tylko na Twoim urządzeniu.</string>
+    <string name="welcome_selling_point_practice_title">Utrwalaj wiedzę</string>
+    <string name="welcome_selling_point_practice_description">Metoda powtórek i różne tryby pomogą Ci na dobre zapamiętać nowe słowa.</string>
+    <string name="welcome_cta_explore_now">Zacznij teraz</string>
 
     <string name="search_placeholder">Wyszukaj słowo...</string>
     <string name="search_open_item">Otwórz %1$s</string>

--- a/composeApp/src/commonMain/composeResources/values-ru/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-ru/strings.xml
@@ -7,14 +7,14 @@
     <string name="nav_word_detail">Слово</string>
     <string name="nav_settings">Настройки</string>
 
-    <string name="welcome_tagline">Глубокое погружение в язык\nдля тех, кто ценит детали.</string>
-    <string name="welcome_selling_point_translations_title">Больше, чем просто перевод</string>
-    <string name="welcome_selling_point_translations_description">Все значения, частотность, устойчивые фразы и живые примеры из речи.</string>
-    <string name="welcome_selling_point_collection_title">Личный словарь</string>
-    <string name="welcome_selling_point_collection_description">Сохраняйте слова в свою библиотеку и пополняйте словарный запас.</string>
-    <string name="welcome_selling_point_no_ads_title">Без рекламы и подписок</string>
-    <string name="welcome_selling_point_no_ads_description">Полный доступ без платных преград. Все данные хранятся только у вас.</string>
-    <string name="welcome_cta_explore_now">Выбрать языки</string>
+    <string name="welcome_tagline">Приложение, чтобы не просто искать слова, а учить их. Бесплатно.</string>
+    <string name="welcome_selling_point_translations_title">Ищите любые слова</string>
+    <string name="welcome_selling_point_translations_description">Примеры, формы, фразы и синонимы — всё в одном месте.</string>
+    <string name="welcome_selling_point_collection_title">Свой список слов</string>
+    <string name="welcome_selling_point_collection_description">Сохраняйте то, что хотите запомнить. Ваша подборка остается только на устройстве.</string>
+    <string name="welcome_selling_point_practice_title">Закрепляйте результат</string>
+    <string name="welcome_selling_point_practice_description">Интервальные повторения и разные режимы помогут по-настоящему запомнить новые слова.</string>
+    <string name="welcome_cta_explore_now">Начать</string>
 
     <string name="search_placeholder">Найти слово...</string>
     <string name="search_open_item">Открыть %1$s</string>

--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -7,14 +7,14 @@
     <string name="nav_word_detail">Word Detail</string>
     <string name="nav_settings">Settings</string>
 
-    <string name="welcome_tagline">Deep-dive dictionary\nfor committed learners like you.</string>
-    <string name="welcome_selling_point_translations_title">Beyond one-word translations</string>
-    <string name="welcome_selling_point_translations_description">Find all meanings, word frequency, common phrases, and real-world examples.</string>
-    <string name="welcome_selling_point_collection_title">Your Collection</string>
-    <string name="welcome_selling_point_collection_description">Save words to your personal library and build your vocabulary locally.</string>
-    <string name="welcome_selling_point_no_ads_title">No ads, no subscription</string>
-    <string name="welcome_selling_point_no_ads_description">Access the full experience without paywalls. Essential data stays on your device.</string>
-    <string name="welcome_cta_explore_now">Explore Now</string>
+    <string name="welcome_tagline">The app that turns looked-up words into learned words. Free.</string>
+    <string name="welcome_selling_point_translations_title">Look up any word</string>
+    <string name="welcome_selling_point_translations_description">Examples, forms, phrases, synonyms — everything about it in one place.</string>
+    <string name="welcome_selling_point_collection_title">Build your personal word list</string>
+    <string name="welcome_selling_point_collection_description">Save words as you go. Your collection stays on your device.</string>
+    <string name="welcome_selling_point_practice_title">Practice until words stick</string>
+    <string name="welcome_selling_point_practice_description">Spaced repetition and multiple modes help you actually remember what you learn.</string>
+    <string name="welcome_cta_explore_now">Get Started</string>
 
     <string name="search_placeholder">Search your word...</string>
     <string name="search_open_item">Open %1$s</string>

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/WelcomeScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/WelcomeScreen.kt
@@ -6,8 +6,8 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.FavoriteBorder
-import androidx.compose.material.icons.outlined.Lightbulb
-import androidx.compose.material.icons.outlined.Shield
+import androidx.compose.material.icons.outlined.Psychology
+import androidx.compose.material.icons.outlined.Search
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
@@ -110,7 +110,7 @@ fun WelcomeScreenContent(
                     verticalArrangement = Arrangement.spacedBy(AppSpacing.md)
                 ) {
                     SellingPointCard(
-                        icon = Icons.Outlined.Lightbulb,
+                        icon = Icons.Outlined.Search,
                         title = stringResource(Res.string.welcome_selling_point_translations_title),
                         description = stringResource(Res.string.welcome_selling_point_translations_description)
                     )
@@ -122,9 +122,9 @@ fun WelcomeScreenContent(
                     )
 
                     SellingPointCard(
-                        icon = Icons.Outlined.Shield,
-                        title = stringResource(Res.string.welcome_selling_point_no_ads_title),
-                        description = stringResource(Res.string.welcome_selling_point_no_ads_description)
+                        icon = Icons.Outlined.Psychology,
+                        title = stringResource(Res.string.welcome_selling_point_practice_title),
+                        description = stringResource(Res.string.welcome_selling_point_practice_description)
                     )
                 }
 


### PR DESCRIPTION
## Summary
- Updated tagline, selling point texts, and CTA button for all 4 locales (EN, RU, NL, PL)
- Renamed `welcome_selling_point_no_ads_*` string keys to `welcome_selling_point_practice_*` to match the new content
- Replaced icons: Search for card 1 (look up), Psychology for card 3 (practice)

## Test plan
- [ ] Check welcome screen in light and dark themes
- [ ] Verify all 4 locales render correctly (EN, RU, NL, PL)
- [ ] Confirm localization key parity: `./gradlew :composeApp:verifyLocalizationKeys`

🤖 Generated with [Claude Code](https://claude.com/claude-code)