### PR TITLE
ui: show study completion praise in studied language

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -164,6 +164,11 @@ private fun MyScreenPreview(
 - If pluralization is needed, add `<plurals>` resources instead of manual `"s"` suffix logic.
 - Keep user-visible copy out of Kotlin literals in `commonMain` UI code.
 - Preview-only literals are acceptable in `@Preview` functions.
+- Exception: copy that must render in the *studied* language (not the user's UI locale) does not belong in
+  `composeResources/`. `stringResource` resolves by OS locale, so it cannot pick by a per-session language code. For
+  these cases, hold the strings in a Kotlin map keyed by `Language` (see
+  `composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/study/StudyCompletionMessages.kt`) and resolve in the
+  ViewModel/state — not in the composable, so random picks are stable across recompositions.
 
 #### Non-composable and shared text
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -163,6 +163,11 @@ private fun MyScreenPreview(
 - If pluralization is needed, add `<plurals>` resources instead of manual `"s"` suffix logic.
 - Keep user-visible copy out of Kotlin literals in `commonMain` UI code.
 - Preview-only literals are acceptable in `@Preview` functions.
+- Exception: copy that must render in the *studied* language (not the user's UI locale) does not belong in
+  `composeResources/`. `stringResource` resolves by OS locale, so it cannot pick by a per-session language code. For
+  these cases, hold the strings in a Kotlin map keyed by `Language` (see
+  `composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/study/StudyCompletionMessages.kt`) and resolve in the
+  ViewModel/state — not in the composable, so random picks are stable across recompositions.
 
 #### Non-composable and shared text
 

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -163,6 +163,11 @@ private fun MyScreenPreview(
 - If pluralization is needed, add `<plurals>` resources instead of manual `"s"` suffix logic.
 - Keep user-visible copy out of Kotlin literals in `commonMain` UI code.
 - Preview-only literals are acceptable in `@Preview` functions.
+- Exception: copy that must render in the *studied* language (not the user's UI locale) does not belong in
+  `composeResources/`. `stringResource` resolves by OS locale, so it cannot pick by a per-session language code. For
+  these cases, hold the strings in a Kotlin map keyed by `Language` (see
+  `composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/study/StudyCompletionMessages.kt`) and resolve in the
+  ViewModel/state — not in the composable, so random picks are stable across recompositions.
 
 #### Non-composable and shared text
 

--- a/composeApp/src/commonMain/composeResources/values-nl/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-nl/strings.xml
@@ -451,7 +451,6 @@
         <item quantity="other">%1$d kaarten afgerond.</item>
     </plurals>
     <string name="study_complete_supporting">Zo blijven woorden hangen.</string>
-    <string name="study_action_done_for_now">Klaar voor nu</string>
     <string name="study_progress_count">%1$d van %2$d</string>
     <string name="study_tap_to_flip">Tik om te draaien</string>
     <string name="study_tap_to_check">Tik om te controleren</string>

--- a/composeApp/src/commonMain/composeResources/values-pl/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-pl/strings.xml
@@ -451,7 +451,6 @@
         <item quantity="other">Przerobiono %1$d karty.</item>
     </plurals>
     <string name="study_complete_supporting">Właśnie tak utrwalasz słownictwo.</string>
-    <string name="study_action_done_for_now">Na dziś wystarczy</string>
     <string name="study_progress_count">%1$d z %2$d</string>
     <string name="study_tap_to_flip">Dotknij, aby odwrócić</string>
     <string name="study_tap_to_check">Dotknij, aby sprawdzić</string>

--- a/composeApp/src/commonMain/composeResources/values-ru/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-ru/strings.xml
@@ -451,7 +451,6 @@
         <item quantity="other">Пройдено %1$d карточки.</item>
     </plurals>
     <string name="study_complete_supporting">Вот так слова и запоминаются.</string>
-    <string name="study_action_done_for_now">На сегодня хватит</string>
     <string name="study_progress_count">%1$d из %2$d</string>
     <string name="study_tap_to_flip">Нажмите, чтобы перевернуть</string>
     <string name="study_tap_to_check">Нажмите, чтобы проверить</string>

--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -451,7 +451,6 @@
         <item quantity="other">%1$d cards completed.</item>
     </plurals>
     <string name="study_complete_supporting">That’s how words stick.</string>
-    <string name="study_action_done_for_now">Done for now</string>
     <string name="study_progress_count">%1$d of %2$d</string>
     <string name="study_tap_to_flip">Tap to flip</string>
     <string name="study_tap_to_check">Tap to check</string>

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/study/StudyCompletionMessages.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/study/StudyCompletionMessages.kt
@@ -1,0 +1,15 @@
+package com.slovy.slovymovyapp.ui.study
+
+import com.slovy.slovymovyapp.data.Language
+
+private val MESSAGES_BY_LANGUAGE: Map<Language, List<String>> = mapOf(
+    Language.ENGLISH to listOf("Well done!", "Great work!", "Nicely done!", "Good job!"),
+    Language.DUTCH to listOf("Goed gedaan!", "Goed bezig!", "Netjes!", "Lekker gewerkt!"),
+    Language.POLISH to listOf("Dobra robota!", "Brawo!", "Świetnie!", "Udało się!"),
+    Language.RUSSIAN to listOf("Отлично!", "Хорошая работа!", "Молодец!", "Готово!"),
+)
+
+fun randomCompletionMessage(language: Language?): String {
+    val list = MESSAGES_BY_LANGUAGE[language] ?: MESSAGES_BY_LANGUAGE.getValue(Language.ENGLISH)
+    return list.random()
+}

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/study/StudySessionModels.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/study/StudySessionModels.kt
@@ -26,6 +26,7 @@ sealed interface StudySessionUiState {
 
     data class Complete(
         val reviewedCount: Int,
+        val message: String,
     ) : StudySessionUiState
 }
 

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/study/StudySessionScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/study/StudySessionScreen.kt
@@ -69,7 +69,6 @@ import org.jetbrains.compose.resources.pluralStringResource
 import org.jetbrains.compose.resources.stringResource
 import slovymovyapp.composeapp.generated.resources.Res
 import slovymovyapp.composeapp.generated.resources.study_action_close
-import slovymovyapp.composeapp.generated.resources.study_action_done_for_now
 import slovymovyapp.composeapp.generated.resources.study_action_retry
 import slovymovyapp.composeapp.generated.resources.study_complete_description
 import slovymovyapp.composeapp.generated.resources.study_complete_supporting
@@ -202,6 +201,7 @@ fun StudySessionScreenContent(
 
         is StudySessionUiState.Complete -> StudySessionCompleteContent(
             reviewedCount = state.reviewedCount,
+            message = state.message,
             scrollState = completeScrollState,
             onClose = onEnd,
             modifier = modifier,
@@ -257,6 +257,7 @@ private fun StudySessionLoadingContent(
 @Composable
 private fun StudySessionCompleteContent(
     reviewedCount: Int,
+    message: String,
     scrollState: ScrollState,
     onClose: () -> Unit,
     modifier: Modifier = Modifier,
@@ -333,7 +334,7 @@ private fun StudySessionCompleteContent(
                 contentPadding = PaddingValues(horizontal = AppSpacing.lg),
             ) {
                 Text(
-                    text = stringResource(Res.string.study_action_done_for_now),
+                    text = message,
                     style = MaterialTheme.typography.titleMedium,
                     fontWeight = FontWeight.SemiBold,
                 )
@@ -1431,7 +1432,7 @@ private fun StudySessionCompletePreview(
 ) {
     ThemedPreview(darkTheme = isDark) {
         StudySessionScreenContent(
-            state = StudySessionUiState.Complete(reviewedCount = 12),
+            state = StudySessionUiState.Complete(reviewedCount = 12, message = "Goed gedaan!"),
             onCancel = {},
             onEnd = {},
         )

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/study/StudySessionViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/study/StudySessionViewModel.kt
@@ -197,7 +197,10 @@ class StudySessionViewModel(
                                 state = if (reviewedCount == 0) {
                                     StudySessionUiState.Empty
                                 } else {
-                                    StudySessionUiState.Complete(reviewedCount)
+                                    StudySessionUiState.Complete(
+                                        reviewedCount = reviewedCount,
+                                        message = randomCompletionMessage(language),
+                                    )
                                 }
                             }
 


### PR DESCRIPTION
Replaces the user-locale "Done for now" button with a randomised praise phrase in the language being studied (EN/NL/PL/RU). Held in a Kotlin map keyed by Language because Compose Resources resolve by OS locale, not by per-session language. Random pick happens in the ViewModel when entering Complete, so it stays stable across recompositions.

Documents the exception in the Localization section of AGENTS.md / CLAUDE.md / GEMINI.md.