### PR TITLE
ui: study session card improvements

### DIFF
--- a/composeApp/src/commonMain/composeResources/values-nl/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-nl/strings.xml
@@ -465,6 +465,12 @@
     <string name="study_play_prompt_audio">Opdracht afspelen</string>
     <string name="study_stop_audio">Audio stoppen</string>
     <string name="study_listen_prompt">Tik om af te spelen. Welk woord hoor je?</string>
+    <plurals name="study_hint_starts_with">
+        <item quantity="one">Hint: begint met %1$s, %2$d letter</item>
+        <item quantity="few">Hint: begint met %1$s, %2$d letters</item>
+        <item quantity="many">Hint: begint met %1$s, %2$d letters</item>
+        <item quantity="other">Hint: begint met %1$s, %2$d letters</item>
+    </plurals>
     <string name="study_rating_again">Opnieuw</string>
     <string name="study_rating_hard">Moeilijk</string>
     <string name="study_rating_good">Goed</string>

--- a/composeApp/src/commonMain/composeResources/values-pl/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-pl/strings.xml
@@ -465,6 +465,12 @@
     <string name="study_play_prompt_audio">Odtwórz zadanie</string>
     <string name="study_stop_audio">Zatrzymaj audio</string>
     <string name="study_listen_prompt">Dotknij, aby odtworzyć. Jakie słowo słyszysz?</string>
+    <plurals name="study_hint_starts_with">
+        <item quantity="one">Podpowiedź: zaczyna się na %1$s, %2$d litera</item>
+        <item quantity="few">Podpowiedź: zaczyna się na %1$s, %2$d litery</item>
+        <item quantity="many">Podpowiedź: zaczyna się na %1$s, %2$d liter</item>
+        <item quantity="other">Podpowiedź: zaczyna się na %1$s, %2$d litery</item>
+    </plurals>
     <string name="study_rating_again">Jeszcze raz</string>
     <string name="study_rating_hard">Trudne</string>
     <string name="study_rating_good">Dobrze</string>

--- a/composeApp/src/commonMain/composeResources/values-ru/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-ru/strings.xml
@@ -465,6 +465,12 @@
     <string name="study_play_prompt_audio">Воспроизвести задание</string>
     <string name="study_stop_audio">Остановить аудио</string>
     <string name="study_listen_prompt">Нажмите для воспроизведения. Какое слово вы слышите?</string>
+    <plurals name="study_hint_starts_with">
+        <item quantity="one">Подсказка: начинается на %1$s, %2$d буква</item>
+        <item quantity="few">Подсказка: начинается на %1$s, %2$d буквы</item>
+        <item quantity="many">Подсказка: начинается на %1$s, %2$d букв</item>
+        <item quantity="other">Подсказка: начинается на %1$s, %2$d букв</item>
+    </plurals>
     <string name="study_rating_again">Снова</string>
     <string name="study_rating_hard">Трудно</string>
     <string name="study_rating_good">Хорошо</string>

--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -464,6 +464,12 @@
     <string name="study_play_word_audio">Play word audio</string>
     <string name="study_play_prompt_audio">Play prompt audio</string>
     <string name="study_stop_audio">Stop audio</string>
+    <plurals name="study_hint_starts_with">
+        <item quantity="one">Hint: starts with %1$s, %2$d letter</item>
+        <item quantity="few">Hint: starts with %1$s, %2$d letters</item>
+        <item quantity="many">Hint: starts with %1$s, %2$d letters</item>
+        <item quantity="other">Hint: starts with %1$s, %2$d letters</item>
+    </plurals>
     <string name="study_listen_prompt">Tap to play. What word do you hear?</string>
     <string name="study_rating_again">Again</string>
     <string name="study_rating_hard">Hard</string>

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/study/StudySessionMapper.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/study/StudySessionMapper.kt
@@ -190,6 +190,7 @@ private fun sourceBack(
 ): StudyCardBackUiState =
     StudyCardBackUiState(
         headline = lemma,
+        isLemmaHeadline = true,
         secondary = targetLanguage?.let { sense.translationWords(it) },
         definition = sense.senseDefinition,
         examples = sense.studyExamples(targetLanguage),
@@ -231,7 +232,7 @@ private fun ExamplePair.toClozeText(): StudyClozeTextUiState? {
     )
 }
 
-private fun String.firstLetterHint(): FirstLetterHint? {
+internal fun String.firstLetterHint(): FirstLetterHint? {
     val first = firstOrNull { it.isLetter() } ?: return null
     val letterCount = count { it.isLetter() }
     val dotCount = letterCount.minus(1).coerceAtLeast(3)

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/study/StudySessionMapper.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/study/StudySessionMapper.kt
@@ -231,13 +231,11 @@ private fun ExamplePair.toClozeText(): StudyClozeTextUiState? {
     )
 }
 
-private fun String.firstLetterHint(): String? {
+private fun String.firstLetterHint(): FirstLetterHint? {
     val first = firstOrNull { it.isLetter() } ?: return null
-    val hiddenCount = count { it.isLetter() }.minus(1).coerceAtLeast(3)
-    return buildString {
-        append(first)
-        repeat(hiddenCount) { append(" _") }
-    }
+    val letterCount = count { it.isLetter() }
+    val dotCount = letterCount.minus(1).coerceAtLeast(3)
+    return FirstLetterHint(letter = first, letterCount = letterCount, dotCount = dotCount)
 }
 
 private fun Language.studyCode(): String = code.uppercase()

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/study/StudySessionModels.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/study/StudySessionModels.kt
@@ -91,6 +91,7 @@ enum class StudyRecognitionMode {
 
 data class StudyCardBackUiState(
     val headline: String,
+    val isLemmaHeadline: Boolean = false,
     val secondary: String? = null,
     val definition: String? = null,
     val examples: List<StudyExampleUiState> = emptyList(),

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/study/StudySessionModels.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/study/StudySessionModels.kt
@@ -2,6 +2,8 @@ package com.slovy.slovymovyapp.ui.study
 
 import com.slovy.slovymovyapp.i18n.UiText
 
+data class FirstLetterHint(val letter: Char, val letterCount: Int, val dotCount: Int)
+
 sealed interface StudySessionUiState {
     data class Loading(
         val progress: StudySessionProgressUiState? = null,
@@ -62,7 +64,7 @@ sealed interface StudyCardUiState {
         override val chipLabel: UiText,
         val promptLabel: UiText,
         val promptText: String,
-        val firstLetterHint: String? = null,
+        val firstLetterHint: FirstLetterHint? = null,
         override val back: StudyCardBackUiState,
     ) : StudyCardUiState
 

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/study/StudySessionScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/study/StudySessionScreen.kt
@@ -39,9 +39,18 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.geometry.CornerRadius
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.text.TextLayoutResult
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.SpanStyle
@@ -1054,35 +1063,54 @@ private fun StudyClozeText(
     val highlightColor = MaterialTheme.colorScheme.primary
     val highlightBackground = MaterialTheme.colorScheme.primaryContainer
     val blank = " ".repeat(cloze.answer.length.coerceAtLeast(6))
+
+    val prefixPlain = HtmlTagParser.plainText(cloze.prefix)
+    val answerPlain = HtmlTagParser.plainText(cloze.answer)
+    val highlightStart = prefixPlain.length
+    val highlightEnd = highlightStart + answerPlain.length
+
     val text = buildAnnotatedString {
-        append(HtmlTagParser.plainText(cloze.prefix))
+        append(prefixPlain)
         if (cloze.filled) {
-            pushStyle(
-                SpanStyle(
-                    color = highlightColor,
-                    background = highlightBackground,
-                    fontWeight = FontWeight.SemiBold,
-                ),
-            )
-            append(HtmlTagParser.plainText(cloze.answer))
+            pushStyle(SpanStyle(color = highlightColor, fontWeight = FontWeight.SemiBold))
+            append(answerPlain)
             pop()
         } else {
-            pushStyle(
-                SpanStyle(
-                    color = highlightColor,
-                    textDecoration = TextDecoration.Underline,
-                ),
-            )
+            pushStyle(SpanStyle(color = highlightColor, textDecoration = TextDecoration.Underline))
             append(blank)
             pop()
         }
         append(HtmlTagParser.plainText(cloze.suffix))
     }
+
+    var layoutResult by remember(text) { mutableStateOf<TextLayoutResult?>(null) }
+
     Text(
         text = text,
         style = style,
         color = MaterialTheme.colorScheme.onSurface,
-        modifier = modifier.fillMaxWidth(),
+        modifier = modifier
+            .fillMaxWidth()
+            .drawBehind {
+                if (!cloze.filled) return@drawBehind
+                val layout = layoutResult ?: return@drawBehind
+                val startLine = layout.getLineForOffset(highlightStart)
+                val endLine = layout.getLineForOffset((highlightEnd - 1).coerceAtLeast(highlightStart))
+                for (line in startLine..endLine) {
+                    val lineRangeStart = maxOf(layout.getLineStart(line), highlightStart)
+                    val lineRangeEnd = minOf(layout.getLineEnd(line), highlightEnd)
+                    if (lineRangeStart >= lineRangeEnd) continue
+                    val startBound = layout.getBoundingBox(lineRangeStart)
+                    val endBound = layout.getBoundingBox((lineRangeEnd - 1).coerceAtLeast(lineRangeStart))
+                    drawRoundRect(
+                        color = highlightBackground,
+                        topLeft = Offset(startBound.left, layout.getLineTop(line)),
+                        size = Size(endBound.right - startBound.left, layout.getLineBottom(line) - layout.getLineTop(line)),
+                        cornerRadius = CornerRadius(4.dp.toPx()),
+                    )
+                }
+            },
+        onTextLayout = { layoutResult = it },
     )
 }
 

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/study/StudySessionScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/study/StudySessionScreen.kt
@@ -57,7 +57,6 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.semantics.contentDescription
-import androidx.compose.ui.semantics.role
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.buildAnnotatedString
@@ -774,7 +773,6 @@ private fun ProductionFront(
                     color = MaterialTheme.colorScheme.surfaceContainerHigh,
                     contentColor = MaterialTheme.colorScheme.onSurfaceVariant,
                     modifier = Modifier.clearAndSetSemantics {
-                        role = Role.Image
                         contentDescription = hintContentDescription
                     },
                 ) {
@@ -792,10 +790,11 @@ private fun ProductionFront(
                             color = MaterialTheme.colorScheme.onSurface,
                         )
                         Text(
-                            text = "·".repeat(hint.dotCount),
+                            text = "·".repeat(hint.dotCount.coerceAtMost(15)),
                             fontSize = 16.sp,
                             fontFamily = MaterialTheme.serifFontFamily,
                             letterSpacing = 8.sp,
+                            maxLines = 1,
                         )
                     }
                 }

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/study/StudySessionScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/study/StudySessionScreen.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.Image
 import androidx.compose.foundation.ScrollState
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.PaddingValues
@@ -19,6 +20,7 @@ import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.shape.CircleShape
@@ -61,6 +63,7 @@ import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.foundation.text.TextAutoSize
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.tooling.preview.Preview
@@ -694,10 +697,12 @@ private fun RecognitionFront(
     onStopAudio: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    Box(
+    BoxWithConstraints(
         modifier = modifier.fillMaxWidth(),
         contentAlignment = Alignment.Center,
     ) {
+        val availableWidth = maxWidth
+        val speakerSpace = if (card.promptAudioText != null) 36.dp + AppSpacing.sm else 0.dp
         Row(
             horizontalArrangement = Arrangement.spacedBy(AppSpacing.sm),
             verticalAlignment = Alignment.CenterVertically,
@@ -709,6 +714,13 @@ private fun RecognitionFront(
                 ),
                 color = MaterialTheme.colorScheme.onSurface,
                 textAlign = TextAlign.Center,
+                maxLines = 1,
+                autoSize = TextAutoSize.StepBased(
+                    minFontSize = 14.sp,
+                    maxFontSize = MaterialTheme.typography.displayMedium.fontSize,
+                    stepSize = 1.sp,
+                ),
+                modifier = Modifier.widthIn(max = availableWidth - speakerSpace),
             )
             card.promptAudioText?.let { audioText ->
                 StudySpeakerButton(
@@ -906,9 +918,10 @@ private fun StudyCardBack(
             Spacer(Modifier.height(AppSpacing.xs))
         }
 
+        val headlineIsLemma = back.audioText != null
         Row(
             horizontalArrangement = Arrangement.spacedBy(AppSpacing.sm),
-            verticalAlignment = Alignment.CenterVertically,
+            verticalAlignment = Alignment.Top,
         ) {
             StudyTaggedText(
                 text = back.headline,
@@ -917,6 +930,12 @@ private fun StudyCardBack(
                 ),
                 color = MaterialTheme.colorScheme.onSurface,
                 textAlign = TextAlign.Start,
+                maxLines = if (headlineIsLemma) 1 else Int.MAX_VALUE,
+                autoSize = if (headlineIsLemma) TextAutoSize.StepBased(
+                    minFontSize = 14.sp,
+                    maxFontSize = MaterialTheme.typography.headlineLarge.fontSize,
+                    stepSize = 1.sp,
+                ) else null,
                 modifier = Modifier.weight(1f, fill = false),
             )
             back.audioText?.let { audioText ->
@@ -1130,6 +1149,8 @@ private fun StudyTaggedText(
     color: Color,
     modifier: Modifier = Modifier,
     textAlign: TextAlign? = null,
+    maxLines: Int = Int.MAX_VALUE,
+    autoSize: TextAutoSize? = null,
 ) {
     val highlightColor = MaterialTheme.colorScheme.primary
     val annotated = buildAnnotatedString {
@@ -1148,13 +1169,26 @@ private fun StudyTaggedText(
             }
         }
     }
-    Text(
-        text = annotated,
-        style = style,
-        color = color,
-        textAlign = textAlign,
-        modifier = modifier,
-    )
+    if (autoSize != null) {
+        Text(
+            text = annotated,
+            style = style,
+            color = color,
+            textAlign = textAlign,
+            maxLines = maxLines,
+            autoSize = autoSize,
+            modifier = modifier,
+        )
+    } else {
+        Text(
+            text = annotated,
+            style = style,
+            color = color,
+            textAlign = textAlign,
+            maxLines = maxLines,
+            modifier = modifier,
+        )
+    }
 }
 
 @Composable

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/study/StudySessionScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/study/StudySessionScreen.kt
@@ -53,11 +53,13 @@ import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.text.TextLayoutResult
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.clearAndSetSemantics
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.role
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontStyle
-import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextDecoration
@@ -93,6 +95,7 @@ import slovymovyapp.composeapp.generated.resources.study_listen_prompt
 import slovymovyapp.composeapp.generated.resources.study_loading
 import slovymovyapp.composeapp.generated.resources.study_play_prompt_audio
 import slovymovyapp.composeapp.generated.resources.study_play_word_audio
+import slovymovyapp.composeapp.generated.resources.study_hint_starts_with
 import slovymovyapp.composeapp.generated.resources.study_stop_audio
 import slovymovyapp.composeapp.generated.resources.study_prompt_translate_to
 import slovymovyapp.composeapp.generated.resources.study_progress_count
@@ -753,10 +756,15 @@ private fun ProductionFront(
                 modifier = Modifier.fillMaxWidth(),
             )
             card.firstLetterHint?.let { hint ->
+                val hintContentDescription = pluralStringResource(Res.plurals.study_hint_starts_with, hint.letterCount, hint.letter.toString(), hint.letterCount)
                 Surface(
                     shape = CircleShape,
                     color = MaterialTheme.colorScheme.surfaceContainerHigh,
                     contentColor = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.clearAndSetSemantics {
+                        role = Role.Image
+                        contentDescription = hintContentDescription
+                    },
                 ) {
                     Row(
                         modifier = Modifier.padding(horizontal = 14.dp, vertical = 8.dp),
@@ -764,17 +772,18 @@ private fun ProductionFront(
                         horizontalArrangement = Arrangement.spacedBy(6.dp),
                     ) {
                         Text(
-                            text = hint.take(1),
+                            text = hint.letter.toString(),
                             fontSize = 16.sp,
                             fontWeight = FontWeight.SemiBold,
                             letterSpacing = 0.sp,
+                            fontFamily = MaterialTheme.serifFontFamily,
                             color = MaterialTheme.colorScheme.onSurface,
                         )
                         Text(
-                            text = hint.drop(2),
+                            text = "·".repeat(hint.dotCount),
                             fontSize = 16.sp,
-                            fontFamily = FontFamily.Monospace,
-                            letterSpacing = 4.sp,
+                            fontFamily = MaterialTheme.serifFontFamily,
+                            letterSpacing = 8.sp,
                         )
                     }
                 }
@@ -1250,7 +1259,7 @@ private fun productionCard() = StudyCardUiState.Production(
     chipLabel = UiText.Plain("EN -> NL"),
     promptLabel = UiText.Resource(Res.string.study_prompt_translate_to, listOf("Dutch")),
     promptText = "cosy, sociable",
-    firstLetterHint = "g _ _ _ _ _ _ _ _",
+    firstLetterHint = FirstLetterHint(letter = 'g', letterCount = 8, dotCount = 7),
     back = StudyCardBackUiState(
         headline = "gezellig",
         secondary = "cosy, sociable",

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/study/StudySessionScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/study/StudySessionScreen.kt
@@ -720,7 +720,7 @@ private fun RecognitionFront(
                     maxFontSize = MaterialTheme.typography.displayMedium.fontSize,
                     stepSize = 1.sp,
                 ),
-                modifier = Modifier.widthIn(max = availableWidth - speakerSpace),
+                modifier = Modifier.widthIn(max = (availableWidth - speakerSpace).coerceAtLeast(0.dp)),
             )
             card.promptAudioText?.let { audioText ->
                 StudySpeakerButton(
@@ -918,7 +918,7 @@ private fun StudyCardBack(
             Spacer(Modifier.height(AppSpacing.xs))
         }
 
-        val headlineIsLemma = back.audioText != null
+        val headlineIsLemma = back.isLemmaHeadline
         Row(
             horizontalArrangement = Arrangement.spacedBy(AppSpacing.sm),
             verticalAlignment = Alignment.Top,

--- a/composeApp/src/commonTest/kotlin/com/slovy/slovymovyapp/ui/study/FirstLetterHintTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/slovy/slovymovyapp/ui/study/FirstLetterHintTest.kt
@@ -1,0 +1,82 @@
+package com.slovy.slovymovyapp.ui.study
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class FirstLetterHintTest {
+
+    @Test
+    fun normalWord() {
+        val hint = "gezellig".firstLetterHint()!!
+        assertEquals('g', hint.letter)
+        assertEquals(8, hint.letterCount)
+        assertEquals(7, hint.dotCount)
+    }
+
+    @Test
+    fun longCompound() {
+        val hint = "tentoonstelling".firstLetterHint()!!
+        assertEquals('t', hint.letter)
+        assertEquals(15, hint.letterCount)
+        assertEquals(14, hint.dotCount)
+    }
+
+    @Test
+    fun oneLetter_dotCountClampedToThree() {
+        val hint = "I".firstLetterHint()!!
+        assertEquals('I', hint.letter)
+        assertEquals(1, hint.letterCount)
+        assertEquals(3, hint.dotCount)
+    }
+
+    @Test
+    fun twoLetters_dotCountClampedToThree() {
+        val hint = "er".firstLetterHint()!!
+        assertEquals('e', hint.letter)
+        assertEquals(2, hint.letterCount)
+        assertEquals(3, hint.dotCount)
+    }
+
+    @Test
+    fun threeLetters_dotCountClampedToThree() {
+        val hint = "het".firstLetterHint()!!
+        assertEquals('h', hint.letter)
+        assertEquals(3, hint.letterCount)
+        assertEquals(3, hint.dotCount)
+    }
+
+    @Test
+    fun fourLetters_dotCountNotClamped() {
+        val hint = "vier".firstLetterHint()!!
+        assertEquals('v', hint.letter)
+        assertEquals(4, hint.letterCount)
+        assertEquals(3, hint.dotCount)
+    }
+
+    @Test
+    fun wordWithApostrophe_onlyLettersCounted() {
+        val hint = "don't".firstLetterHint()!!
+        assertEquals('d', hint.letter)
+        assertEquals(4, hint.letterCount)
+        assertEquals(3, hint.dotCount)
+    }
+
+    @Test
+    fun emptyString_returnsNull() {
+        assertNull("".firstLetterHint())
+    }
+
+    @Test
+    fun noLetters_returnsNull() {
+        assertNull("123".firstLetterHint())
+    }
+
+    @Test
+    fun leadingNonLetter_firstLetterIsCorrect() {
+        val hint = "1abc".firstLetterHint()!!
+        assertEquals('a', hint.letter)
+        assertEquals(3, hint.letterCount)
+        assertEquals(3, hint.dotCount)
+    }
+}


### PR DESCRIPTION
## Summary

- **Rounded cloze highlight**: filled answer highlight in cloze cards now uses rounded rectangles drawn per-line via `drawBehind`, matching the app's visual style
- **Mid-dot hint pill**: replaces the underscore row (`g _ _ _ _`) on the production-bilingual front with a non-interactive serif pill (`g · · · · ·`). Introduces `FirstLetterHint` model so visual dot count (padded ≥ 3) and real letter count for the accessibility label are tracked separately. Adds a pluralised `study_hint_starts_with` string resource across all four locales (EN, RU, NL, PL)
- **Long-lemma layout fix**: very long words (e.g. "tentoonstelling", "vriendschapsband") no longer wrap and push the speaker button off-screen. `RecognitionFront` uses `BoxWithConstraints` + `TextAutoSize.StepBased` to scale the prompt word down to a single line; the card back applies the same auto-sizing only when the headline is a lemma (`audioText != null`), leaving translation phrases to wrap freely. Speaker alignment changed to `Alignment.Top` on the back

## Test plan

- [ ] Production-bilingual card front shows pill hint (`g · · · ·`), not underscores
- [ ] TalkBack/VoiceOver announces hint as e.g. "Hint: starts with g, 8 letters" (localised)
- [ ] Short words render at full size on the recognition front; speaker is inline
- [ ] Long words (15+ chars) scale down to one line on the recognition front; speaker stays visible
- [ ] Long lemmas on the card back scale to one line; long translation phrases still wrap
- [ ] Cloze filled-answer highlight has rounded corners
- [ ] `verifyLocalizationKeys` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)