### PR TITLE
fix: prevent Forms chip overflow with long Dutch POS labels

### DIFF
--- a/composeApp/src/commonMain/composeResources/values-nl/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-nl/strings.xml
@@ -271,10 +271,10 @@
     <string name="sense_frequency_low">Laag</string>
     <string name="sense_frequency_very_low">Zeer laag</string>
     <string name="pos_article">Lidwoord</string>
-    <string name="pos_noun">Zelfstandig naamwoord</string>
+    <string name="pos_noun">Zelfst. naamwoord</string>
     <string name="pos_name">Naam</string>
     <string name="pos_verb">Werkwoord</string>
-    <string name="pos_adjective">Bijvoeglijk naamwoord</string>
+    <string name="pos_adjective">Bijv. naamwoord</string>
     <string name="pos_adverb">Bijwoord</string>
     <string name="pos_pronoun">Voornaamwoord</string>
     <string name="pos_preposition">Voorzetsel</string>

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/components/PartOfSpeechIndicator.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/components/PartOfSpeechIndicator.kt
@@ -12,6 +12,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.slovy.slovymovyapp.data.remote.PartOfSpeech
@@ -84,7 +85,9 @@ fun PartOfSpeechIndicator(
                     fontWeight = FontWeight.Bold,
                     letterSpacing = 1.2.sp
                 ),
-                color = MaterialTheme.colorScheme.onSurface
+                color = MaterialTheme.colorScheme.onSurface,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis
             )
         } else if (cardLoading) {
             Text(

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/word/EntryCard.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/word/EntryCard.kt
@@ -531,11 +531,10 @@ internal fun EntryCard(
                 pos = entry.pos,
                 meaningCount = if (showContent) entry.senses.size else null,
                 cardLoading = cardLoading,
-                cardError = cardError
+                cardError = cardError,
+                modifier = Modifier.weight(1f)
             )
             if (showContent) {
-                Spacer(modifier = Modifier.weight(1f))
-
                 if (entry.formsViews.isNotEmpty()) {
                     Box(
                         modifier = Modifier


### PR DESCRIPTION
## Summary
- Give `PartOfSpeechIndicator` `weight(1f)` in the POS header row so the Forms chip always reserves its own space
- Remove the now-redundant `Spacer(weight(1f))`
- Add `maxLines = 1` + `TextOverflow.Ellipsis` to the POS label as a safety net for any locale
- Abbreviate Dutch `pos_noun` → `Zelfst. naamwoord` and `pos_adjective` → `Bijv. naamwoord`

## Test plan
- [ ] Open word detail for a Dutch noun (e.g. *wagen*) — Forms chip visible next to `ZELFST. NAAMWOORD`
- [ ] Open word detail for a Dutch adjective — Forms chip visible next to `BIJV. NAAMWOORD`
- [ ] Verify other locales (EN, RU, PL) render POS header normally with no truncation

🤖 Generated with [Claude Code](https://claude.com/claude-code)