### PR TITLE
fix: persist language filter selection in Search and Favorites

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/App.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/App.kt
@@ -165,7 +165,7 @@ fun App(
     val wordDetailViewModels = remember { linkedMapOf<AppDestination.WordDetail, WordDetailViewModel>() }
     // Shared ViewModel for Favorites screen to preserve state across navigation
     val favoritesViewModel = remember {
-        FavoritesViewModel(favoritesRepository, dictionaryRepository, statsService, intakeService)
+        FavoritesViewModel(favoritesRepository, dictionaryRepository, statsService, intakeService, settingsRepository)
     }
     val buildConfig = remember { appBuildConfig }
     val settingsViewModel =
@@ -451,7 +451,7 @@ fun App(
                 val viewModel = viewModel(
                     viewModelStoreOwner = backStackEntry
                 ) {
-                    SearchViewModel(dictionaryRepository)
+                    SearchViewModel(dictionaryRepository, settingsRepository)
                 }
 
                 LaunchedEffect(pendingSearchQuery) {

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/FavoritesScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/FavoritesScreen.kt
@@ -35,6 +35,10 @@ import com.slovy.slovymovyapp.data.favorites.FavoritesRepository
 import com.slovy.slovymovyapp.data.learning.intake.LearningIntake
 import com.slovy.slovymovyapp.data.learning.stats.StatsService
 import com.slovy.slovymovyapp.data.remote.*
+import com.slovy.slovymovyapp.data.settings.Setting
+import com.slovy.slovymovyapp.data.settings.SettingsRepository
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.jsonPrimitive
 import com.slovy.slovymovyapp.ui.components.AppSearchBar
 import com.slovy.slovymovyapp.ui.components.EmptyState
 import com.slovy.slovymovyapp.ui.theme.AppSpacing
@@ -99,6 +103,7 @@ class FavoritesViewModel(
     private val dictionaryRepository: DictionaryRepository,
     private val statsService: StatsService,
     private val intakeService: LearningIntake,
+    private val settingsRepository: SettingsRepository,
 ) : ViewModel() {
 
     var state by mutableStateOf<FavoritesUiState>(FavoritesUiState.Loading)
@@ -108,6 +113,7 @@ class FavoritesViewModel(
     val snackbarHostState = SnackbarHostState()
 
     private var pendingScrollToTop: Boolean = false
+    private var savedFavoritesLanguage: Language? = null
 
     /** Called from outside (e.g. word detail) when a favorite was just added. */
     fun requestScrollToTop() {
@@ -129,6 +135,11 @@ class FavoritesViewModel(
 
     init {
         viewModelScope.launch {
+            // Restore saved language before observing queryFlow so the first load uses the right language.
+            val savedCode = settingsRepository.getById(Setting.Name.FAVORITES_LANGUAGE)
+                ?.value?.jsonPrimitive?.content
+            savedFavoritesLanguage = savedCode?.let { Language.fromCodeOrNull(it) }
+
             @OptIn(FlowPreview::class, ExperimentalCoroutinesApi::class)
             queryFlow
                 .debounce(QUERY_DEBOUNCE_MS.milliseconds)
@@ -167,6 +178,10 @@ class FavoritesViewModel(
         val content = state as? FavoritesUiState.Content ?: return
         if (content.selectedLanguage == language) return
         state = content.copy(selectedLanguage = language)
+        savedFavoritesLanguage = language
+        viewModelScope.launch {
+            settingsRepository.insert(Setting(Setting.Name.FAVORITES_LANGUAGE, JsonPrimitive(language.code)))
+        }
         queryFlow.value = QueryState(content.query, Uuid.random(), runIntake = true)
     }
 
@@ -278,6 +293,7 @@ class FavoritesViewModel(
     ): Language? =
         when {
             availableLanguages.size <= 1 -> availableLanguages.firstOrNull()
+            savedFavoritesLanguage in availableLanguages -> savedFavoritesLanguage
             currentContent?.selectedLanguage in availableLanguages -> currentContent?.selectedLanguage
             else -> availableLanguages.firstOrNull()
         }

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/SearchScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/SearchScreen.kt
@@ -41,6 +41,10 @@ import com.slovy.slovymovyapp.analytics.Analytics
 import com.slovy.slovymovyapp.analytics.AnalyticsEvent
 import com.slovy.slovymovyapp.data.Language
 import com.slovy.slovymovyapp.data.remote.DictionaryRepository
+import com.slovy.slovymovyapp.data.settings.Setting
+import com.slovy.slovymovyapp.data.settings.SettingsRepository
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.jsonPrimitive
 import com.slovy.slovymovyapp.data.remote.PartOfSpeech
 import com.slovy.slovymovyapp.ui.components.AppSearchBar
 import com.slovy.slovymovyapp.ui.components.EmptyState
@@ -74,7 +78,8 @@ data class SearchUiState(
 )
 
 class SearchViewModel(
-    private val repository: DictionaryRepository
+    private val repository: DictionaryRepository,
+    private val settingsRepository: SettingsRepository,
 ) : ViewModel() {
 
     data class Search(
@@ -100,6 +105,7 @@ class SearchViewModel(
 
     private val queryFlow = MutableStateFlow(Search("", state.selectedLanguage, Uuid.random()))
     private var suggestionsInitialized = false
+    private var savedSearchLanguage: Language? = null
 
     init {
         viewModelScope.launch {
@@ -129,8 +135,16 @@ class SearchViewModel(
                     }
                 }
         }
-        // Load initial suggestions
         viewModelScope.launch {
+            // Restore saved language before loading suggestions so they load for the right language.
+            val savedCode = settingsRepository.getById(Setting.Name.SEARCH_LANGUAGE)
+                ?.value?.jsonPrimitive?.content
+            val savedLang = savedCode?.let { Language.fromCodeOrNull(it) }
+            savedSearchLanguage = savedLang
+            if (savedLang != null && savedLang in state.availableLanguages && savedLang != state.selectedLanguage) {
+                state = state.copy(selectedLanguage = savedLang)
+                queryFlow.value = queryFlow.value.copy(language = savedLang)
+            }
             loadSuggestionsForCurrentLanguage()
             suggestionsInitialized = true
         }
@@ -192,17 +206,30 @@ class SearchViewModel(
 
     fun refreshLanguageIndicators() {
         val installed = repository.installedDictionaries()
-        state = state.copy(
-            availableLanguages = installed
-        )
-        if (state.selectedLanguage !in state.availableLanguages) {
-            setSelectedLanguage(state.availableLanguages.firstOrNull())
+        state = state.copy(availableLanguages = installed)
+        val preferred = savedSearchLanguage?.takeIf { it in installed }
+        val target = when {
+            state.selectedLanguage in installed && preferred == state.selectedLanguage -> return
+            state.selectedLanguage in installed && preferred != null -> preferred
+            else -> preferred ?: installed.firstOrNull()
         }
+        // Do not call setSelectedLanguage — that would overwrite the saved preference.
+        state = state.copy(selectedLanguage = target)
+        queryFlow.value = queryFlow.value.copy(language = target)
+        viewModelScope.launch { loadSuggestionsForCurrentLanguage() }
     }
 
     fun setSelectedLanguage(language: Language?) {
         val langChanged = state.selectedLanguage != language
         state = state.copy(selectedLanguage = language)
+        savedSearchLanguage = language
+        viewModelScope.launch {
+            if (language != null) {
+                settingsRepository.insert(Setting(Setting.Name.SEARCH_LANGUAGE, JsonPrimitive(language.code)))
+            } else {
+                settingsRepository.deleteById(Setting.Name.SEARCH_LANGUAGE)
+            }
+        }
         // Re-trigger search with new language filter
         val normalized = state.query.trim()
         if (normalized.isNotEmpty()) {

--- a/composeApp/src/commonTest/kotlin/com/slovy/slovymovyapp/ui/FavoritesViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/slovy/slovymovyapp/ui/FavoritesViewModelTest.kt
@@ -9,6 +9,7 @@ import com.slovy.slovymovyapp.data.learning.intake.IntakeResult
 import com.slovy.slovymovyapp.data.learning.intake.LearningIntake
 import com.slovy.slovymovyapp.data.learning.stats.StatsService
 import com.slovy.slovymovyapp.data.remote.DictionaryRepository
+import com.slovy.slovymovyapp.data.settings.Setting
 import com.slovy.slovymovyapp.data.settings.SettingsRepository
 import com.slovy.slovymovyapp.db.AppDatabase
 import com.slovy.slovymovyapp.test.BaseTest
@@ -44,6 +45,14 @@ open class FavoritesViewModelTest : BaseTest() {
             IntakeResult(activated = emptyList(), skipped = emptyList(), cardsCreated = 0)
     }
 
+    @BeforeTest
+    fun setUp() = runTest {
+        // Clear persisted language prefs so tests don't see each other's selections.
+        val repo = SettingsRepository(testAppDatabaseHolder().database)
+        repo.deleteById(Setting.Name.FAVORITES_LANGUAGE)
+        repo.deleteById(Setting.Name.SEARCH_LANGUAGE)
+    }
+
     @AfterTest
     fun tearDown() {
         viewModelStore.clear()
@@ -71,8 +80,9 @@ open class FavoritesViewModelTest : BaseTest() {
         dictRepo: DictionaryRepository = dictionaryRepository(favRepo),
         statsService: StatsService = StatsService(testAppDatabaseHolder().database.favoritesQueries, clock = Clock.System),
         intakeService: LearningIntake = NoopIntake,
+        settingsRepo: SettingsRepository = SettingsRepository(testAppDatabaseHolder().database),
     ): FavoritesViewModel {
-        val vm = FavoritesViewModel(favRepo, dictRepo, statsService, intakeService)
+        val vm = FavoritesViewModel(favRepo, dictRepo, statsService, intakeService, settingsRepo)
         viewModelStore.put("test", vm)
         return vm
     }

--- a/shared/src/commonMain/kotlin/com/slovy/slovymovyapp/data/settings/Setting.kt
+++ b/shared/src/commonMain/kotlin/com/slovy/slovymovyapp/data/settings/Setting.kt
@@ -17,6 +17,8 @@ data class Setting(
         DICTIONARY,
         DATA_VERSION,
         ENABLED_VOICES,
-        VOICE_SETUP_SHOWN
+        VOICE_SETUP_SHOWN,
+        SEARCH_LANGUAGE,
+        FAVORITES_LANGUAGE
     }
 }


### PR DESCRIPTION
## Summary

- Users' language filter choice in Search and Favorites was reset to English (first enum entry) whenever the OS killed and restored the app, because both ViewModels re-initialised from scratch
- Added `SEARCH_LANGUAGE` and `FAVORITES_LANGUAGE` to `Setting.Name`; both ViewModels now read the saved preference on init and restore it before loading suggestions/favorites
- `setSelectedLanguage` writes to settings on every explicit user pick; `refreshLanguageIndicators` restores the saved preference when it becomes available again after a temporary fallback, without overwriting it

## Test plan

- [ ] Run `./gradlew :composeApp:desktopTest` — all `FavoritesViewModelTest` tests pass (5 pre-existing `DictionaryClientTest` network failures unaffected)
- [ ] Manual: with 2+ languages downloaded, pick a non-English language in Search, force-kill the app, reopen — confirm it returns to the same language
- [ ] Same for Favorites screen

🤖 Generated with [Claude Code](https://claude.com/claude-code)