### PR TITLE
fix: improve production card UI — hint overlay, definition auto-size, card elevation

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/study/StudySessionColors.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/study/StudySessionColors.kt
@@ -4,6 +4,10 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Color
 import com.slovy.slovymovyapp.ui.theme.LocalIsDarkTheme
 
+// Warm dark brown (rgb 31,22,8) — harmonises with linen/paper backgrounds in light theme;
+// effectively invisible on dark surfaces, where elevation comes from surface.container alone.
+internal val StudySessionCardShadowColor = Color(red = 31, green = 22, blue = 8, alpha = 255)
+
 @Composable
 internal fun colorsForRating(rating: StudyRating): Pair<Color, Color> {
     val dark = LocalIsDarkTheme.current

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/study/StudySessionMapper.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/study/StudySessionMapper.kt
@@ -76,6 +76,7 @@ fun SessionCard.toStudyCardUiState(): StudyCardUiState? {
             promptLabel = UiText.Resource(Res.string.study_prompt_recall_word),
             promptText = sense.senseDefinition,
             firstLetterHint = lemma.firstLetterHint(),
+            isDefinitionPrompt = true,
             back = sourceBack(
                 lemma = lemma,
                 sense = sense,

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/study/StudySessionModels.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/study/StudySessionModels.kt
@@ -65,6 +65,7 @@ sealed interface StudyCardUiState {
         val promptLabel: UiText,
         val promptText: String,
         val firstLetterHint: FirstLetterHint? = null,
+        val isDefinitionPrompt: Boolean = false,
         override val back: StudyCardBackUiState,
     ) : StudyCardUiState
 

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/study/StudySessionScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/study/StudySessionScreen.kt
@@ -781,18 +781,11 @@ private fun ProductionFront(
             )
             StudyTaggedText(
                 text = card.promptText,
-                style = MaterialTheme.typography.displaySmall.copy(
+                style = (if (card.isDefinitionPrompt) MaterialTheme.typography.headlineMedium else MaterialTheme.typography.displaySmall).copy(
                     fontFamily = MaterialTheme.serifFontFamily,
                 ),
                 color = MaterialTheme.colorScheme.onSurface,
                 textAlign = TextAlign.Center,
-                maxLines = if (card.isDefinitionPrompt) 8 else Int.MAX_VALUE,
-                overflow = if (card.isDefinitionPrompt) TextOverflow.Ellipsis else TextOverflow.Clip,
-                autoSize = if (card.isDefinitionPrompt) TextAutoSize.StepBased(
-                    minFontSize = 14.sp,
-                    maxFontSize = MaterialTheme.typography.displaySmall.fontSize,
-                    stepSize = 1.sp,
-                ) else null,
                 modifier = Modifier.fillMaxWidth(),
             )
         }

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/study/StudySessionScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/study/StudySessionScreen.kt
@@ -23,6 +23,7 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.layout.IntrinsicSize
+import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
@@ -50,6 +51,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.geometry.CornerRadius
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
@@ -66,6 +68,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.foundation.text.TextAutoSize
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextDecoration
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.dp
@@ -107,6 +110,10 @@ import slovymovyapp.composeapp.generated.resources.study_rating_good
 import slovymovyapp.composeapp.generated.resources.study_rating_hard
 import slovymovyapp.composeapp.generated.resources.study_tap_to_check
 import slovymovyapp.composeapp.generated.resources.study_tap_to_flip
+
+// Warm dark brown (rgb 31,22,8) — harmonises with linen/paper backgrounds in light theme;
+// effectively invisible on dark surfaces, where elevation comes from surface.container alone.
+private val CardShadowColor = Color(red = 31, green = 22, blue = 8, alpha = 255)
 
 @Composable
 fun StudySessionScreen(
@@ -250,9 +257,17 @@ private fun StudySessionLoadingContent(
             Surface(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .weight(1f),
+                    .weight(1f)
+                    .shadow(
+                        elevation = 8.dp,
+                        shape = MaterialTheme.shapes.extraLarge,
+                        clip = false,
+                        ambientColor = CardShadowColor.copy(alpha = 0.04f),
+                        spotColor = CardShadowColor.copy(alpha = 0.06f),
+                    ),
                 shape = MaterialTheme.shapes.extraLarge,
-                color = MaterialTheme.colorScheme.surfaceContainerLow,
+                color = MaterialTheme.colorScheme.surfaceContainer,
+                border = BorderStroke(1.dp, MaterialTheme.colorScheme.onSurface.copy(alpha = 0.09f)),
                 tonalElevation = 0.dp,
             ) {
                 Box(
@@ -536,12 +551,21 @@ private fun StudyCardSurface(
         if (card is StudyCardUiState.Recognition) Res.string.study_tap_to_flip else Res.string.study_tap_to_check,
     )
     Surface(
-        modifier = modifier,
+        modifier = modifier.shadow(
+            elevation = 8.dp,
+            shape = MaterialTheme.shapes.extraLarge,
+            clip = false,
+            ambientColor = CardShadowColor.copy(alpha = 0.04f),
+            spotColor = CardShadowColor.copy(alpha = 0.06f),
+        ),
         shape = MaterialTheme.shapes.extraLarge,
-        color = MaterialTheme.colorScheme.surfaceContainerLow,
+        color = MaterialTheme.colorScheme.surfaceContainer,
+        border = BorderStroke(1.dp, MaterialTheme.colorScheme.onSurface.copy(alpha = 0.09f)),
         tonalElevation = 0.dp,
     ) {
         if (side == StudyCardSide.FRONT) {
+            val productionHint = (card as? StudyCardUiState.Production)?.firstLetterHint
+            val hintOverlayHeight = if (productionHint != null) 56.dp else 0.dp
             Box(modifier = Modifier.fillMaxSize()) {
                 Column(
                     modifier = Modifier
@@ -551,7 +575,7 @@ private fun StudyCardSurface(
                             start = AppSpacing.xl,
                             top = AppSpacing.xl,
                             end = AppSpacing.xl,
-                            bottom = AppSpacing.xl + 88.dp,
+                            bottom = AppSpacing.xl + 88.dp + hintOverlayHeight,
                         ),
                 ) {
                     StudyChip(label = card.chipLabel)
@@ -566,6 +590,16 @@ private fun StudyCardSurface(
                             .fillMaxWidth()
                             .heightIn(min = 360.dp),
                     )
+                }
+                if (productionHint != null) {
+                    Box(
+                        modifier = Modifier
+                            .align(Alignment.BottomCenter)
+                            .padding(bottom = 88.dp + AppSpacing.md),
+                        contentAlignment = Alignment.Center,
+                    ) {
+                        FirstLetterHintView(hint = productionHint)
+                    }
                 }
                 Box(
                     modifier = Modifier
@@ -752,41 +786,15 @@ private fun ProductionFront(
                 ),
                 color = MaterialTheme.colorScheme.onSurface,
                 textAlign = TextAlign.Center,
+                maxLines = if (card.isDefinitionPrompt) 8 else Int.MAX_VALUE,
+                overflow = if (card.isDefinitionPrompt) TextOverflow.Ellipsis else TextOverflow.Clip,
+                autoSize = if (card.isDefinitionPrompt) TextAutoSize.StepBased(
+                    minFontSize = 14.sp,
+                    maxFontSize = MaterialTheme.typography.displaySmall.fontSize,
+                    stepSize = 1.sp,
+                ) else null,
                 modifier = Modifier.fillMaxWidth(),
             )
-            card.firstLetterHint?.let { hint ->
-                val hintContentDescription = pluralStringResource(Res.plurals.study_hint_starts_with, hint.letterCount, hint.letter.toString(), hint.letterCount)
-                Surface(
-                    shape = CircleShape,
-                    color = MaterialTheme.colorScheme.surfaceContainerHigh,
-                    contentColor = MaterialTheme.colorScheme.onSurfaceVariant,
-                    modifier = Modifier.clearAndSetSemantics {
-                        contentDescription = hintContentDescription
-                    },
-                ) {
-                    Row(
-                        modifier = Modifier.padding(horizontal = 14.dp, vertical = 8.dp),
-                        verticalAlignment = Alignment.CenterVertically,
-                        horizontalArrangement = Arrangement.spacedBy(6.dp),
-                    ) {
-                        Text(
-                            text = hint.letter.toString(),
-                            fontSize = 16.sp,
-                            fontWeight = FontWeight.SemiBold,
-                            letterSpacing = 0.sp,
-                            fontFamily = MaterialTheme.serifFontFamily,
-                            color = MaterialTheme.colorScheme.onSurface,
-                        )
-                        Text(
-                            text = "·".repeat(hint.dotCount.coerceAtMost(15)),
-                            fontSize = 16.sp,
-                            fontFamily = MaterialTheme.serifFontFamily,
-                            letterSpacing = 8.sp,
-                            maxLines = 1,
-                        )
-                    }
-                }
-            }
         }
     }
 }
@@ -1137,6 +1145,7 @@ private fun StudyTaggedText(
     modifier: Modifier = Modifier,
     textAlign: TextAlign? = null,
     maxLines: Int = Int.MAX_VALUE,
+    overflow: TextOverflow = TextOverflow.Clip,
     autoSize: TextAutoSize? = null,
 ) {
     val highlightColor = MaterialTheme.colorScheme.primary
@@ -1163,6 +1172,7 @@ private fun StudyTaggedText(
             color = color,
             textAlign = textAlign,
             maxLines = maxLines,
+            overflow = overflow,
             autoSize = autoSize,
             modifier = modifier,
         )
@@ -1173,8 +1183,50 @@ private fun StudyTaggedText(
             color = color,
             textAlign = textAlign,
             maxLines = maxLines,
+            overflow = overflow,
             modifier = modifier,
         )
+    }
+}
+
+@Composable
+private fun FirstLetterHintView(
+    hint: FirstLetterHint,
+    modifier: Modifier = Modifier,
+) {
+    val hintContentDescription = pluralStringResource(
+        Res.plurals.study_hint_starts_with,
+        hint.letterCount,
+        hint.letter.toString(),
+        hint.letterCount,
+    )
+    Surface(
+        shape = CircleShape,
+        color = MaterialTheme.colorScheme.secondaryContainer,
+        contentColor = MaterialTheme.colorScheme.onSecondaryContainer,
+        modifier = modifier.clearAndSetSemantics { contentDescription = hintContentDescription },
+    ) {
+        Row(
+            modifier = Modifier.padding(horizontal = 14.dp, vertical = 8.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(6.dp),
+        ) {
+            Text(
+                text = hint.letter.toString(),
+                fontSize = 16.sp,
+                fontWeight = FontWeight.SemiBold,
+                letterSpacing = 0.sp,
+                fontFamily = MaterialTheme.serifFontFamily,
+                color = MaterialTheme.colorScheme.onSurface,
+            )
+            Text(
+                text = "·".repeat(hint.dotCount.coerceAtMost(15)),
+                fontSize = 16.sp,
+                fontFamily = MaterialTheme.serifFontFamily,
+                letterSpacing = 8.sp,
+                maxLines = 1,
+            )
+        }
     }
 }
 

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/study/StudySessionScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/study/StudySessionScreen.kt
@@ -111,10 +111,6 @@ import slovymovyapp.composeapp.generated.resources.study_rating_hard
 import slovymovyapp.composeapp.generated.resources.study_tap_to_check
 import slovymovyapp.composeapp.generated.resources.study_tap_to_flip
 
-// Warm dark brown (rgb 31,22,8) — harmonises with linen/paper backgrounds in light theme;
-// effectively invisible on dark surfaces, where elevation comes from surface.container alone.
-private val CardShadowColor = Color(red = 31, green = 22, blue = 8, alpha = 255)
-
 @Composable
 fun StudySessionScreen(
     viewModel: StudySessionViewModel,
@@ -262,8 +258,8 @@ private fun StudySessionLoadingContent(
                         elevation = 8.dp,
                         shape = MaterialTheme.shapes.extraLarge,
                         clip = false,
-                        ambientColor = CardShadowColor.copy(alpha = 0.04f),
-                        spotColor = CardShadowColor.copy(alpha = 0.06f),
+                        ambientColor = StudySessionCardShadowColor.copy(alpha = 0.04f),
+                        spotColor = StudySessionCardShadowColor.copy(alpha = 0.06f),
                     ),
                 shape = MaterialTheme.shapes.extraLarge,
                 color = MaterialTheme.colorScheme.surfaceContainer,
@@ -555,8 +551,8 @@ private fun StudyCardSurface(
             elevation = 8.dp,
             shape = MaterialTheme.shapes.extraLarge,
             clip = false,
-            ambientColor = CardShadowColor.copy(alpha = 0.04f),
-            spotColor = CardShadowColor.copy(alpha = 0.06f),
+            ambientColor = StudySessionCardShadowColor.copy(alpha = 0.04f),
+            spotColor = StudySessionCardShadowColor.copy(alpha = 0.06f),
         ),
         shape = MaterialTheme.shapes.extraLarge,
         color = MaterialTheme.colorScheme.surfaceContainer,


### PR DESCRIPTION
## Summary

- **Hint overlap fix**: first-letter hint pill is now a fixed overlay pinned above the "Tap to check" bar, so it's always visible regardless of definition length. Previously, long definitions pushed the hint behind the overlay.
- **Definition auto-sizing**: `SOURCE_DEFINITION_TO_WORD` prompts auto-size from `displaySmall` down to 14sp (max 8 lines) so long NL-style definitions don't dominate the screen. Translation-cue prompts (`TRANSLATION_TO_WORD`) are unchanged.
- **Card elevation**: card surface stepped up from `surfaceContainerLow` → `surfaceContainer`, gained a `1dp onSurface@9%` border and a warm-brown two-layer shadow, so the card reads as a distinct elevated object in both light and dark themes.
- **Hint pill contrast**: pill background switched from `surfaceContainerHigh` to `secondaryContainer` (body text `onSecondaryContainer`), which guarantees visible contrast against the card surface in dark theme where adjacent surface-container steps sit within a few hex points of each other.

## Test plan

- [ ] Production card with short translation cue (e.g. "cosy, sociable") — text stays at full `displaySmall`, hint pill visible above "Tap to check"
- [ ] Production card with long NL definition — text auto-shrinks to fit, hint pill always visible, definition fully readable (no truncation for typical lengths)
- [ ] Light theme: card edges clearly visible from arm's length; hint pill distinct from card surface
- [ ] Dark theme: card reads as a distinct object; hint pill visible; shadow is invisible (correct)
- [ ] Back side, recognition, cloze, and listening card fronts render identically to before

🤖 Generated with [Claude Code](https://claude.com/claude-code)