### PR TITLE
Show review-due indicator on Favorites navigation item

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/App.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/App.kt
@@ -718,6 +718,13 @@ fun App(
                             if (added) {
                                 favoritesViewModel.requestScrollToTop()
                             }
+                            coroutineScope.launch {
+                                hasFavoritesToReview = computeHasFavoritesToReview(
+                                    favoritesRepository,
+                                    intakeService,
+                                    statsService,
+                                )
+                            }
                         },
                     ).also { created ->
                         wordDetailViewModels[args] = created

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/App.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/App.kt
@@ -277,6 +277,7 @@ fun App(
                 platform,
                 buildConfig,
                 onDictionaryDataChanged = { recoverFavorites ->
+                    favoritesReviewCoordinator.invalidateIntakeCache()
                     dictionaryRepository.clearSenseCache()
                     if (recoverFavorites) {
                         platform.runWithProcessKeepAlive {
@@ -491,6 +492,7 @@ fun App(
                                 }
                             },
                             finalize = {
+                                favoritesReviewCoordinator.invalidateIntakeCache()
                                 dictionaryRepository.clearSenseCache()
                                 platform.runWithProcessKeepAlive {
                                     withContext(Dispatchers.Default) {
@@ -697,6 +699,7 @@ fun App(
                         if (!navController.popBackStack(AppDestination.Settings, inclusive = false))
                             navController.navigate(AppDestination.Settings)
                     },
+                    hasFavoritesToReview = hasFavoritesToReview,
                 )
             }
             composable<AppDestination.StudySession> { backStackEntry ->
@@ -712,6 +715,9 @@ fun App(
                         clock = Clock.System,
                         ttsManager = ttsManager,
                         voiceFilterHelper = voiceFilterHelper,
+                        onReviewSubmitted = {
+                            favoritesReviewCoordinator.invalidateIntakeCache()
+                        },
                     )
                 }
                 StudySessionScreen(
@@ -843,6 +849,7 @@ fun App(
                             dataManager.deleteAllDownloadedData()
                             localDbManager.deleteAll()
                             dictionaryRepository.clearSenseCache()
+                            favoritesReviewCoordinator.invalidateIntakeCache()
                             favoritesViewModel.dropCachedFavoriteDetails()
                             val target = selectInitialDestination()
                             navController.navigate(target) {

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/App.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/App.kt
@@ -36,6 +36,8 @@ import com.slovy.slovymovyapp.ui.word.WordDetailViewModel
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
@@ -44,30 +46,72 @@ import org.jetbrains.compose.resources.stringResource
 import slovymovyapp.composeapp.generated.resources.Res
 import slovymovyapp.composeapp.generated.resources.download_title_downloading
 import kotlin.time.Clock
+import kotlin.time.Duration.Companion.minutes
 import kotlin.time.ExperimentalTime
+import kotlin.time.Instant
 
-private data class FavoritesReviewState(
+internal data class FavoritesReviewState(
     val dueCountByLanguage: Map<Language, Int>,
 ) {
     val hasDueCards: Boolean get() = dueCountByLanguage.values.any { it > 0 }
 }
 
-private suspend fun computeFavoritesReviewState(
-    favoritesRepository: FavoritesRepository,
-    intakeService: LearningIntake,
-    statsService: StatsService,
-): FavoritesReviewState = withContext(Dispatchers.Default) {
-    val languages = favoritesRepository.getAllGroupedByLangAndLemma()
-        .map { it.language }
-        .distinct()
-    languages.forEach { language ->
-        intakeService.runIntake(language.code)
+@OptIn(ExperimentalTime::class)
+internal class FavoritesReviewCoordinator(
+    private val clock: Clock = Clock.System,
+) {
+    private val refreshMutex = Mutex()
+    private var lastIntakeAtByLanguage: Map<Language, Instant> = emptyMap()
+
+    suspend fun refresh(
+        favoritesRepository: FavoritesRepository,
+        intakeService: LearningIntake,
+        statsService: StatsService,
+        invalidateIntakeCache: Boolean = false,
+    ): FavoritesReviewState = refreshMutex.withLock {
+        if (invalidateIntakeCache) {
+            invalidateIntakeCache()
+        }
+        computeFavoritesReviewState(favoritesRepository, intakeService, statsService)
     }
-    FavoritesReviewState(
-        dueCountByLanguage = languages.associateWith { language ->
-            statsService.globalStats(language.code).dueToday
-        },
-    )
+
+    fun invalidateIntakeCache() {
+        lastIntakeAtByLanguage = emptyMap()
+    }
+
+    private suspend fun computeFavoritesReviewState(
+        favoritesRepository: FavoritesRepository,
+        intakeService: LearningIntake,
+        statsService: StatsService,
+    ): FavoritesReviewState = withContext(Dispatchers.Default) {
+        val languages = favoritesRepository.getAllGroupedByLangAndLemma()
+            .map { it.language }
+            .distinct()
+        languages.forEach { language ->
+            if (shouldRunIntake(language)) {
+                intakeService.runIntake(language.code)
+                markIntakeRun(language)
+            }
+        }
+        FavoritesReviewState(
+            dueCountByLanguage = languages.associateWith { language ->
+                statsService.globalStats(language.code).dueToday
+            },
+        )
+    }
+
+    internal fun shouldRunIntake(language: Language): Boolean {
+        val lastRunAt = lastIntakeAtByLanguage[language] ?: return true
+        return clock.now() - lastRunAt >= INTAKE_CACHE_TTL
+    }
+
+    internal fun markIntakeRun(language: Language) {
+        lastIntakeAtByLanguage += language to clock.now()
+    }
+
+    private companion object {
+        val INTAKE_CACHE_TTL = 5.minutes
+    }
 }
 
 @Serializable
@@ -198,6 +242,7 @@ fun App(
     val wordDetailViewModels = remember { linkedMapOf<AppDestination.WordDetail, WordDetailViewModel>() }
     val coroutineScope = rememberCoroutineScope()
     var hasFavoritesToReview by remember { mutableStateOf(false) }
+    val favoritesReviewCoordinator = remember { FavoritesReviewCoordinator() }
 
     // Shared ViewModel for Favorites screen to preserve state across navigation
     val favoritesViewModel = remember {
@@ -208,8 +253,13 @@ fun App(
         )
     }
 
-    suspend fun refreshFavoritesReviewState() {
-        val reviewState = computeFavoritesReviewState(favoritesRepository, intakeService, statsService)
+    suspend fun refreshFavoritesReviewState(invalidateIntakeCache: Boolean = false) {
+        val reviewState = favoritesReviewCoordinator.refresh(
+            favoritesRepository = favoritesRepository,
+            intakeService = intakeService,
+            statsService = statsService,
+            invalidateIntakeCache = invalidateIntakeCache,
+        )
         favoritesViewModel.updateReviewDueCounts(reviewState.dueCountByLanguage)
         hasFavoritesToReview = reviewState.hasDueCards
     }
@@ -615,7 +665,7 @@ fun App(
                         navController.navigate(AppDestination.StudySession(language.code))
                     },
                     onFavoritesChanged = {
-                        coroutineScope.launch { refreshFavoritesReviewState() }
+                        coroutineScope.launch { refreshFavoritesReviewState(invalidateIntakeCache = true) }
                     },
                 )
             }
@@ -741,7 +791,7 @@ fun App(
                             if (added) {
                                 favoritesViewModel.requestScrollToTop()
                             }
-                            coroutineScope.launch { refreshFavoritesReviewState() }
+                            coroutineScope.launch { refreshFavoritesReviewState(invalidateIntakeCache = true) }
                         },
                     ).also { created ->
                         wordDetailViewModels[args] = created

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/App.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/App.kt
@@ -173,6 +173,7 @@ fun App(
     val favoritesViewModel = remember {
         FavoritesViewModel(favoritesRepository, dictionaryRepository, statsService, intakeService, settingsRepository)
     }
+    val favoritesDueCount = favoritesViewModel.reviewDueCount
     val buildConfig = remember { appBuildConfig }
     val settingsViewModel =
         remember {
@@ -201,6 +202,10 @@ fun App(
 
     DisposableEffect(Unit) {
         onDispose { downloadCoordinator.close() }
+    }
+
+    LaunchedEffect(Unit) {
+        favoritesViewModel.refreshReviewDueCount()
     }
 
     // Keep nativeLanguages and dictionaryLanguage in sync with settings changes from SettingsScreen
@@ -527,7 +532,8 @@ fun App(
                     onNavigateToSettings = {
                         if (!navController.popBackStack(AppDestination.Settings, inclusive = false))
                             navController.navigate(AppDestination.Settings)
-                    }
+                    },
+                    dueCount = favoritesDueCount,
                 )
             }
             composable<AppDestination.Favorites> {
@@ -621,12 +627,14 @@ fun App(
                 StudySessionScreen(
                     viewModel = viewModel,
                     onCancel = {
+                        favoritesViewModel.refreshReviewDueCount()
                         logEvent(AnalyticsEvent.STUDY_CANCEL_SESSION)
                         if (!navController.popBackStack()) {
                             navController.navigate(AppDestination.Favorites)
                         }
                     },
                     onEnd = {
+                        favoritesViewModel.refreshReviewDueCount()
                         logEvent(AnalyticsEvent.STUDY_END_SESSION)
                         if (!navController.popBackStack()) {
                             navController.navigate(AppDestination.Favorites)
@@ -654,7 +662,8 @@ fun App(
                         wordDetailViewModels.keys.lastOrNull()?.let { destination ->
                             navController.navigate(destination)
                         }
-                    }
+                    },
+                    dueCount = favoritesDueCount,
                 )
             }
             composable<AppDestination.WordDetail> { backStackEntry ->
@@ -690,7 +699,8 @@ fun App(
                         args.lemma,
                         args.targetSenseId,
                         args.translationLanguages,
-                        onFavoriteAdded = { favoritesViewModel.requestScrollToTop() }
+                        onFavoriteAdded = { favoritesViewModel.requestScrollToTop() },
+                        onFavoriteChanged = { favoritesViewModel.refreshReviewDueCount() },
                     ).also { created ->
                         wordDetailViewModels[args] = created
                     }
@@ -729,7 +739,8 @@ fun App(
                             translationLanguageCodes = translationCodes
                         )
                         navController.navigate(destination)
-                    }
+                    },
+                    dueCount = favoritesDueCount,
                 )
             }
             composable<AppDestination.DataVersionMismatch> {

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/App.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/App.kt
@@ -188,7 +188,7 @@ fun App(
     val wordDetailViewModels = remember { linkedMapOf<AppDestination.WordDetail, WordDetailViewModel>() }
     // Shared ViewModel for Favorites screen to preserve state across navigation
     val favoritesViewModel = remember {
-        FavoritesViewModel(favoritesRepository, dictionaryRepository, statsService, intakeService, settingsRepository)
+        FavoritesViewModel(favoritesRepository, dictionaryRepository, statsService, settingsRepository)
     }
     var hasFavoritesToReview by remember { mutableStateOf(false) }
     val buildConfig = remember { appBuildConfig }

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/App.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/App.kt
@@ -46,18 +46,28 @@ import slovymovyapp.composeapp.generated.resources.download_title_downloading
 import kotlin.time.Clock
 import kotlin.time.ExperimentalTime
 
-private suspend fun computeHasFavoritesToReview(
+private data class FavoritesReviewState(
+    val dueCountByLanguage: Map<Language, Int>,
+) {
+    val hasDueCards: Boolean get() = dueCountByLanguage.values.any { it > 0 }
+}
+
+private suspend fun computeFavoritesReviewState(
     favoritesRepository: FavoritesRepository,
     intakeService: LearningIntake,
     statsService: StatsService,
-): Boolean = withContext(Dispatchers.Default) {
+): FavoritesReviewState = withContext(Dispatchers.Default) {
     val languages = favoritesRepository.getAllGroupedByLangAndLemma()
         .map { it.language }
         .distinct()
     languages.forEach { language ->
         intakeService.runIntake(language.code)
     }
-    languages.any { language -> statsService.globalStats(language.code).dueToday > 0 }
+    FavoritesReviewState(
+        dueCountByLanguage = languages.associateWith { language ->
+            statsService.globalStats(language.code).dueToday
+        },
+    )
 }
 
 @Serializable
@@ -186,11 +196,23 @@ fun App(
     val navBackStackEntry by navController.currentBackStackEntryAsState()
     var startDestination by remember { mutableStateOf<AppDestination?>(null) }
     val wordDetailViewModels = remember { linkedMapOf<AppDestination.WordDetail, WordDetailViewModel>() }
+    val coroutineScope = rememberCoroutineScope()
+    var hasFavoritesToReview by remember { mutableStateOf(false) }
+
     // Shared ViewModel for Favorites screen to preserve state across navigation
     val favoritesViewModel = remember {
-        FavoritesViewModel(favoritesRepository, dictionaryRepository, statsService, settingsRepository)
+        FavoritesViewModel(
+            favoritesRepository = favoritesRepository,
+            dictionaryRepository = dictionaryRepository,
+            settingsRepository = settingsRepository,
+        )
     }
-    var hasFavoritesToReview by remember { mutableStateOf(false) }
+
+    suspend fun refreshFavoritesReviewState() {
+        val reviewState = computeFavoritesReviewState(favoritesRepository, intakeService, statsService)
+        favoritesViewModel.updateReviewDueCounts(reviewState.dueCountByLanguage)
+        hasFavoritesToReview = reviewState.hasDueCards
+    }
     val buildConfig = remember { appBuildConfig }
     val settingsViewModel =
         remember {
@@ -215,14 +237,12 @@ fun App(
                 },
             )
         }
-    val coroutineScope = rememberCoroutineScope()
-
     DisposableEffect(Unit) {
         onDispose { downloadCoordinator.close() }
     }
 
     LaunchedEffect(navBackStackEntry) {
-        hasFavoritesToReview = computeHasFavoritesToReview(favoritesRepository, intakeService, statsService)
+        refreshFavoritesReviewState()
     }
 
     // Keep nativeLanguages and dictionaryLanguage in sync with settings changes from SettingsScreen
@@ -593,7 +613,10 @@ fun App(
                     onStartStudy = { language ->
                         logEvent(AnalyticsEvent.STUDY_START_SESSION)
                         navController.navigate(AppDestination.StudySession(language.code))
-                    }
+                    },
+                    onFavoritesChanged = {
+                        coroutineScope.launch { refreshFavoritesReviewState() }
+                    },
                 )
             }
             composable<AppDestination.Stats> { backStackEntry ->
@@ -718,13 +741,7 @@ fun App(
                             if (added) {
                                 favoritesViewModel.requestScrollToTop()
                             }
-                            coroutineScope.launch {
-                                hasFavoritesToReview = computeHasFavoritesToReview(
-                                    favoritesRepository,
-                                    intakeService,
-                                    statsService,
-                                )
-                            }
+                            coroutineScope.launch { refreshFavoritesReviewState() }
                         },
                     ).also { created ->
                         wordDetailViewModels[args] = created

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/App.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/App.kt
@@ -6,6 +6,7 @@ import androidx.compose.runtime.*
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
+import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
 import androidx.navigation.toRoute
 import com.slovy.slovymovyapp.analytics.Analytics.logEvent
@@ -43,6 +44,16 @@ import slovymovyapp.composeapp.generated.resources.Res
 import slovymovyapp.composeapp.generated.resources.download_title_downloading
 import kotlin.time.Clock
 import kotlin.time.ExperimentalTime
+
+private suspend fun computeHasFavoritesToReview(
+    favoritesRepository: FavoritesRepository,
+    statsService: StatsService,
+): Boolean = withContext(Dispatchers.Default) {
+    favoritesRepository.getAllGroupedByLangAndLemma()
+        .map { it.language }
+        .distinct()
+        .any { language -> statsService.globalStats(language.code).dueToday > 0 }
+}
 
 @Serializable
 private sealed interface AppDestination {
@@ -167,13 +178,18 @@ fun App(
     val voiceFilterHelper = remember(settingsRepository) { VoiceFilterHelper(settingsRepository) }
 
     val navController = rememberNavController()
+    val navBackStackEntry by navController.currentBackStackEntryAsState()
     var startDestination by remember { mutableStateOf<AppDestination?>(null) }
     val wordDetailViewModels = remember { linkedMapOf<AppDestination.WordDetail, WordDetailViewModel>() }
     // Shared ViewModel for Favorites screen to preserve state across navigation
     val favoritesViewModel = remember {
         FavoritesViewModel(favoritesRepository, dictionaryRepository, statsService, intakeService, settingsRepository)
     }
-    val favoritesDueCount = favoritesViewModel.reviewDueCount
+    var hasFavoritesToReview by remember { mutableStateOf(false) }
+    var favoriteReviewIndicatorRefreshToken by remember { mutableIntStateOf(0) }
+    fun refreshFavoriteReviewIndicator() {
+        favoriteReviewIndicatorRefreshToken++
+    }
     val buildConfig = remember { appBuildConfig }
     val settingsViewModel =
         remember {
@@ -204,8 +220,8 @@ fun App(
         onDispose { downloadCoordinator.close() }
     }
 
-    LaunchedEffect(Unit) {
-        favoritesViewModel.refreshReviewDueCount()
+    LaunchedEffect(navBackStackEntry, favoriteReviewIndicatorRefreshToken) {
+        hasFavoritesToReview = computeHasFavoritesToReview(favoritesRepository, statsService)
     }
 
     // Keep nativeLanguages and dictionaryLanguage in sync with settings changes from SettingsScreen
@@ -533,7 +549,7 @@ fun App(
                         if (!navController.popBackStack(AppDestination.Settings, inclusive = false))
                             navController.navigate(AppDestination.Settings)
                     },
-                    dueCount = favoritesDueCount,
+                    hasFavoritesToReview = hasFavoritesToReview,
                 )
             }
             composable<AppDestination.Favorites> {
@@ -627,14 +643,12 @@ fun App(
                 StudySessionScreen(
                     viewModel = viewModel,
                     onCancel = {
-                        favoritesViewModel.refreshReviewDueCount()
                         logEvent(AnalyticsEvent.STUDY_CANCEL_SESSION)
                         if (!navController.popBackStack()) {
                             navController.navigate(AppDestination.Favorites)
                         }
                     },
                     onEnd = {
-                        favoritesViewModel.refreshReviewDueCount()
                         logEvent(AnalyticsEvent.STUDY_END_SESSION)
                         if (!navController.popBackStack()) {
                             navController.navigate(AppDestination.Favorites)
@@ -663,7 +677,7 @@ fun App(
                             navController.navigate(destination)
                         }
                     },
-                    dueCount = favoritesDueCount,
+                    hasFavoritesToReview = hasFavoritesToReview,
                 )
             }
             composable<AppDestination.WordDetail> { backStackEntry ->
@@ -699,8 +713,12 @@ fun App(
                         args.lemma,
                         args.targetSenseId,
                         args.translationLanguages,
-                        onFavoriteAdded = { favoritesViewModel.requestScrollToTop() },
-                        onFavoriteChanged = { favoritesViewModel.refreshReviewDueCount() },
+                        onFavoriteChanged = { added ->
+                            if (added) {
+                                favoritesViewModel.requestScrollToTop()
+                            }
+                            refreshFavoriteReviewIndicator()
+                        },
                     ).also { created ->
                         wordDetailViewModels[args] = created
                     }
@@ -740,7 +758,7 @@ fun App(
                         )
                         navController.navigate(destination)
                     },
-                    dueCount = favoritesDueCount,
+                    hasFavoritesToReview = hasFavoritesToReview,
                 )
             }
             composable<AppDestination.DataVersionMismatch> {

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/App.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/App.kt
@@ -17,6 +17,7 @@ import com.slovy.slovymovyapp.data.favorites.FavoritesRepository
 import com.slovy.slovymovyapp.data.learning.fsrs.FsrsDefaults
 import com.slovy.slovymovyapp.data.learning.fsrs.FsrsScheduler
 import com.slovy.slovymovyapp.data.learning.intake.IntakeService
+import com.slovy.slovymovyapp.data.learning.intake.LearningIntake
 import com.slovy.slovymovyapp.data.learning.session.ExamplePicker
 import com.slovy.slovymovyapp.data.learning.session.SessionService
 import com.slovy.slovymovyapp.data.learning.stats.StatsService
@@ -47,12 +48,16 @@ import kotlin.time.ExperimentalTime
 
 private suspend fun computeHasFavoritesToReview(
     favoritesRepository: FavoritesRepository,
+    intakeService: LearningIntake,
     statsService: StatsService,
 ): Boolean = withContext(Dispatchers.Default) {
-    favoritesRepository.getAllGroupedByLangAndLemma()
+    val languages = favoritesRepository.getAllGroupedByLangAndLemma()
         .map { it.language }
         .distinct()
-        .any { language -> statsService.globalStats(language.code).dueToday > 0 }
+    languages.forEach { language ->
+        intakeService.runIntake(language.code)
+    }
+    languages.any { language -> statsService.globalStats(language.code).dueToday > 0 }
 }
 
 @Serializable
@@ -186,10 +191,6 @@ fun App(
         FavoritesViewModel(favoritesRepository, dictionaryRepository, statsService, intakeService, settingsRepository)
     }
     var hasFavoritesToReview by remember { mutableStateOf(false) }
-    var favoriteReviewIndicatorRefreshToken by remember { mutableIntStateOf(0) }
-    fun refreshFavoriteReviewIndicator() {
-        favoriteReviewIndicatorRefreshToken++
-    }
     val buildConfig = remember { appBuildConfig }
     val settingsViewModel =
         remember {
@@ -220,8 +221,8 @@ fun App(
         onDispose { downloadCoordinator.close() }
     }
 
-    LaunchedEffect(navBackStackEntry, favoriteReviewIndicatorRefreshToken) {
-        hasFavoritesToReview = computeHasFavoritesToReview(favoritesRepository, statsService)
+    LaunchedEffect(navBackStackEntry) {
+        hasFavoritesToReview = computeHasFavoritesToReview(favoritesRepository, intakeService, statsService)
     }
 
     // Keep nativeLanguages and dictionaryLanguage in sync with settings changes from SettingsScreen
@@ -717,7 +718,6 @@ fun App(
                             if (added) {
                                 favoritesViewModel.requestScrollToTop()
                             }
-                            refreshFavoriteReviewIndicator()
                         },
                     ).also { created ->
                         wordDetailViewModels[args] = created

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/AppNavigationBar.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/AppNavigationBar.kt
@@ -43,14 +43,14 @@ fun AppNavigationBar(
     onNavigateToWordDetail: () -> Unit,
     wordDetailLabel: String? = null,
     onNavigateToSettings: () -> Unit = {},
-    dueCount: Int = 0,
+    hasFavoritesToReview: Boolean = false,
 ) {
     val searchLabel = stringResource(Res.string.nav_search)
     val favoritesLabel = stringResource(Res.string.nav_favorites)
     val statsLabel = stringResource(Res.string.nav_stats)
     val wordDetailLabelText = stringResource(Res.string.nav_word_detail)
     val settingsLabel = stringResource(Res.string.nav_settings)
-    val showFavoritesDueDot = dueCount > 0 && currentScreen != AppScreen.FAVORITES
+    val showFavoritesDueDot = hasFavoritesToReview && currentScreen != AppScreen.FAVORITES
 
     val itemColors = NavigationBarItemDefaults.colors(
         indicatorColor = Color.Transparent,
@@ -234,7 +234,7 @@ fun PreviewAppNavigationBar(
             onNavigateToStats = {},
             onNavigateToWordDetail = {},
             wordDetailLabel = "example",
-            dueCount = 3,
+            hasFavoritesToReview = true,
         )
     }
 }
@@ -252,7 +252,7 @@ fun PreviewAppNavigationBarFavoritesSelected(
             onNavigateToStats = {},
             onNavigateToWordDetail = {},
             wordDetailLabel = "example",
-            dueCount = 3,
+            hasFavoritesToReview = true,
         )
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/AppNavigationBar.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/AppNavigationBar.kt
@@ -22,6 +22,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.dp
 import org.jetbrains.compose.resources.stringResource
 import slovymovyapp.composeapp.generated.resources.*
@@ -221,10 +223,10 @@ private fun NavigationIconWithReviewDot(
     }
 }
 
-@androidx.compose.ui.tooling.preview.Preview
+@Preview
 @Composable
 fun PreviewAppNavigationBar(
-    @androidx.compose.ui.tooling.preview.PreviewParameter(ThemePreviewProvider::class) isDark: Boolean
+    @PreviewParameter(ThemePreviewProvider::class) isDark: Boolean
 ) {
     ThemedPreview(darkTheme = isDark) {
         AppNavigationBar(
@@ -239,10 +241,10 @@ fun PreviewAppNavigationBar(
     }
 }
 
-@androidx.compose.ui.tooling.preview.Preview
+@Preview
 @Composable
 fun PreviewAppNavigationBarFavoritesSelected(
-    @androidx.compose.ui.tooling.preview.PreviewParameter(ThemePreviewProvider::class) isDark: Boolean
+    @PreviewParameter(ThemePreviewProvider::class) isDark: Boolean
 ) {
     ThemedPreview(darkTheme = isDark) {
         AppNavigationBar(

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/AppNavigationBar.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/AppNavigationBar.kt
@@ -1,5 +1,11 @@
 package com.slovy.slovymovyapp.ui
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.wrapContentSize
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Book
 import androidx.compose.material.icons.filled.Favorite
@@ -11,8 +17,12 @@ import androidx.compose.material.icons.outlined.Search
 import androidx.compose.material.icons.outlined.Settings
 import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
 import org.jetbrains.compose.resources.stringResource
 import slovymovyapp.composeapp.generated.resources.*
 
@@ -32,13 +42,15 @@ fun AppNavigationBar(
     onNavigateToStats: () -> Unit = {},
     onNavigateToWordDetail: () -> Unit,
     wordDetailLabel: String? = null,
-    onNavigateToSettings: () -> Unit = {}
+    onNavigateToSettings: () -> Unit = {},
+    dueCount: Int = 0,
 ) {
     val searchLabel = stringResource(Res.string.nav_search)
     val favoritesLabel = stringResource(Res.string.nav_favorites)
     val statsLabel = stringResource(Res.string.nav_stats)
     val wordDetailLabelText = stringResource(Res.string.nav_word_detail)
     val settingsLabel = stringResource(Res.string.nav_settings)
+    val showFavoritesDueDot = dueCount > 0 && currentScreen != AppScreen.FAVORITES
 
     val itemColors = NavigationBarItemDefaults.colors(
         indicatorColor = Color.Transparent,
@@ -103,13 +115,14 @@ fun AppNavigationBar(
         )
         NavigationBarItem(
             icon = {
-                Icon(
+                NavigationIconWithReviewDot(
                     imageVector = if (currentScreen == AppScreen.FAVORITES) {
                         Icons.Filled.Favorite
                     } else {
                         Icons.Outlined.FavoriteBorder
                     },
-                    contentDescription = favoritesLabel
+                    contentDescription = favoritesLabel,
+                    showDot = showFavoritesDueDot,
                 )
             },
             label = {
@@ -173,6 +186,41 @@ fun AppNavigationBar(
     }
 }
 
+@Composable
+private fun NavigationIconWithReviewDot(
+    imageVector: ImageVector,
+    contentDescription: String,
+    showDot: Boolean,
+) {
+    Box(
+        modifier = Modifier
+            .size(22.dp)
+            .wrapContentSize(unbounded = true)
+    ) {
+        Icon(
+            imageVector = imageVector,
+            contentDescription = contentDescription,
+            modifier = Modifier.size(22.dp),
+        )
+        if (showDot) {
+            Box(
+                modifier = Modifier
+                    .align(Alignment.TopEnd)
+                    .offset(x = 4.dp, y = (-3.5).dp)
+                    .size(11.dp)
+                    .background(MaterialTheme.colorScheme.surfaceContainer, CircleShape),
+                contentAlignment = Alignment.Center,
+            ) {
+                Box(
+                    modifier = Modifier
+                        .size(8.dp)
+                        .background(MaterialTheme.colorScheme.error, CircleShape),
+                )
+            }
+        }
+    }
+}
+
 @androidx.compose.ui.tooling.preview.Preview
 @Composable
 fun PreviewAppNavigationBar(
@@ -185,7 +233,26 @@ fun PreviewAppNavigationBar(
             onNavigateToFavorites = {},
             onNavigateToStats = {},
             onNavigateToWordDetail = {},
-            wordDetailLabel = "example"
+            wordDetailLabel = "example",
+            dueCount = 3,
+        )
+    }
+}
+
+@androidx.compose.ui.tooling.preview.Preview
+@Composable
+fun PreviewAppNavigationBarFavoritesSelected(
+    @androidx.compose.ui.tooling.preview.PreviewParameter(ThemePreviewProvider::class) isDark: Boolean
+) {
+    ThemedPreview(darkTheme = isDark) {
+        AppNavigationBar(
+            currentScreen = AppScreen.FAVORITES,
+            onNavigateToSearch = {},
+            onNavigateToFavorites = {},
+            onNavigateToStats = {},
+            onNavigateToWordDetail = {},
+            wordDetailLabel = "example",
+            dueCount = 3,
         )
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/FavoritesScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/FavoritesScreen.kt
@@ -115,6 +115,11 @@ private fun FavoriteSenseItem.withoutCachedDetails(): FavoriteSenseItem =
         error = null,
     )
 
+internal data class FavoritesStateResult(
+    val state: FavoritesUiState.Content,
+    val reviewDueCount: Int,
+)
+
 class FavoritesViewModel(
     private val favoritesRepository: FavoritesRepository,
     private val dictionaryRepository: DictionaryRepository,
@@ -126,11 +131,15 @@ class FavoritesViewModel(
     var state by mutableStateOf<FavoritesUiState>(FavoritesUiState.Loading)
         private set
 
+    var reviewDueCount by mutableStateOf(0)
+        private set
+
     val scrollState = LazyListState()
     val snackbarHostState = SnackbarHostState()
 
     private var pendingScrollToTop: Boolean = false
     private var savedFavoritesLanguage: Language? = null
+    private var reviewDueCountRefreshJob: Job? = null
 
     /** Called from outside (e.g. word detail) when a favorite was just added. */
     fun requestScrollToTop() {
@@ -180,8 +189,8 @@ class FavoritesViewModel(
                         .flowOn(Dispatchers.Default)
                 }
                 .collect { newState ->
-                    applyNewState(newState)
-                    prefetchSenses(newState.senses.take(PREFETCH_LIMIT))
+                    applyStateResult(newState)
+                    prefetchSenses(newState.state.senses.take(PREFETCH_LIMIT))
                 }
         }
     }
@@ -199,6 +208,13 @@ class FavoritesViewModel(
             force = Uuid.random(),
             runIntake = true,
         )
+    }
+
+    fun refreshReviewDueCount() {
+        reviewDueCountRefreshJob?.cancel()
+        reviewDueCountRefreshJob = viewModelScope.launch {
+            reviewDueCount = computeReviewDueCount()
+        }
     }
 
     fun setSelectedLanguage(language: Language) {
@@ -219,7 +235,7 @@ class FavoritesViewModel(
 
     /**
      * Computes the new favorites state from the repository. Safe to call from any dispatcher.
-     * Returns the new [FavoritesUiState.Content] without mutating [state].
+     * Returns the new [FavoritesUiState.Content] and the due count without mutating [state].
      *
      * @param currentContent snapshot of the current UI state, captured on Main before dispatching.
      */
@@ -227,7 +243,7 @@ class FavoritesViewModel(
         query: String,
         currentContent: FavoritesUiState.Content?,
         runIntake: Boolean = false,
-    ): FavoritesUiState.Content {
+    ): FavoritesStateResult {
         val currentSenses = currentContent?.senses.orEmpty()
         val currentById = currentSenses.associateBy { it.senseId }
 
@@ -248,6 +264,10 @@ class FavoritesViewModel(
         val hasAnyFavorites = allFavorites.isNotEmpty()
         val availableLanguages = allFavorites.availableLanguages()
         val selectedLanguage = selectedLanguageFor(availableLanguages, currentContent)
+        val dueCountByLanguage = availableLanguages.associateWith { language ->
+            statsService.globalStats(language.code).dueToday
+        }
+        val reviewDueCount = dueCountByLanguage.values.sum()
 
         // Filter favorites to selected language when multi-language
         val langFiltered = if (availableLanguages.size > 1 && selectedLanguage != null) {
@@ -292,27 +312,36 @@ class FavoritesViewModel(
         }
         val study = selectedLanguage
             ?.let { language ->
-                statsService.globalStats(language.code)
-                    .dueToday
-                    .takeIf { it > 0 }
+                dueCountByLanguage[language]
+                    ?.takeIf { it > 0 }
                     ?.let { dueCount -> FavoritesStudyUiState(language, dueCount) }
             }
 
-        return FavoritesUiState.Content(
-            senses = senses,
-            query = query,
-            hasAnyFavorites = hasAnyFavorites,
-            favoriteLemmas = langFiltered.map { it.lemma }.toSet(),
-            availableLanguages = availableLanguages,
-            selectedLanguage = selectedLanguage,
-            isLanguageDropdownExpanded = if (availableLanguages.size > 1)
-                currentContent?.isLanguageDropdownExpanded ?: false else false,
-            study = study,
+        return FavoritesStateResult(
+            state = FavoritesUiState.Content(
+                senses = senses,
+                query = query,
+                hasAnyFavorites = hasAnyFavorites,
+                favoriteLemmas = langFiltered.map { it.lemma }.toSet(),
+                availableLanguages = availableLanguages,
+                selectedLanguage = selectedLanguage,
+                isLanguageDropdownExpanded = if (availableLanguages.size > 1)
+                    currentContent?.isLanguageDropdownExpanded ?: false else false,
+                study = study,
+            ),
+            reviewDueCount = reviewDueCount,
         )
     }
 
     private fun List<Favorite>.availableLanguages(): List<Language> =
         map { it.language }.distinct().sorted()
+
+    private suspend fun computeReviewDueCount(): Int =
+        withContext(Dispatchers.Default) {
+            favoritesRepository.getAllGroupedByLangAndLemma()
+                .availableLanguages()
+                .sumOf { language -> statsService.globalStats(language.code).dueToday }
+        }
 
     private fun selectedLanguageFor(
         availableLanguages: List<Language>,
@@ -340,13 +369,20 @@ class FavoritesViewModel(
         }
     }
 
+    private fun applyStateResult(result: FavoritesStateResult) {
+        reviewDueCountRefreshJob?.cancel()
+        reviewDueCountRefreshJob = null
+        reviewDueCount = result.reviewDueCount
+        applyNewState(result.state)
+    }
+
     /** Computes and applies favorites state. Exposed for tests; production code uses the
      *  debounced flow or [toggleFavorite] which handle threading via [Dispatchers.Default]. */
     internal suspend fun loadAndApplyState(
         query: String,
         runIntake: Boolean = false,
     ) {
-        applyNewState(
+        applyStateResult(
             computeFavoritesState(
                 query = query,
                 currentContent = state as? FavoritesUiState.Content,
@@ -415,8 +451,8 @@ class FavoritesViewModel(
             // filtering, language switches, and all edge cases correctly)
             val snapshot = state as? FavoritesUiState.Content
             val newState = withContext(Dispatchers.Default) { computeFavoritesState(content.query, snapshot) }
-            state = newState
-            prefetchSenses(newState.senses.take(PREFETCH_LIMIT))
+            applyStateResult(newState)
+            prefetchSenses(newState.state.senses.take(PREFETCH_LIMIT))
 
             // Show snackbar with an undo option
             val result = snackbarHostState.showSnackbar(

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/FavoritesScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/FavoritesScreen.kt
@@ -32,7 +32,6 @@ import com.slovy.slovymovyapp.analytics.AnalyticsEvent
 import com.slovy.slovymovyapp.data.Language
 import com.slovy.slovymovyapp.data.favorites.Favorite
 import com.slovy.slovymovyapp.data.favorites.FavoritesRepository
-import com.slovy.slovymovyapp.data.learning.intake.LearningIntake
 import com.slovy.slovymovyapp.data.learning.stats.StatsService
 import com.slovy.slovymovyapp.data.remote.*
 import com.slovy.slovymovyapp.data.settings.Setting
@@ -120,7 +119,6 @@ class FavoritesViewModel(
     private val favoritesRepository: FavoritesRepository,
     private val dictionaryRepository: DictionaryRepository,
     private val statsService: StatsService,
-    private val intakeService: LearningIntake,
     private val settingsRepository: SettingsRepository,
 ) : ViewModel() {
 
@@ -144,12 +142,11 @@ class FavoritesViewModel(
         state = content.withoutCachedFavoriteDetails()
     }
 
-    private val queryFlow = MutableStateFlow(QueryState("", Uuid.random(), runIntake = true))
+    private val queryFlow = MutableStateFlow(QueryState("", Uuid.random()))
 
     private data class QueryState(
         val query: String,
         val force: Uuid,
-        val runIntake: Boolean = false,
     )
 
     companion object {
@@ -174,7 +171,6 @@ class FavoritesViewModel(
                             computeFavoritesState(
                                 query = queryState.query,
                                 currentContent = snapshot,
-                                runIntake = queryState.runIntake,
                             ),
                         )
                     }
@@ -190,7 +186,7 @@ class FavoritesViewModel(
     fun updateQuery(newQuery: String) {
         val content = state as? FavoritesUiState.Content ?: return
         state = content.copy(query = newQuery)
-        queryFlow.value = QueryState(newQuery, Uuid.random(), runIntake = false)
+        queryFlow.value = QueryState(newQuery, Uuid.random())
     }
 
     fun loadFavorites() {
@@ -198,7 +194,6 @@ class FavoritesViewModel(
         queryFlow.value = QueryState(
             query = currentQuery,
             force = Uuid.random(),
-            runIntake = true,
         )
     }
 
@@ -210,7 +205,7 @@ class FavoritesViewModel(
         viewModelScope.launch {
             settingsRepository.insert(Setting(Setting.Name.FAVORITES_LANGUAGE, JsonPrimitive(language.code)))
         }
-        queryFlow.value = QueryState(content.query, Uuid.random(), runIntake = true)
+        queryFlow.value = QueryState(content.query, Uuid.random())
     }
 
     fun setLanguageDropdownExpanded(expanded: Boolean) {
@@ -227,25 +222,11 @@ class FavoritesViewModel(
     internal suspend fun computeFavoritesState(
         query: String,
         currentContent: FavoritesUiState.Content?,
-        runIntake: Boolean = false,
     ): FavoritesUiState.Content {
         val currentSenses = currentContent?.senses.orEmpty()
         val currentById = currentSenses.associateBy { it.senseId }
 
-        val initialFavorites = favoritesRepository.getAllGroupedByLangAndLemma()
-        val initialSelectedLanguage = selectedLanguageFor(
-            availableLanguages = initialFavorites.availableLanguages(),
-            currentContent = currentContent,
-        )
-        if (runIntake && initialSelectedLanguage != null) {
-            intakeService.runIntake(initialSelectedLanguage.code)
-        }
-
-        val allFavorites = if (runIntake) {
-            favoritesRepository.getAllGroupedByLangAndLemma()
-        } else {
-            initialFavorites
-        }
+        val allFavorites = favoritesRepository.getAllGroupedByLangAndLemma()
         val hasAnyFavorites = allFavorites.isNotEmpty()
         val availableLanguages = allFavorites.availableLanguages()
         val selectedLanguage = selectedLanguageFor(availableLanguages, currentContent)
@@ -347,15 +328,11 @@ class FavoritesViewModel(
 
     /** Computes and applies favorites state. Exposed for tests; production code uses the
      *  debounced flow or [toggleFavorite] which handle threading via [Dispatchers.Default]. */
-    internal suspend fun loadAndApplyState(
-        query: String,
-        runIntake: Boolean = false,
-    ) {
+    internal suspend fun loadAndApplyState(query: String) {
         applyNewState(
             computeFavoritesState(
                 query = query,
                 currentContent = state as? FavoritesUiState.Content,
-                runIntake = runIntake,
             ),
         )
     }

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/FavoritesScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/FavoritesScreen.kt
@@ -95,6 +95,7 @@ sealed interface FavoritesUiState {
         val selectedLanguage: Language? = null,
         val isLanguageDropdownExpanded: Boolean = false,
         val study: FavoritesStudyUiState? = null,
+        val reviewDueCount: Int = 0,
         val scrollToTop: Boolean = false
     ) : FavoritesUiState {
         val showNoResults: Boolean get() = senses.isEmpty() && query.isNotBlank()
@@ -115,11 +116,6 @@ private fun FavoriteSenseItem.withoutCachedDetails(): FavoriteSenseItem =
         error = null,
     )
 
-internal data class FavoritesStateResult(
-    val state: FavoritesUiState.Content,
-    val reviewDueCount: Int,
-)
-
 class FavoritesViewModel(
     private val favoritesRepository: FavoritesRepository,
     private val dictionaryRepository: DictionaryRepository,
@@ -131,15 +127,11 @@ class FavoritesViewModel(
     var state by mutableStateOf<FavoritesUiState>(FavoritesUiState.Loading)
         private set
 
-    var reviewDueCount by mutableStateOf(0)
-        private set
-
     val scrollState = LazyListState()
     val snackbarHostState = SnackbarHostState()
 
     private var pendingScrollToTop: Boolean = false
     private var savedFavoritesLanguage: Language? = null
-    private var reviewDueCountRefreshJob: Job? = null
 
     /** Called from outside (e.g. word detail) when a favorite was just added. */
     fun requestScrollToTop() {
@@ -189,8 +181,8 @@ class FavoritesViewModel(
                         .flowOn(Dispatchers.Default)
                 }
                 .collect { newState ->
-                    applyStateResult(newState)
-                    prefetchSenses(newState.state.senses.take(PREFETCH_LIMIT))
+                    applyNewState(newState)
+                    prefetchSenses(newState.senses.take(PREFETCH_LIMIT))
                 }
         }
     }
@@ -208,13 +200,6 @@ class FavoritesViewModel(
             force = Uuid.random(),
             runIntake = true,
         )
-    }
-
-    fun refreshReviewDueCount() {
-        reviewDueCountRefreshJob?.cancel()
-        reviewDueCountRefreshJob = viewModelScope.launch {
-            reviewDueCount = computeReviewDueCount()
-        }
     }
 
     fun setSelectedLanguage(language: Language) {
@@ -235,7 +220,7 @@ class FavoritesViewModel(
 
     /**
      * Computes the new favorites state from the repository. Safe to call from any dispatcher.
-     * Returns the new [FavoritesUiState.Content] and the due count without mutating [state].
+     * Returns the new [FavoritesUiState.Content] without mutating [state].
      *
      * @param currentContent snapshot of the current UI state, captured on Main before dispatching.
      */
@@ -243,7 +228,7 @@ class FavoritesViewModel(
         query: String,
         currentContent: FavoritesUiState.Content?,
         runIntake: Boolean = false,
-    ): FavoritesStateResult {
+    ): FavoritesUiState.Content {
         val currentSenses = currentContent?.senses.orEmpty()
         val currentById = currentSenses.associateBy { it.senseId }
 
@@ -317,31 +302,22 @@ class FavoritesViewModel(
                     ?.let { dueCount -> FavoritesStudyUiState(language, dueCount) }
             }
 
-        return FavoritesStateResult(
-            state = FavoritesUiState.Content(
-                senses = senses,
-                query = query,
-                hasAnyFavorites = hasAnyFavorites,
-                favoriteLemmas = langFiltered.map { it.lemma }.toSet(),
-                availableLanguages = availableLanguages,
-                selectedLanguage = selectedLanguage,
-                isLanguageDropdownExpanded = if (availableLanguages.size > 1)
-                    currentContent?.isLanguageDropdownExpanded ?: false else false,
-                study = study,
-            ),
+        return FavoritesUiState.Content(
+            senses = senses,
+            query = query,
+            hasAnyFavorites = hasAnyFavorites,
+            favoriteLemmas = langFiltered.map { it.lemma }.toSet(),
+            availableLanguages = availableLanguages,
+            selectedLanguage = selectedLanguage,
+            isLanguageDropdownExpanded = if (availableLanguages.size > 1)
+                currentContent?.isLanguageDropdownExpanded ?: false else false,
+            study = study,
             reviewDueCount = reviewDueCount,
         )
     }
 
     private fun List<Favorite>.availableLanguages(): List<Language> =
         map { it.language }.distinct().sorted()
-
-    private suspend fun computeReviewDueCount(): Int =
-        withContext(Dispatchers.Default) {
-            favoritesRepository.getAllGroupedByLangAndLemma()
-                .availableLanguages()
-                .sumOf { language -> statsService.globalStats(language.code).dueToday }
-        }
 
     private fun selectedLanguageFor(
         availableLanguages: List<Language>,
@@ -369,20 +345,13 @@ class FavoritesViewModel(
         }
     }
 
-    private fun applyStateResult(result: FavoritesStateResult) {
-        reviewDueCountRefreshJob?.cancel()
-        reviewDueCountRefreshJob = null
-        reviewDueCount = result.reviewDueCount
-        applyNewState(result.state)
-    }
-
     /** Computes and applies favorites state. Exposed for tests; production code uses the
      *  debounced flow or [toggleFavorite] which handle threading via [Dispatchers.Default]. */
     internal suspend fun loadAndApplyState(
         query: String,
         runIntake: Boolean = false,
     ) {
-        applyStateResult(
+        applyNewState(
             computeFavoritesState(
                 query = query,
                 currentContent = state as? FavoritesUiState.Content,
@@ -451,8 +420,8 @@ class FavoritesViewModel(
             // filtering, language switches, and all edge cases correctly)
             val snapshot = state as? FavoritesUiState.Content
             val newState = withContext(Dispatchers.Default) { computeFavoritesState(content.query, snapshot) }
-            applyStateResult(newState)
-            prefetchSenses(newState.state.senses.take(PREFETCH_LIMIT))
+            applyNewState(newState)
+            prefetchSenses(newState.senses.take(PREFETCH_LIMIT))
 
             // Show snackbar with an undo option
             val result = snackbarHostState.showSnackbar(

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/FavoritesScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/FavoritesScreen.kt
@@ -32,7 +32,6 @@ import com.slovy.slovymovyapp.analytics.AnalyticsEvent
 import com.slovy.slovymovyapp.data.Language
 import com.slovy.slovymovyapp.data.favorites.Favorite
 import com.slovy.slovymovyapp.data.favorites.FavoritesRepository
-import com.slovy.slovymovyapp.data.learning.stats.StatsService
 import com.slovy.slovymovyapp.data.remote.*
 import com.slovy.slovymovyapp.data.settings.Setting
 import com.slovy.slovymovyapp.data.settings.SettingsRepository
@@ -118,7 +117,6 @@ private fun FavoriteSenseItem.withoutCachedDetails(): FavoriteSenseItem =
 class FavoritesViewModel(
     private val favoritesRepository: FavoritesRepository,
     private val dictionaryRepository: DictionaryRepository,
-    private val statsService: StatsService,
     private val settingsRepository: SettingsRepository,
 ) : ViewModel() {
 
@@ -130,6 +128,7 @@ class FavoritesViewModel(
 
     private var pendingScrollToTop: Boolean = false
     private var savedFavoritesLanguage: Language? = null
+    private var dueCountByLanguage: Map<Language, Int> = emptyMap()
 
     /** Called from outside (e.g. word detail) when a favorite was just added. */
     fun requestScrollToTop() {
@@ -140,6 +139,12 @@ class FavoritesViewModel(
     fun dropCachedFavoriteDetails() {
         val content = state as? FavoritesUiState.Content ?: return
         state = content.withoutCachedFavoriteDetails()
+    }
+
+    fun updateReviewDueCounts(updatedDueCountByLanguage: Map<Language, Int>) {
+        dueCountByLanguage = updatedDueCountByLanguage
+        val content = state as? FavoritesUiState.Content ?: return
+        state = content.withReviewDueCounts()
     }
 
     private val queryFlow = MutableStateFlow(QueryState("", Uuid.random()))
@@ -230,10 +235,9 @@ class FavoritesViewModel(
         val hasAnyFavorites = allFavorites.isNotEmpty()
         val availableLanguages = allFavorites.availableLanguages()
         val selectedLanguage = selectedLanguageFor(availableLanguages, currentContent)
-        val dueCountByLanguage = availableLanguages.associateWith { language ->
-            statsService.globalStats(language.code).dueToday
+        val visibleDueCountByLanguage = availableLanguages.associateWith { language ->
+            dueCountByLanguage[language] ?: 0
         }
-        val reviewDueCount = dueCountByLanguage.values.sum()
 
         // Filter favorites to selected language when multi-language
         val langFiltered = if (availableLanguages.size > 1 && selectedLanguage != null) {
@@ -278,7 +282,7 @@ class FavoritesViewModel(
         }
         val study = selectedLanguage
             ?.let { language ->
-                dueCountByLanguage[language]
+                visibleDueCountByLanguage[language]
                     ?.takeIf { it > 0 }
                     ?.let { dueCount -> FavoritesStudyUiState(language, dueCount) }
             }
@@ -293,7 +297,23 @@ class FavoritesViewModel(
             isLanguageDropdownExpanded = if (availableLanguages.size > 1)
                 currentContent?.isLanguageDropdownExpanded ?: false else false,
             study = study,
-            reviewDueCount = reviewDueCount,
+            reviewDueCount = visibleDueCountByLanguage.values.sum(),
+        )
+    }
+
+    private fun FavoritesUiState.Content.withReviewDueCounts(): FavoritesUiState.Content {
+        val visibleDueCountByLanguage = availableLanguages.associateWith { language ->
+            dueCountByLanguage[language] ?: 0
+        }
+        val updatedStudy = selectedLanguage
+            ?.let { language ->
+                visibleDueCountByLanguage[language]
+                    ?.takeIf { it > 0 }
+                    ?.let { dueCount -> FavoritesStudyUiState(language, dueCount) }
+            }
+        return copy(
+            study = updatedStudy,
+            reviewDueCount = visibleDueCountByLanguage.values.sum(),
         )
     }
 
@@ -381,7 +401,12 @@ class FavoritesViewModel(
         }
     }
 
-    fun toggleFavorite(senseId: String, removedMessage: String, undoLabel: String) {
+    fun toggleFavorite(
+        senseId: String,
+        removedMessage: String,
+        undoLabel: String,
+        onFavoritesChanged: () -> Unit = {},
+    ) {
         val item = findSense(senseId) ?: return
         viewModelScope.launch {
             // Fetch the favorite to get its createdAt before removal
@@ -390,6 +415,7 @@ class FavoritesViewModel(
             // Remove from repository, then remove from displayed list for immediate feedback
             favoritesRepository.remove(senseId, favorite.language)
             Analytics.logEvent(AnalyticsEvent.FAVOURITES_REMOVE)
+            onFavoritesChanged()
             val content = state as? FavoritesUiState.Content ?: return@launch
             state = content.copy(senses = content.senses.filter { it.senseId != senseId })
 
@@ -411,6 +437,7 @@ class FavoritesViewModel(
                 // Re-add with the original createdAt to preserve position
                 favoritesRepository.add(senseId, favorite.language, favorite.lemma, favorite.createdAt)
                 Analytics.logEvent(AnalyticsEvent.FAVOURITES_SAVE)
+                onFavoritesChanged()
                 loadFavorites()
             }
         }
@@ -497,6 +524,7 @@ fun FavoritesScreen(
     onNavigateToSettings: () -> Unit = {},
     onNavigateToStats: () -> Unit = {},
     onStartStudy: (Language) -> Unit = {},
+    onFavoritesChanged: () -> Unit = {},
 ) {
     val focusManager = LocalFocusManager.current
     val removedMessage = stringResource(Res.string.favorites_removed_message)
@@ -529,7 +557,7 @@ fun FavoritesScreen(
         onSearchInDictionary = onSearchInDictionary,
         onQueryChange = { viewModel.updateQuery(it) },
         onSenseToggle = { viewModel.toggleSense(it) },
-        onFavoriteToggle = { viewModel.toggleFavorite(it, removedMessage, undoLabel) },
+        onFavoriteToggle = { viewModel.toggleFavorite(it, removedMessage, undoLabel, onFavoritesChanged) },
         onNavigateToWordDetail = onNavigateToWordDetail,
         wordDetailLabel = wordDetailLabel,
         onNavigateToLastWordDetail = onNavigateToLastWordDetail,

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/SearchScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/SearchScreen.kt
@@ -268,7 +268,7 @@ fun SearchScreen(
     onNavigateToFavorites: () -> Unit = {},
     onNavigateToStats: () -> Unit = {},
     onNavigateToSettings: () -> Unit = {},
-    dueCount: Int = 0,
+    hasFavoritesToReview: Boolean = false,
 ) {
     val focusManager = LocalFocusManager.current
     // restore after process death
@@ -321,7 +321,7 @@ fun SearchScreen(
         onNavigateToFavorites = onNavigateToFavorites,
         onNavigateToStats = onNavigateToStats,
         onNavigateToSettings = onNavigateToSettings,
-        dueCount = dueCount,
+        hasFavoritesToReview = hasFavoritesToReview,
     )
 }
 
@@ -340,7 +340,7 @@ fun SearchScreenContent(
     onNavigateToFavorites: () -> Unit = {},
     onNavigateToStats: () -> Unit = {},
     onNavigateToSettings: () -> Unit = {},
-    dueCount: Int = 0,
+    hasFavoritesToReview: Boolean = false,
 ) {
     val focusManager = LocalFocusManager.current
     Scaffold(
@@ -354,7 +354,7 @@ fun SearchScreenContent(
                 onNavigateToWordDetail = onNavigateToWordDetail,
                 wordDetailLabel = wordDetailLabel,
                 onNavigateToSettings = onNavigateToSettings,
-                dueCount = dueCount,
+                hasFavoritesToReview = hasFavoritesToReview,
             )
         }
     ) { innerPadding ->

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/SearchScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/SearchScreen.kt
@@ -267,7 +267,8 @@ fun SearchScreen(
     onNavigateToWordDetail: () -> Unit = {},
     onNavigateToFavorites: () -> Unit = {},
     onNavigateToStats: () -> Unit = {},
-    onNavigateToSettings: () -> Unit = {}
+    onNavigateToSettings: () -> Unit = {},
+    dueCount: Int = 0,
 ) {
     val focusManager = LocalFocusManager.current
     // restore after process death
@@ -319,7 +320,8 @@ fun SearchScreen(
         onNavigateToWordDetail = onNavigateToWordDetail,
         onNavigateToFavorites = onNavigateToFavorites,
         onNavigateToStats = onNavigateToStats,
-        onNavigateToSettings = onNavigateToSettings
+        onNavigateToSettings = onNavigateToSettings,
+        dueCount = dueCount,
     )
 }
 
@@ -337,7 +339,8 @@ fun SearchScreenContent(
     onNavigateToWordDetail: () -> Unit = {},
     onNavigateToFavorites: () -> Unit = {},
     onNavigateToStats: () -> Unit = {},
-    onNavigateToSettings: () -> Unit = {}
+    onNavigateToSettings: () -> Unit = {},
+    dueCount: Int = 0,
 ) {
     val focusManager = LocalFocusManager.current
     Scaffold(
@@ -350,7 +353,8 @@ fun SearchScreenContent(
                 onNavigateToStats = onNavigateToStats,
                 onNavigateToWordDetail = onNavigateToWordDetail,
                 wordDetailLabel = wordDetailLabel,
-                onNavigateToSettings = onNavigateToSettings
+                onNavigateToSettings = onNavigateToSettings,
+                dueCount = dueCount,
             )
         }
     ) { innerPadding ->

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/SettingsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/SettingsScreen.kt
@@ -896,7 +896,7 @@ fun SettingsScreen(
     onNavigateToFavorites: () -> Unit = {},
     onNavigateToStats: () -> Unit = {},
     onNavigateToWordDetail: () -> Unit = {},
-    dueCount: Int = 0,
+    hasFavoritesToReview: Boolean = false,
 ) {
     LifecycleResumeEffect(Unit) {
         viewModel.reloadSettings()
@@ -943,7 +943,7 @@ fun SettingsScreen(
         onNavigateToFavorites = onNavigateToFavorites,
         onNavigateToStats = onNavigateToStats,
         onNavigateToWordDetail = onNavigateToWordDetail,
-        dueCount = dueCount,
+        hasFavoritesToReview = hasFavoritesToReview,
     )
 }
 
@@ -981,7 +981,7 @@ fun SettingsScreenContent(
     onNavigateToFavorites: () -> Unit = {},
     onNavigateToStats: () -> Unit = {},
     onNavigateToWordDetail: () -> Unit = {},
-    dueCount: Int = 0,
+    hasFavoritesToReview: Boolean = false,
 ) {
     val dismissActionLabel = stringResource(Res.string.common_dismiss)
     state.errorMessage?.let { error ->
@@ -1020,7 +1020,7 @@ fun SettingsScreenContent(
                     onNavigateToWordDetail = onNavigateToWordDetail,
                     wordDetailLabel = wordDetailLabel,
                     onNavigateToSettings = {},
-                    dueCount = dueCount,
+                    hasFavoritesToReview = hasFavoritesToReview,
                 )
             },
             snackbarHost = {

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/SettingsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/SettingsScreen.kt
@@ -895,7 +895,8 @@ fun SettingsScreen(
     onNavigateToSearch: () -> Unit = {},
     onNavigateToFavorites: () -> Unit = {},
     onNavigateToStats: () -> Unit = {},
-    onNavigateToWordDetail: () -> Unit = {}
+    onNavigateToWordDetail: () -> Unit = {},
+    dueCount: Int = 0,
 ) {
     LifecycleResumeEffect(Unit) {
         viewModel.reloadSettings()
@@ -941,7 +942,8 @@ fun SettingsScreen(
         onNavigateToSearch = onNavigateToSearch,
         onNavigateToFavorites = onNavigateToFavorites,
         onNavigateToStats = onNavigateToStats,
-        onNavigateToWordDetail = onNavigateToWordDetail
+        onNavigateToWordDetail = onNavigateToWordDetail,
+        dueCount = dueCount,
     )
 }
 
@@ -978,7 +980,8 @@ fun SettingsScreenContent(
     onNavigateToSearch: () -> Unit = {},
     onNavigateToFavorites: () -> Unit = {},
     onNavigateToStats: () -> Unit = {},
-    onNavigateToWordDetail: () -> Unit = {}
+    onNavigateToWordDetail: () -> Unit = {},
+    dueCount: Int = 0,
 ) {
     val dismissActionLabel = stringResource(Res.string.common_dismiss)
     state.errorMessage?.let { error ->
@@ -1016,7 +1019,8 @@ fun SettingsScreenContent(
                     onNavigateToStats = onNavigateToStats,
                     onNavigateToWordDetail = onNavigateToWordDetail,
                     wordDetailLabel = wordDetailLabel,
-                    onNavigateToSettings = {}
+                    onNavigateToSettings = {},
+                    dueCount = dueCount,
                 )
             },
             snackbarHost = {

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/StatsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/StatsScreen.kt
@@ -140,6 +140,7 @@ fun StatsScreen(
     onNavigateToFavorites: () -> Unit = {},
     onNavigateToWordDetail: () -> Unit = {},
     onNavigateToSettings: () -> Unit = {},
+    hasFavoritesToReview: Boolean = false,
 ) {
     LaunchedEffect(learningLanguages) {
         viewModel.updateLearningLanguages(learningLanguages)
@@ -159,6 +160,7 @@ fun StatsScreen(
         onNavigateToFavorites = onNavigateToFavorites,
         onNavigateToWordDetail = onNavigateToWordDetail,
         onNavigateToSettings = onNavigateToSettings,
+        hasFavoritesToReview = hasFavoritesToReview,
     )
 }
 
@@ -175,6 +177,7 @@ fun StatsScreenContent(
     onNavigateToFavorites: () -> Unit = {},
     onNavigateToWordDetail: () -> Unit = {},
     onNavigateToSettings: () -> Unit = {},
+    hasFavoritesToReview: Boolean = false,
 ) {
     Scaffold(
         modifier = Modifier.fillMaxSize(),
@@ -187,6 +190,7 @@ fun StatsScreenContent(
                 onNavigateToWordDetail = onNavigateToWordDetail,
                 wordDetailLabel = wordDetailLabel,
                 onNavigateToSettings = onNavigateToSettings,
+                hasFavoritesToReview = hasFavoritesToReview,
             )
         },
         containerColor = MaterialTheme.colorScheme.background,

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/study/StudySessionViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/study/StudySessionViewModel.kt
@@ -36,6 +36,7 @@ class StudySessionViewModel(
     private val clock: Clock,
     private val ttsManager: TextToSpeechManager,
     private val voiceFilterHelper: VoiceFilterHelper,
+    private val onReviewSubmitted: () -> Unit,
 ) : ViewModel() {
 
     var state by mutableStateOf<StudySessionUiState>(StudySessionUiState.Loading())
@@ -156,6 +157,7 @@ class StudySessionViewModel(
                     durationMs = (clock.now() - cardShownAt).inWholeMilliseconds,
                 )
             }.onSuccess {
+                onReviewSubmitted()
                 reviewedCount += 1
                 currentCard = null
                 currentOutcomes = emptyList()

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/word/WordDetailsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/word/WordDetailsScreen.kt
@@ -267,8 +267,7 @@ class WordDetailViewModel(
     private val lemma: String = "",
     val targetSenseId: String? = null,
     private val translationLanguages: List<Language>? = null,
-    private val onFavoriteAdded: (() -> Unit)? = null,
-    private val onFavoriteChanged: (() -> Unit)? = null,
+    private val onFavoriteChanged: ((added: Boolean) -> Unit)? = null,
 ) : ViewModel() {
     var state by mutableStateOf<WordDetailUiState>(
         WordDetailUiState.Empty(
@@ -542,17 +541,16 @@ class WordDetailViewModel(
     fun toggleFavorite(senseId: String) {
         viewModelScope.launch {
             dictionaryLanguage.let { lang ->
-                if (senseId in favoriteSenses) {
+                val added = if (senseId in favoriteSenses) {
                     favoritesRepository.remove(senseId, lang)
                     Analytics.logEvent(AnalyticsEvent.WORD_DETAILS_FAVOURITES_REMOVE)
-
-
+                    false
                 } else {
                     favoritesRepository.add(senseId, lang, lemma)
                     Analytics.logEvent(AnalyticsEvent.WORD_DETAILS_FAVOURITES_SAVE)
-                    onFavoriteAdded?.invoke()
+                    true
                 }
-                onFavoriteChanged?.invoke()
+                onFavoriteChanged?.invoke(added)
                 loadFavorites()
             }
         }
@@ -754,7 +752,7 @@ fun WordDetailScreen(
     onNavigateToStats: () -> Unit = {},
     onNavigateToSettings: () -> Unit = {},
     onNavigateToWordDetail: (Language, String) -> Unit = { _, _ -> },
-    dueCount: Int = 0,
+    hasFavoritesToReview: Boolean = false,
 ) {
     DisposableEffect(viewModel) {
         viewModel.attachTtsListener()
@@ -823,7 +821,7 @@ fun WordDetailScreen(
         onWordClick = { word ->
             onNavigateToWordDetail(viewModel.dictionaryLanguage, word)
         },
-        dueCount = dueCount,
+        hasFavoritesToReview = hasFavoritesToReview,
     )
 }
 
@@ -862,7 +860,7 @@ fun WordDetailScreenContent(
     isSenseFavorite: (String) -> Boolean = { false },
     onSenseFavoriteToggle: (String) -> Unit = {},
     onWordClick: (String) -> Unit = {},
-    dueCount: Int = 0,
+    hasFavoritesToReview: Boolean = false,
 ) {
     val fallbackTitle = stringResource(Res.string.word_details_title)
     val titleText = when (state) {
@@ -956,7 +954,7 @@ fun WordDetailScreenContent(
                 onNavigateToWordDetail = {},
                 onNavigateToSettings = onNavigateToSettings,
                 wordDetailLabel = titleText,
-                dueCount = dueCount,
+                hasFavoritesToReview = hasFavoritesToReview,
             )
         },
         snackbarHost = { SnackbarHost(hostState = snackbarHostState) },

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/word/WordDetailsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/word/WordDetailsScreen.kt
@@ -267,7 +267,8 @@ class WordDetailViewModel(
     private val lemma: String = "",
     val targetSenseId: String? = null,
     private val translationLanguages: List<Language>? = null,
-    private val onFavoriteAdded: (() -> Unit)? = null
+    private val onFavoriteAdded: (() -> Unit)? = null,
+    private val onFavoriteChanged: (() -> Unit)? = null,
 ) : ViewModel() {
     var state by mutableStateOf<WordDetailUiState>(
         WordDetailUiState.Empty(
@@ -551,6 +552,7 @@ class WordDetailViewModel(
                     Analytics.logEvent(AnalyticsEvent.WORD_DETAILS_FAVOURITES_SAVE)
                     onFavoriteAdded?.invoke()
                 }
+                onFavoriteChanged?.invoke()
                 loadFavorites()
             }
         }
@@ -751,7 +753,8 @@ fun WordDetailScreen(
     onNavigateToFavorites: () -> Unit = {},
     onNavigateToStats: () -> Unit = {},
     onNavigateToSettings: () -> Unit = {},
-    onNavigateToWordDetail: (Language, String) -> Unit = { _, _ -> }
+    onNavigateToWordDetail: (Language, String) -> Unit = { _, _ -> },
+    dueCount: Int = 0,
 ) {
     DisposableEffect(viewModel) {
         viewModel.attachTtsListener()
@@ -819,7 +822,8 @@ fun WordDetailScreen(
         },
         onWordClick = { word ->
             onNavigateToWordDetail(viewModel.dictionaryLanguage, word)
-        }
+        },
+        dueCount = dueCount,
     )
 }
 
@@ -857,7 +861,8 @@ fun WordDetailScreenContent(
     onSensePositioned: (String, Float) -> Unit = { _, _ -> },
     isSenseFavorite: (String) -> Boolean = { false },
     onSenseFavoriteToggle: (String) -> Unit = {},
-    onWordClick: (String) -> Unit = {}
+    onWordClick: (String) -> Unit = {},
+    dueCount: Int = 0,
 ) {
     val fallbackTitle = stringResource(Res.string.word_details_title)
     val titleText = when (state) {
@@ -950,7 +955,8 @@ fun WordDetailScreenContent(
                 onNavigateToStats = onNavigateToStats,
                 onNavigateToWordDetail = {},
                 onNavigateToSettings = onNavigateToSettings,
-                wordDetailLabel = titleText
+                wordDetailLabel = titleText,
+                dueCount = dueCount,
             )
         },
         snackbarHost = { SnackbarHost(hostState = snackbarHostState) },

--- a/composeApp/src/commonTest/kotlin/com/slovy/slovymovyapp/FavoritesReviewCoordinatorTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/slovy/slovymovyapp/FavoritesReviewCoordinatorTest.kt
@@ -1,0 +1,59 @@
+package com.slovy.slovymovyapp
+
+import com.slovy.slovymovyapp.data.Language
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import kotlin.time.Clock
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Duration.Companion.seconds
+import kotlin.time.ExperimentalTime
+import kotlin.time.Instant
+
+@OptIn(ExperimentalTime::class)
+class FavoritesReviewCoordinatorTest {
+    private val start = Instant.parse("2026-05-10T00:00:00Z")
+    private val clock = MutableClock(start)
+    private val coordinator = FavoritesReviewCoordinator(clock)
+
+    @Test
+    fun cachesIntakeForFiveMinutesPerLanguage() {
+        assertTrue(coordinator.shouldRunIntake(Language.ENGLISH))
+        assertTrue(coordinator.shouldRunIntake(Language.POLISH))
+
+        coordinator.markIntakeRun(Language.ENGLISH)
+
+        assertFalse(coordinator.shouldRunIntake(Language.ENGLISH))
+        assertTrue(coordinator.shouldRunIntake(Language.POLISH))
+
+        clock.advance(4.minutes + 59.seconds)
+        assertFalse(coordinator.shouldRunIntake(Language.ENGLISH))
+
+        clock.advance(1.seconds)
+        assertTrue(coordinator.shouldRunIntake(Language.ENGLISH))
+    }
+
+    @Test
+    fun invalidateIntakeCacheDropsCachedLanguages() {
+        coordinator.markIntakeRun(Language.ENGLISH)
+        coordinator.markIntakeRun(Language.POLISH)
+
+        assertFalse(coordinator.shouldRunIntake(Language.ENGLISH))
+        assertFalse(coordinator.shouldRunIntake(Language.POLISH))
+
+        coordinator.invalidateIntakeCache()
+
+        assertTrue(coordinator.shouldRunIntake(Language.ENGLISH))
+        assertTrue(coordinator.shouldRunIntake(Language.POLISH))
+    }
+}
+
+@OptIn(ExperimentalTime::class)
+private class MutableClock(private var current: Instant) : Clock {
+    override fun now(): Instant = current
+
+    fun advance(duration: Duration) {
+        current += duration
+    }
+}

--- a/composeApp/src/commonTest/kotlin/com/slovy/slovymovyapp/ui/FavoritesViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/slovy/slovymovyapp/ui/FavoritesViewModelTest.kt
@@ -273,7 +273,7 @@ open class FavoritesViewModelTest : BaseTest() {
         vm.loadAndApplyState("")
         assertFalse(contentState(vm).scrollToTop)
 
-        // Favorite is added and onFavoriteAdded fires after the initial load
+        // Favorite is added and the app asks Favorites to scroll after the initial load
         favRepo.add(SENSE_1, Language.ENGLISH, "hello")
         vm.requestScrollToTop() // sets the pending flag
         vm.loadAndApplyState("") // simulate the subsequent Favorites reload (debounced queryFlow)
@@ -282,7 +282,7 @@ open class FavoritesViewModelTest : BaseTest() {
         assertEquals(1, content.senses.size, "New favorite should be present")
         assertTrue(
             content.scrollToTop,
-            "Should scroll to top even when the initial Favorites load ran before onFavoriteAdded"
+            "Should scroll to top even when the initial Favorites load ran before the app requested it"
         )
     }
 
@@ -581,7 +581,7 @@ open class FavoritesViewModelTest : BaseTest() {
         vm.loadAndApplyState("")
 
         val content = contentState(vm)
-        assertEquals(2, vm.reviewDueCount)
+        assertEquals(2, content.reviewDueCount)
         assertEquals(1, assertNotNull(content.study).dueCount)
     }
 }

--- a/composeApp/src/commonTest/kotlin/com/slovy/slovymovyapp/ui/FavoritesViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/slovy/slovymovyapp/ui/FavoritesViewModelTest.kt
@@ -529,4 +529,59 @@ open class FavoritesViewModelTest : BaseTest() {
         assertEquals(1, study.dueCount)
         assertEquals(1, study.estimatedMinutes)
     }
+
+    @Test
+    fun reviewDueCount_aggregatesDueCardsAcrossFavoriteLanguages() = runTest {
+        val app = testAppDatabaseHolder().database
+        val favRepo = favoritesRepository(app)
+        favRepo.deleteAll()
+        favRepo.add(SENSE_1, Language.ENGLISH, "hello")
+        favRepo.add(SENSE_2, Language.RUSSIAN, "привет")
+        app.favoritesQueries.insertCard(
+            id = Uuid.parse("00000000-0000-0000-0000-000000000501"),
+            sense_id = Uuid.parse(SENSE_1),
+            lemma_id = Uuid.parse("00000000-0000-0000-0000-000000000601"),
+            lang_code = Language.ENGLISH.code,
+            family = CardFamily.RECOGNIZE_SENSE,
+            state = CardState.REVIEW,
+            stability = 1.0,
+            difficulty = 1.0,
+            due = 0L,
+            last_review = null,
+            reps = 1,
+            lapses = 0,
+            created_at = 0L,
+            available_after = null,
+            answer_key = "hello",
+            suspended = false,
+        )
+        app.favoritesQueries.insertCard(
+            id = Uuid.parse("00000000-0000-0000-0000-000000000502"),
+            sense_id = Uuid.parse(SENSE_2),
+            lemma_id = Uuid.parse("00000000-0000-0000-0000-000000000602"),
+            lang_code = Language.RUSSIAN.code,
+            family = CardFamily.RECOGNIZE_SENSE,
+            state = CardState.REVIEW,
+            stability = 1.0,
+            difficulty = 1.0,
+            due = 0L,
+            last_review = null,
+            reps = 1,
+            lapses = 0,
+            created_at = 0L,
+            available_after = null,
+            answer_key = "привет",
+            suspended = false,
+        )
+
+        val vm = createViewModel(
+            favRepo = favRepo,
+            statsService = StatsService(app.favoritesQueries, clock = Clock.System),
+        )
+        vm.loadAndApplyState("")
+
+        val content = contentState(vm)
+        assertEquals(2, vm.reviewDueCount)
+        assertEquals(1, assertNotNull(content.study).dueCount)
+    }
 }

--- a/composeApp/src/commonTest/kotlin/com/slovy/slovymovyapp/ui/FavoritesViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/slovy/slovymovyapp/ui/FavoritesViewModelTest.kt
@@ -5,8 +5,6 @@ import com.slovy.slovymovyapp.data.Language
 import com.slovy.slovymovyapp.data.favorites.FavoritesRepository
 import com.slovy.slovymovyapp.data.learning.CardFamily
 import com.slovy.slovymovyapp.data.learning.CardState
-import com.slovy.slovymovyapp.data.learning.intake.IntakeResult
-import com.slovy.slovymovyapp.data.learning.intake.LearningIntake
 import com.slovy.slovymovyapp.data.learning.stats.StatsService
 import com.slovy.slovymovyapp.data.remote.*
 import com.slovy.slovymovyapp.data.settings.Setting
@@ -29,23 +27,6 @@ open class FavoritesViewModelTest : BaseTest() {
         const val SENSE_1 = "00000000-0000-0000-0000-000000000101"
         const val SENSE_2 = "00000000-0000-0000-0000-000000000102"
         const val SENSE_3 = "00000000-0000-0000-0000-000000000103"
-    }
-
-    private class RecordingIntake(
-        private val onRun: suspend (String) -> Unit = {},
-    ) : LearningIntake {
-        val langCodes = mutableListOf<String>()
-
-        override suspend fun runIntake(langCode: String): IntakeResult {
-            langCodes += langCode
-            onRun(langCode)
-            return IntakeResult(activated = emptyList(), skipped = emptyList(), cardsCreated = 0)
-        }
-    }
-
-    private object NoopIntake : LearningIntake {
-        override suspend fun runIntake(langCode: String): IntakeResult =
-            IntakeResult(activated = emptyList(), skipped = emptyList(), cardsCreated = 0)
     }
 
     @BeforeTest
@@ -90,10 +71,9 @@ open class FavoritesViewModelTest : BaseTest() {
             testAppDatabaseHolder().database.favoritesQueries,
             clock = Clock.System
         ),
-        intakeService: LearningIntake = NoopIntake,
         settingsRepo: SettingsRepository = SettingsRepository(testAppDatabaseHolder().database),
     ): FavoritesViewModel {
-        val vm = FavoritesViewModel(favRepo, dictRepo, statsService, intakeService, settingsRepo)
+        val vm = FavoritesViewModel(favRepo, dictRepo, statsService, settingsRepo)
         viewModelStore.put("test", vm)
         createdViewModels += vm
         return vm
@@ -329,38 +309,6 @@ open class FavoritesViewModelTest : BaseTest() {
     }
 
     @Test
-    fun loadAndApplyState_runsIntakeWhenRequestedForSelectedLanguage() = runTest {
-        val favRepo = favoritesRepository()
-        val intake = RecordingIntake()
-        favRepo.deleteAll()
-        favRepo.add(SENSE_1, Language.ENGLISH, "hello")
-
-        val vm = createViewModel(favRepo, intakeService = intake)
-        vm.loadAndApplyState("", runIntake = true)
-        vm.loadAndApplyState("", runIntake = true)
-
-        assertEquals(listOf(Language.ENGLISH.code, Language.ENGLISH.code), intake.langCodes)
-        assertFalse(contentState(vm).scrollToTop)
-    }
-
-    @Test
-    fun loadAndApplyState_usesFavoritesSnapshotAfterIntake() = runTest {
-        val favRepo = favoritesRepository()
-        favRepo.deleteAll()
-        favRepo.add(SENSE_1, Language.ENGLISH, "hello")
-        val intake = RecordingIntake {
-            favRepo.add(SENSE_2, Language.ENGLISH, "world")
-        }
-
-        val vm = createViewModel(favRepo, intakeService = intake)
-        vm.loadAndApplyState("", runIntake = true)
-
-        val content = contentState(vm)
-        assertEquals(setOf(SENSE_1, SENSE_2), content.senses.map { it.senseId }.toSet())
-        assertEquals(setOf("hello", "world"), content.favoriteLemmas)
-    }
-
-    @Test
     fun withoutCachedFavoriteDetails_dropsLoadedSenseDetails() {
         val state = FavoritesUiState.Content(
             senses = listOf(
@@ -400,38 +348,35 @@ open class FavoritesViewModelTest : BaseTest() {
     }
 
     @Test
-    fun loadAndApplyState_showsStudyCardForNewCardCreatedByIntake() = runTest {
+    fun loadAndApplyState_showsStudyCardForDueCard() = runTest {
         val app = testAppDatabaseHolder().database
         val favRepo = favoritesRepository(app)
         favRepo.deleteAll()
         favRepo.add(SENSE_1, Language.ENGLISH, "hello")
-        val intake = RecordingIntake {
-            app.favoritesQueries.insertCard(
-                id = Uuid.parse("00000000-0000-0000-0000-000000000401"),
-                sense_id = Uuid.parse(SENSE_1),
-                lemma_id = Uuid.parse("00000000-0000-0000-0000-000000000402"),
-                lang_code = Language.ENGLISH.code,
-                family = CardFamily.RECOGNIZE_SENSE,
-                state = CardState.NEW,
-                stability = 0.0,
-                difficulty = 0.0,
-                due = 0L,
-                last_review = null,
-                reps = 0,
-                lapses = 0,
-                created_at = 0L,
-                available_after = null,
-                answer_key = "hello",
-                suspended = false,
-            )
-        }
+        app.favoritesQueries.insertCard(
+            id = Uuid.parse("00000000-0000-0000-0000-000000000401"),
+            sense_id = Uuid.parse(SENSE_1),
+            lemma_id = Uuid.parse("00000000-0000-0000-0000-000000000402"),
+            lang_code = Language.ENGLISH.code,
+            family = CardFamily.RECOGNIZE_SENSE,
+            state = CardState.NEW,
+            stability = 0.0,
+            difficulty = 0.0,
+            due = 0L,
+            last_review = null,
+            reps = 0,
+            lapses = 0,
+            created_at = 0L,
+            available_after = null,
+            answer_key = "hello",
+            suspended = false,
+        )
 
         val vm = createViewModel(
             favRepo = favRepo,
             statsService = StatsService(app.favoritesQueries, clock = Clock.System),
-            intakeService = intake,
         )
-        vm.loadAndApplyState("", runIntake = true)
+        vm.loadAndApplyState("")
 
         val study = assertNotNull(contentState(vm).study)
         assertEquals(Language.ENGLISH, study.language)

--- a/composeApp/src/commonTest/kotlin/com/slovy/slovymovyapp/ui/FavoritesViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/slovy/slovymovyapp/ui/FavoritesViewModelTest.kt
@@ -3,9 +3,6 @@ package com.slovy.slovymovyapp.ui
 import androidx.lifecycle.ViewModelStore
 import com.slovy.slovymovyapp.data.Language
 import com.slovy.slovymovyapp.data.favorites.FavoritesRepository
-import com.slovy.slovymovyapp.data.learning.CardFamily
-import com.slovy.slovymovyapp.data.learning.CardState
-import com.slovy.slovymovyapp.data.learning.stats.StatsService
 import com.slovy.slovymovyapp.data.remote.*
 import com.slovy.slovymovyapp.data.settings.Setting
 import com.slovy.slovymovyapp.data.settings.SettingsRepository
@@ -15,8 +12,6 @@ import com.slovy.slovymovyapp.test.BaseTest
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runTest
 import kotlin.test.*
-import kotlin.time.Clock
-import kotlin.uuid.Uuid
 
 open class FavoritesViewModelTest : BaseTest() {
 
@@ -67,13 +62,9 @@ open class FavoritesViewModelTest : BaseTest() {
     private fun createViewModel(
         favRepo: FavoritesRepository,
         dictRepo: DictionaryRepository = dictionaryRepository(favRepo),
-        statsService: StatsService = StatsService(
-            testAppDatabaseHolder().database.favoritesQueries,
-            clock = Clock.System
-        ),
         settingsRepo: SettingsRepository = SettingsRepository(testAppDatabaseHolder().database),
     ): FavoritesViewModel {
-        val vm = FavoritesViewModel(favRepo, dictRepo, statsService, settingsRepo)
+        val vm = FavoritesViewModel(favRepo, dictRepo, settingsRepo)
         viewModelStore.put("test", vm)
         createdViewModels += vm
         return vm
@@ -349,33 +340,12 @@ open class FavoritesViewModelTest : BaseTest() {
 
     @Test
     fun loadAndApplyState_showsStudyCardForDueCard() = runTest {
-        val app = testAppDatabaseHolder().database
-        val favRepo = favoritesRepository(app)
+        val favRepo = favoritesRepository()
         favRepo.deleteAll()
         favRepo.add(SENSE_1, Language.ENGLISH, "hello")
-        app.favoritesQueries.insertCard(
-            id = Uuid.parse("00000000-0000-0000-0000-000000000401"),
-            sense_id = Uuid.parse(SENSE_1),
-            lemma_id = Uuid.parse("00000000-0000-0000-0000-000000000402"),
-            lang_code = Language.ENGLISH.code,
-            family = CardFamily.RECOGNIZE_SENSE,
-            state = CardState.NEW,
-            stability = 0.0,
-            difficulty = 0.0,
-            due = 0L,
-            last_review = null,
-            reps = 0,
-            lapses = 0,
-            created_at = 0L,
-            available_after = null,
-            answer_key = "hello",
-            suspended = false,
-        )
 
-        val vm = createViewModel(
-            favRepo = favRepo,
-            statsService = StatsService(app.favoritesQueries, clock = Clock.System),
-        )
+        val vm = createViewModel(favRepo)
+        vm.updateReviewDueCounts(mapOf(Language.ENGLISH to 1))
         vm.loadAndApplyState("")
 
         val study = assertNotNull(contentState(vm).study)
@@ -440,33 +410,12 @@ open class FavoritesViewModelTest : BaseTest() {
 
     @Test
     fun studyState_showsDueCountForSelectedLanguage() = runTest {
-        val app = testAppDatabaseHolder().database
-        val favRepo = favoritesRepository(app)
+        val favRepo = favoritesRepository()
         favRepo.deleteAll()
         favRepo.add(SENSE_1, Language.ENGLISH, "hello")
-        app.favoritesQueries.insertCard(
-            id = Uuid.parse("00000000-0000-0000-0000-000000000201"),
-            sense_id = Uuid.parse(SENSE_1),
-            lemma_id = Uuid.parse("00000000-0000-0000-0000-000000000301"),
-            lang_code = Language.ENGLISH.code,
-            family = CardFamily.RECOGNIZE_SENSE,
-            state = CardState.REVIEW,
-            stability = 1.0,
-            difficulty = 1.0,
-            due = 0L,
-            last_review = null,
-            reps = 1,
-            lapses = 0,
-            created_at = 0L,
-            available_after = null,
-            answer_key = "hello",
-            suspended = false,
-        )
 
-        val vm = createViewModel(
-            favRepo = favRepo,
-            statsService = StatsService(app.favoritesQueries, clock = Clock.System),
-        )
+        val vm = createViewModel(favRepo)
+        vm.updateReviewDueCounts(mapOf(Language.ENGLISH to 1))
         vm.loadAndApplyState("")
 
         val study = assertNotNull(contentState(vm).study)
@@ -477,51 +426,17 @@ open class FavoritesViewModelTest : BaseTest() {
 
     @Test
     fun reviewDueCount_aggregatesDueCardsAcrossFavoriteLanguages() = runTest {
-        val app = testAppDatabaseHolder().database
-        val favRepo = favoritesRepository(app)
+        val favRepo = favoritesRepository()
         favRepo.deleteAll()
         favRepo.add(SENSE_1, Language.ENGLISH, "hello")
         favRepo.add(SENSE_2, Language.RUSSIAN, "привет")
-        app.favoritesQueries.insertCard(
-            id = Uuid.parse("00000000-0000-0000-0000-000000000501"),
-            sense_id = Uuid.parse(SENSE_1),
-            lemma_id = Uuid.parse("00000000-0000-0000-0000-000000000601"),
-            lang_code = Language.ENGLISH.code,
-            family = CardFamily.RECOGNIZE_SENSE,
-            state = CardState.REVIEW,
-            stability = 1.0,
-            difficulty = 1.0,
-            due = 0L,
-            last_review = null,
-            reps = 1,
-            lapses = 0,
-            created_at = 0L,
-            available_after = null,
-            answer_key = "hello",
-            suspended = false,
-        )
-        app.favoritesQueries.insertCard(
-            id = Uuid.parse("00000000-0000-0000-0000-000000000502"),
-            sense_id = Uuid.parse(SENSE_2),
-            lemma_id = Uuid.parse("00000000-0000-0000-0000-000000000602"),
-            lang_code = Language.RUSSIAN.code,
-            family = CardFamily.RECOGNIZE_SENSE,
-            state = CardState.REVIEW,
-            stability = 1.0,
-            difficulty = 1.0,
-            due = 0L,
-            last_review = null,
-            reps = 1,
-            lapses = 0,
-            created_at = 0L,
-            available_after = null,
-            answer_key = "привет",
-            suspended = false,
-        )
 
-        val vm = createViewModel(
-            favRepo = favRepo,
-            statsService = StatsService(app.favoritesQueries, clock = Clock.System),
+        val vm = createViewModel(favRepo)
+        vm.updateReviewDueCounts(
+            mapOf(
+                Language.ENGLISH to 1,
+                Language.RUSSIAN to 1,
+            )
         )
         vm.loadAndApplyState("")
 
@@ -529,4 +444,5 @@ open class FavoritesViewModelTest : BaseTest() {
         assertEquals(2, content.reviewDueCount)
         assertEquals(1, assertNotNull(content.study).dueCount)
     }
+
 }


### PR DESCRIPTION

## Summary
- Add a review-due dot to the Favorites nav item when cards are due
    - Keep the due count in FavoritesViewModel as the single source of truth
    - Refresh due count after study completion/cancel and favorite changes
    - Reuse computed favorites state to avoid redundant DB queries
    - Add ViewModel coverage for aggregated review due count


## Testing
