### PR TITLE
feat: dictionary version mismatch screen + spinner fix

### DIFF
--- a/composeApp/src/commonMain/composeResources/values-nl/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-nl/strings.xml
@@ -106,9 +106,9 @@
     <string name="feedback_dialog_title">App-feedback</string>
     <string name="feedback_dialog_placeholder">Deel je gedachten...</string>
 
-    <string name="app_data_version_mismatch_message">We hebben het woordenboekformaat bijgewerkt. Je moet je
-        woordenboeken opnieuw downloaden — je opgeslagen woorden zijn veilig.
-    </string>
+    <string name="app_data_version_mismatch_title">Je woordenboeken zijn aan vernieuwing toe</string>
+    <string name="app_data_version_mismatch_body">We hebben de indeling van de woordenboeken verbeterd. Download ze opnieuw voor de nieuwste versie—via wifi duurt dit een paar minuten. Je opgeslagen woorden en voortgang blijven bewaard.</string>
+    <string name="app_data_version_mismatch_action">Vernieuw woordenboeken</string>
 
     <string name="word_details_title">Woorddetails</string>
     <string name="word_details_action_stop">Stoppen</string>

--- a/composeApp/src/commonMain/composeResources/values-pl/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-pl/strings.xml
@@ -107,9 +107,9 @@
     <string name="feedback_dialog_title">Opinia o aplikacji</string>
     <string name="feedback_dialog_placeholder">Napisz, co myślisz...</string>
 
-    <string name="app_data_version_mismatch_message">Zaktualizowaliśmy format słowników. Musisz pobrać je ponownie —
-        Twoje zapisane słowa są bezpieczne.
-    </string>
+    <string name="app_data_version_mismatch_title">Twoje słowniki wymagają odświeżenia</string>
+    <string name="app_data_version_mismatch_body">Poprawiliśmy format słowników. Pobierz je ponownie, aby korzystać z nowej wersji—przez Wi-Fi zajmie to kilka minut. Twoje zapisane słowa i postępy są bezpieczne.</string>
+    <string name="app_data_version_mismatch_action">Odśwież słowniki</string>
 
     <string name="word_details_title">O słowie</string>
     <string name="word_details_action_stop">Zatrzymaj</string>

--- a/composeApp/src/commonMain/composeResources/values-ru/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-ru/strings.xml
@@ -107,9 +107,9 @@
     <string name="feedback_dialog_title">Отзыв о приложении</string>
     <string name="feedback_dialog_placeholder">Напишите, что вы думаете...</string>
 
-    <string name="app_data_version_mismatch_message">Мы обновили формат словарей. Их нужно скачать заново — ваши
-        сохранённые слова в безопасности.
-    </string>
+    <string name="app_data_version_mismatch_title">Словари нужно обновить</string>
+    <string name="app_data_version_mismatch_body">Мы улучшили формат словарей. Скачайте их заново, чтобы получить новую версию. На это уйдет пара минут при подключении к Wi-Fi. Ваши сохраненные слова и прогресс не пропадут.</string>
+    <string name="app_data_version_mismatch_action">Обновить словари</string>
 
     <string name="word_details_title">О слове</string>
     <string name="word_details_action_stop">Стоп</string>

--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -107,9 +107,9 @@
     <string name="feedback_dialog_title">App feedback</string>
     <string name="feedback_dialog_placeholder">Share your thoughts…</string>
 
-    <string name="app_data_version_mismatch_message">We've updated the dictionary format. You'll need to re-download
-        your dictionaries — your saved words are safe.
-    </string>
+    <string name="app_data_version_mismatch_title">Your dictionaries need a refresh</string>
+    <string name="app_data_version_mismatch_body">We've improved the dictionary format. Re-download to get the latest version—it takes a couple of minutes on Wi-Fi. Your saved words and progress are safe.</string>
+    <string name="app_data_version_mismatch_action">Re-download dictionaries</string>
 
     <string name="word_details_title">Word Details</string>
     <string name="word_details_action_stop">Stop</string>

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/App.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/App.kt
@@ -32,7 +32,9 @@ import com.slovy.slovymovyapp.ui.theme.AppTheme
 import com.slovy.slovymovyapp.ui.word.WordDetailScreen
 import com.slovy.slovymovyapp.ui.word.WordDetailViewModel
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.jsonPrimitive
@@ -394,7 +396,9 @@ fun App(
                             finalize = {
                                 dictionaryRepository.clearSenseCache()
                                 platform.runWithProcessKeepAlive {
-                                    favoriteLemmaRecovery.recoverAllInstalledFavorites()
+                                    withContext(Dispatchers.Default) {
+                                        favoriteLemmaRecovery.recoverAllInstalledFavorites()
+                                    }
                                 }
                                 favoritesViewModel.dropCachedFavoriteDetails()
                             },

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/App.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/App.kt
@@ -38,7 +38,6 @@ import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.jsonPrimitive
 import org.jetbrains.compose.resources.stringResource
 import slovymovyapp.composeapp.generated.resources.Res
-import slovymovyapp.composeapp.generated.resources.app_data_version_mismatch_message
 import slovymovyapp.composeapp.generated.resources.download_title_downloading
 import kotlin.time.Clock
 import kotlin.time.ExperimentalTime
@@ -270,7 +269,6 @@ fun App(
     }
 
     val resolvedStart = startDestination ?: return
-    val dataVersionMismatchMessage = stringResource(Res.string.app_data_version_mismatch_message)
 
     AppTheme {
         NavHost(
@@ -679,17 +677,10 @@ fun App(
                     }
                 )
             }
-            composable<AppDestination.DataVersionMismatch> { backStackEntry ->
+            composable<AppDestination.DataVersionMismatch> {
                 val coroutineScope = rememberCoroutineScope()
-                val viewModel = viewModel(
-                    viewModelStoreOwner = backStackEntry
-                ) {
-                    ErrorViewModel(dataVersionMismatchMessage)
-                }
-
-                ErrorScreen(
-                    viewModel = viewModel,
-                    onOkay = {
+                DataVersionMismatchScreen(
+                    onRedownload = {
                         coroutineScope.launch {
                             dataManager.deleteAllDownloadedData()
                             localDbManager.deleteAll()

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/DataVersionMismatchScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/DataVersionMismatchScreen.kt
@@ -1,0 +1,137 @@
+package com.slovy.slovymovyapp.ui
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Download
+import androidx.compose.material.icons.outlined.MenuBook
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewParameter
+import androidx.compose.ui.unit.dp
+import com.slovy.slovymovyapp.ui.theme.AppSpacing
+import org.jetbrains.compose.resources.stringResource
+import slovymovyapp.composeapp.generated.resources.Res
+import slovymovyapp.composeapp.generated.resources.app_data_version_mismatch_action
+import slovymovyapp.composeapp.generated.resources.app_data_version_mismatch_body
+import slovymovyapp.composeapp.generated.resources.app_data_version_mismatch_title
+
+@Composable
+fun DataVersionMismatchScreen(onRedownload: () -> Unit) {
+    DataVersionMismatchContent(onRedownload = onRedownload)
+}
+
+@Composable
+fun DataVersionMismatchContent(onRedownload: () -> Unit = {}) {
+    Scaffold(
+        containerColor = MaterialTheme.colorScheme.background,
+        bottomBar = {
+            Button(
+                onClick = onRedownload,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = AppSpacing.xl, vertical = AppSpacing.xxl)
+                    .height(56.dp),
+                shape = RoundedCornerShape(28.dp),
+                colors = ButtonDefaults.buttonColors(
+                    containerColor = MaterialTheme.colorScheme.primary
+                )
+            ) {
+                Icon(
+                    imageVector = Icons.Outlined.Download,
+                    contentDescription = null,
+                    modifier = Modifier.size(20.dp)
+                )
+                Spacer(modifier = Modifier.width(AppSpacing.sm))
+                Text(
+                    text = stringResource(Res.string.app_data_version_mismatch_action),
+                    style = MaterialTheme.typography.titleMedium.copy(
+                        fontWeight = FontWeight.SemiBold
+                    )
+                )
+            }
+        }
+    ) { innerPadding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .verticalScroll(rememberScrollState())
+                .padding(innerPadding)
+                .padding(horizontal = AppSpacing.xl),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center
+        ) {
+            Box(
+                modifier = Modifier
+                    .size(120.dp)
+                    .background(
+                        color = MaterialTheme.colorScheme.primaryContainer,
+                        shape = CircleShape
+                    ),
+                contentAlignment = Alignment.Center
+            ) {
+                Icon(
+                    imageVector = Icons.Outlined.MenuBook,
+                    contentDescription = null,
+                    modifier = Modifier.size(48.dp),
+                    tint = MaterialTheme.colorScheme.onPrimaryContainer
+                )
+            }
+
+            Spacer(modifier = Modifier.height(AppSpacing.xxl))
+
+            Text(
+                text = stringResource(Res.string.app_data_version_mismatch_title),
+                style = MaterialTheme.typography.headlineMedium.copy(
+                    fontWeight = FontWeight.Bold
+                ),
+                textAlign = TextAlign.Center,
+                color = MaterialTheme.colorScheme.onBackground
+            )
+
+            Spacer(modifier = Modifier.height(AppSpacing.lg))
+
+            Text(
+                text = stringResource(Res.string.app_data_version_mismatch_body),
+                style = MaterialTheme.typography.bodyMedium,
+                textAlign = TextAlign.Center,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.widthIn(max = 320.dp)
+            )
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun DataVersionMismatchPreview(
+    @PreviewParameter(ThemePreviewProvider::class) isDark: Boolean
+) {
+    ThemedPreview(darkTheme = isDark) {
+        DataVersionMismatchContent()
+    }
+}


### PR DESCRIPTION
## Summary

- Replaces the generic error screen for dictionary version mismatch with a dedicated `DataVersionMismatchScreen` — book icon in a circle, headline, body text, and a full-width bottom CTA button
- Adds localized strings for all 4 locales (EN, RU, NL, PL) using the provided copy; old `app_data_version_mismatch_message` key removed
- Fixes a frozen spinner during the post-download preparation step by moving `recoverAllInstalledFavorites()` to `Dispatchers.Default` inside the `finalize` lambda, keeping `acquireProcessKeepAlive` and mutableState mutations on Main

## Test plan

- [ ] Bump `DataDbManager.VERSION` temporarily to trigger the mismatch screen, verify it renders correctly in light and dark mode
- [ ] Tap "Re-download dictionaries" — verify data is cleared and download flow starts
- [ ] After a fresh download completes, verify the spinner animates during the preparation step
- [ ] Check all 4 locales (EN, RU, NL, PL) render the mismatch screen strings correctly
- [ ] Run `./gradlew :composeApp:verifyLocalizationKeys` — should pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)