### PR TITLE
Polish Stats screen UI and persist language selection

### DIFF
--- a/composeApp/src/commonMain/composeResources/values-nl/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-nl/strings.xml
@@ -37,7 +37,7 @@
     <string name="search_no_results_title">Geen resultaten voor "%1$s"</string>
     <string name="search_no_results_description">Probeer een andere spelling of zoekterm</string>
 
-    <string name="stats_title">Je voortgang</string>
+    <string name="stats_title">Mijn voortgang</string>
     <string name="stats_previous_month">Vorige maand</string>
     <string name="stats_next_month">Volgende maand</string>
     <plurals name="stats_day_streak">
@@ -58,7 +58,7 @@
     </plurals>
     <string name="stats_today_label">vandaag</string>
     <string name="stats_this_week_label">deze week</string>
-    <string name="stats_library_section">Je bibliotheek</string>
+    <string name="stats_library_section">Mijn woordenschat</string>
     <plurals name="stats_words_label">
         <item quantity="one">woord</item>
         <item quantity="few">woorden</item>
@@ -76,8 +76,7 @@
     <string name="stats_stage_middle">Herinneren</string>
     <string name="stats_stage_strong">Stabiel</string>
     <string name="stats_stage_learned">Geleerd</string>
-    <string name="stats_caption_before_learned">Betekenissen schuiven omlaag als je ze bij herhalingen goed blijft onthouden, en weer omhoog als je ze vergeet.</string>
-    <string name="stats_caption_after_learned">is afgerond — uit de actieve herhaling.</string>
+    <string name="stats_caption_learned">Woorden zakken naar beneden in de lijst naarmate je ze bij overhoringen goed blijft onthouden, en schuiven weer omhoog als je ze vergeet. «%1$s» betekent dat ze zijn voltooid — ze doen niet meer mee in de actieve herhaling.</string>
     <string name="stats_month_january">Januari</string>
     <string name="stats_month_february">Februari</string>
     <string name="stats_month_march">Maart</string>

--- a/composeApp/src/commonMain/composeResources/values-pl/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-pl/strings.xml
@@ -38,7 +38,7 @@
     <string name="search_no_results_title">Brak wyników dla „%1$s"</string>
     <string name="search_no_results_description">Sprawdź pisownię lub spróbuj innego słowa.</string>
 
-    <string name="stats_title">Twoje postępy</string>
+    <string name="stats_title">Moje postępy</string>
     <string name="stats_previous_month">Poprzedni miesiąc</string>
     <string name="stats_next_month">Następny miesiąc</string>
     <plurals name="stats_day_streak">
@@ -59,7 +59,7 @@
     </plurals>
     <string name="stats_today_label">dziś</string>
     <string name="stats_this_week_label">w tym tygodniu</string>
-    <string name="stats_library_section">Twoja biblioteka</string>
+    <string name="stats_library_section">Moje słownictwo</string>
     <plurals name="stats_words_label">
         <item quantity="one">słowo</item>
         <item quantity="few">słowa</item>
@@ -77,8 +77,7 @@
     <string name="stats_stage_middle">Średnie</string>
     <string name="stats_stage_strong">Mocne</string>
     <string name="stats_stage_learned">Nauczone</string>
-    <string name="stats_caption_before_learned">Znaczenia przesuwają się w dół listy, gdy dobrze je pamiętasz w powtórkach, i wracają wyżej, gdy je zapominasz.</string>
-    <string name="stats_caption_after_learned">oznacza ukończone — poza aktywnymi powtórkami.</string>
+    <string name="stats_caption_learned">Znaczenia spadają niżej na liście, jeśli bez problemu przypominasz je sobie podczas powtórek, i wracają w górę, gdy je zapomnisz. Status «%1$s» oznacza, że materiał został opanowany i wypada z aktywnego cyklu powtórzeń.</string>
     <string name="stats_month_january">Styczeń</string>
     <string name="stats_month_february">Luty</string>
     <string name="stats_month_march">Marzec</string>    <string name="stats_month_april">Kwiecień</string>

--- a/composeApp/src/commonMain/composeResources/values-ru/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-ru/strings.xml
@@ -37,7 +37,7 @@
     <string name="search_no_results_title">Ничего не нашлось по запросу "%1$s"</string>
     <string name="search_no_results_description">Проверьте написание или попробуйте другое слово.</string>
 
-    <string name="stats_title">Ваш прогресс</string>
+    <string name="stats_title">Мой прогресс</string>
     <string name="stats_previous_month">Предыдущий месяц</string>
     <string name="stats_next_month">Следующий месяц</string>
     <plurals name="stats_day_streak">
@@ -58,7 +58,7 @@
     </plurals>
     <string name="stats_today_label">сегодня</string>
     <string name="stats_this_week_label">за неделю</string>
-    <string name="stats_library_section">Ваша библиотека</string>
+    <string name="stats_library_section">Мой словарь</string>
     <plurals name="stats_words_label">
         <item quantity="one">слово</item>
         <item quantity="few">слова</item>
@@ -76,8 +76,7 @@
     <string name="stats_stage_middle">Средние</string>
     <string name="stats_stage_strong">Сильные</string>
     <string name="stats_stage_learned">Выучены</string>
-    <string name="stats_caption_before_learned">Значения двигаются вниз по списку, когда вы стабильно вспоминаете их на повторах, и поднимаются обратно, когда забываете.</string>
-    <string name="stats_caption_after_learned">значит, что они выпущены из активного повтора.</string>
+    <string name="stats_caption_learned">Значения опускаются ниже по списку, если вы стабильно их вспоминаете, и возвращаются наверх, если вы их забыли. Статус «%1$s» означает, что карточка освоена и исключена из активного цикла повторений.</string>
     <string name="stats_month_january">Январь</string>
     <string name="stats_month_february">Февраль</string>
     <string name="stats_month_march">Март</string>

--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -37,7 +37,7 @@
     <string name="search_no_results_title">No results for "%1$s"</string>
     <string name="search_no_results_description">Try a different spelling or search term?</string>
 
-    <string name="stats_title">Your progress</string>
+    <string name="stats_title">My progress</string>
     <string name="stats_previous_month">Previous month</string>
     <string name="stats_next_month">Next month</string>
     <plurals name="stats_day_streak">
@@ -58,7 +58,7 @@
     </plurals>
     <string name="stats_today_label">today</string>
     <string name="stats_this_week_label">this week</string>
-    <string name="stats_library_section">Your library</string>
+    <string name="stats_library_section">My vocabulary</string>
     <plurals name="stats_words_label">
         <item quantity="one">word</item>
         <item quantity="few">words</item>
@@ -66,18 +66,17 @@
         <item quantity="other">words</item>
     </plurals>
     <plurals name="stats_senses_label">
-        <item quantity="one">sense</item>
-        <item quantity="few">senses</item>
-        <item quantity="many">senses</item>
-        <item quantity="other">senses</item>
+        <item quantity="one">meaning</item>
+        <item quantity="few">meanings</item>
+        <item quantity="many">meanings</item>
+        <item quantity="other">meanings</item>
     </plurals>
     <string name="stats_stage_new">New</string>
     <string name="stats_stage_fresh">Fresh</string>
     <string name="stats_stage_middle">Recalling</string>
     <string name="stats_stage_strong">Solid</string>
     <string name="stats_stage_learned">Learned</string>
-    <string name="stats_caption_before_learned">Senses move down the list as your recall holds up across reviews, and slip back up when you forget.</string>
-    <string name="stats_caption_after_learned">is graduated — out of active rotation.</string>
+    <string name="stats_caption_learned">Meanings move down the list as your recall holds up across reviews, and slip back up when you forget. %1$s means the card is learned and out of active rotation.</string>
     <string name="stats_month_january">January</string>
     <string name="stats_month_february">February</string>
     <string name="stats_month_march">March</string>

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/App.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/App.kt
@@ -675,7 +675,7 @@ fun App(
                 val viewModel = viewModel(
                     viewModelStoreOwner = backStackEntry
                 ) {
-                    StatsViewModel(learningLanguagesForStats, statsService, Clock.System)
+                    StatsViewModel(learningLanguagesForStats, statsService, settingsRepository, Clock.System)
                 }
 
                 StatsScreen(

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/StatsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/StatsScreen.kt
@@ -76,12 +76,15 @@ class StatsViewModel(
 
     private var savedStatsLanguage: Language? = null
     private var savedStatsLanguageLoaded = false
+    private var languageSelectedDuringRestore = false
 
     init {
         viewModelScope.launch {
             val savedCode = settingsRepository.getById(Setting.Name.STATS_LANGUAGE)
                 ?.value?.jsonPrimitive?.contentOrNull
-            savedStatsLanguage = savedCode?.let { Language.fromCodeOrNull(it) }
+            if (!languageSelectedDuringRestore) {
+                savedStatsLanguage = savedCode?.let { Language.fromCodeOrNull(it) }
+            }
             savedStatsLanguageLoaded = true
             val selected = selectedLanguageFor(state.learningLanguages)
             if (selected != state.selectedLanguage) {
@@ -103,6 +106,9 @@ class StatsViewModel(
         if (state.selectedLanguage == language) return
         state = state.copy(selectedLanguage = language, languageDropdownExpanded = false)
         savedStatsLanguage = language
+        if (!savedStatsLanguageLoaded) {
+            languageSelectedDuringRestore = true
+        }
         viewModelScope.launch {
             settingsRepository.insert(Setting(Setting.Name.STATS_LANGUAGE, JsonPrimitive(language.code)))
         }

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/StatsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/StatsScreen.kt
@@ -27,10 +27,15 @@ import com.slovy.slovymovyapp.data.learning.stats.StatsPipelineStageId
 import com.slovy.slovymovyapp.data.learning.stats.StatsPracticeDay
 import com.slovy.slovymovyapp.data.learning.stats.StatsService
 import com.slovy.slovymovyapp.data.learning.stats.StatsYearMonth
+import com.slovy.slovymovyapp.data.settings.Setting
+import com.slovy.slovymovyapp.data.settings.SettingsRepository
 import com.slovy.slovymovyapp.ui.theme.serifFontFamily
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonPrimitive
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toLocalDateTime
@@ -61,6 +66,7 @@ data class StatsUiState(
 class StatsViewModel(
     initialLearningLanguages: List<Language>,
     private val statsService: StatsService,
+    private val settingsRepository: SettingsRepository,
     private val clock: Clock,
 ) : ViewModel() {
     val scrollState = ScrollState(0)
@@ -68,13 +74,26 @@ class StatsViewModel(
     var state by mutableStateOf(initialStatsState(initialLearningLanguages, clock))
         private set
 
+    private var savedStatsLanguage: Language? = null
+    private var savedStatsLanguageLoaded = false
+
     init {
-        scheduleReload()
+        viewModelScope.launch {
+            val savedCode = settingsRepository.getById(Setting.Name.STATS_LANGUAGE)
+                ?.value?.jsonPrimitive?.contentOrNull
+            savedStatsLanguage = savedCode?.let { Language.fromCodeOrNull(it) }
+            savedStatsLanguageLoaded = true
+            val selected = selectedLanguageFor(state.learningLanguages)
+            if (selected != state.selectedLanguage) {
+                state = state.copy(selectedLanguage = selected)
+            }
+            scheduleReload()
+        }
     }
 
     fun updateLearningLanguages(languages: List<Language>) {
         val normalized = languages.ifEmpty { listOf(Language.ENGLISH) }.distinct().sortedBy { it.ordinal }
-        val selected = state.selectedLanguage.takeIf { it in normalized } ?: normalized.first()
+        val selected = selectedLanguageFor(normalized)
         if (normalized == state.learningLanguages && selected == state.selectedLanguage) return
         state = state.copy(learningLanguages = normalized, selectedLanguage = selected)
         scheduleReload()
@@ -83,6 +102,10 @@ class StatsViewModel(
     fun setSelectedLanguage(language: Language) {
         if (state.selectedLanguage == language) return
         state = state.copy(selectedLanguage = language, languageDropdownExpanded = false)
+        savedStatsLanguage = language
+        viewModelScope.launch {
+            settingsRepository.insert(Setting(Setting.Name.STATS_LANGUAGE, JsonPrimitive(language.code)))
+        }
         scheduleReload()
     }
 
@@ -108,6 +131,7 @@ class StatsViewModel(
     }
 
     private fun scheduleReload() {
+        if (!savedStatsLanguageLoaded) return
         val today = currentLocalDate(clock)
         val langCode = state.selectedLanguage.code
         val viewMonth = state.viewMonth
@@ -126,6 +150,15 @@ class StatsViewModel(
                 wordsTotal = data.wordsTotal,
                 pipeline = data.pipeline,
             )
+        }
+    }
+
+    private fun selectedLanguageFor(languages: List<Language>): Language {
+        val saved = savedStatsLanguage
+        return when {
+            saved != null && saved in languages -> saved
+            state.selectedLanguage in languages -> state.selectedLanguage
+            else -> languages.first()
         }
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/StatsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/StatsScreen.kt
@@ -491,14 +491,17 @@ private fun CalendarGrid(state: StatsUiState) {
                 LegendDot(
                     color = MaterialTheme.colorScheme.primary,
                     label = stringResource(Res.string.stats_legend_today),
+                    borderStroke = BorderStroke(0.5.dp, MaterialTheme.colorScheme.outlineVariant),
                 )
                 LegendDot(
                     color = MaterialTheme.colorScheme.primaryContainer,
                     label = stringResource(Res.string.stats_legend_practiced),
+                    borderStroke = BorderStroke(0.5.dp, MaterialTheme.colorScheme.outlineVariant),
                 )
                 LegendDot(
                     color = MaterialTheme.colorScheme.surfaceContainerHighest,
                     label = stringResource(Res.string.stats_legend_missed),
+                    borderStroke = BorderStroke(1.dp, MaterialTheme.colorScheme.outline),
                 )
             }
         }
@@ -539,14 +542,14 @@ private fun CalendarCell(
 
         isFuture -> {
             background = Color.Transparent
-            content = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.45f)
-            weight = FontWeight.Normal
+            content = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.55f)
+            weight = FontWeight.Medium
         }
 
         else -> {
             background = MaterialTheme.colorScheme.surfaceContainerHighest
-            content = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f)
-            weight = FontWeight.Normal
+            content = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.7f)
+            weight = FontWeight.Medium
         }
     }
 
@@ -572,8 +575,8 @@ private fun CalendarCell(
             text = day.toString(),
             style = MaterialTheme.typography.bodySmall.copy(
                 fontFamily = MaterialTheme.serifFontFamily,
-                fontSize = 10.5.sp,
-                lineHeight = 11.sp,
+                fontSize = 12.sp,
+                lineHeight = 12.sp,
                 fontWeight = weight,
             ),
             color = content,
@@ -582,25 +585,29 @@ private fun CalendarCell(
 }
 
 @Composable
-private fun LegendDot(color: Color, label: String) {
+private fun LegendDot(color: Color, label: String, borderStroke: BorderStroke) {
+    val shape = RoundedCornerShape(3.dp)
     Row(
         horizontalArrangement = Arrangement.spacedBy(5.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {
         Box(
             modifier = Modifier
-                .size(9.dp)
-                .clip(RoundedCornerShape(3.dp))
+                .size(11.dp)
+                .clip(shape)
                 .background(color)
                 .border(
-                    BorderStroke(0.5.dp, MaterialTheme.colorScheme.outlineVariant),
-                    RoundedCornerShape(3.dp),
+                    borderStroke,
+                    shape,
                 ),
         )
         Text(
             text = label,
-            style = MaterialTheme.typography.bodySmall.copy(fontSize = 10.sp),
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            style = MaterialTheme.typography.bodySmall.copy(
+                fontSize = 12.sp,
+                fontWeight = FontWeight.Medium,
+            ),
+            color = MaterialTheme.colorScheme.onSurface,
         )
     }
 }
@@ -790,9 +797,14 @@ private fun PipelineBars(pipeline: List<StatsPipelineStage>) {
 @Composable
 private fun PipelineCaption() {
     val learned = stringResource(Res.string.stats_stage_learned)
+    val captionText = stringResource(Res.string.stats_caption_learned, learned)
+    val learnedStart = captionText.indexOf(learned)
     val caption = buildAnnotatedString {
-        append(stringResource(Res.string.stats_caption_before_learned))
-        append(" ")
+        if (learnedStart == -1) {
+            append(captionText)
+            return@buildAnnotatedString
+        }
+        append(captionText.substring(0, learnedStart))
         withStyle(
             SpanStyle(
                 color = MaterialTheme.colorScheme.onSurface,
@@ -802,8 +814,7 @@ private fun PipelineCaption() {
         ) {
             append(learned)
         }
-        append(" ")
-        append(stringResource(Res.string.stats_caption_after_learned))
+        append(captionText.substring(learnedStart + learned.length))
     }
     Text(
         text = caption,

--- a/shared/src/commonMain/kotlin/com/slovy/slovymovyapp/data/settings/Setting.kt
+++ b/shared/src/commonMain/kotlin/com/slovy/slovymovyapp/data/settings/Setting.kt
@@ -19,6 +19,7 @@ data class Setting(
         ENABLED_VOICES,
         VOICE_SETUP_SHOWN,
         SEARCH_LANGUAGE,
-        FAVORITES_LANGUAGE
+        FAVORITES_LANGUAGE,
+        STATS_LANGUAGE
     }
 }


### PR DESCRIPTION
## Summary
- update Stats screen copy and localization for progress/vocabulary and learned-stage caption
- improve calendar readability and legend styling
- persist the selected Stats language across navigation and app restarts

## Validation
- ./gradlew :composeApp:verifyLocalizationKeys
- ./gradlew :composeApp:compileKotlinDesktop