### PR TITLE
Dictionary: Ignore numeric form notes during ingestion

### DIFF
--- a/server/src/test/kotlin/com/slovy/slovymovyapp/builder/IgnoredFormNotesIngestionTest.kt
+++ b/server/src/test/kotlin/com/slovy/slovymovyapp/builder/IgnoredFormNotesIngestionTest.kt
@@ -1,0 +1,91 @@
+@file:OptIn(kotlin.uuid.ExperimentalUuidApi::class)
+
+package com.slovy.slovymovyapp.builder
+
+import com.slovy.slovymovyapp.data.dictionary.DictionaryPos
+import com.slovy.slovymovyapp.ingestion.JsonIngestionBuilder
+import java.nio.file.Files
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class IgnoredFormNotesIngestionTest {
+
+    @Test
+    fun raw_only_ignores_numeric_forms_marked_by_note() {
+        val outDir = Files.createTempDirectory("ignored_form_notes_test").toFile()
+        val serverDbManager = ServerDbManager(outDir)
+
+        val lang = "nl"
+        val word = "honderdzeventig"
+        val rawJson = """
+            {
+              "word": "$word",
+              "lang_code": "$lang",
+              "source_file_to_entries": {
+                "nl-extract.jsonl": [
+                  {
+                    "entry_id": "11111111-1111-1111-1111-111111111111",
+                    "word": "$word",
+                    "pos": "num",
+                    "lang_code": "$lang",
+                    "forms": [
+                      {
+                        "form_id": "22222222-2222-2222-2222-222222222222",
+                        "entry_id": "11111111-1111-1111-1111-111111111111",
+                        "tags": [],
+                        "form": "10101010",
+                        "note": "binair"
+                      },
+                      {
+                        "form_id": "33333333-3333-3333-3333-333333333333",
+                        "entry_id": "11111111-1111-1111-1111-111111111111",
+                        "tags": [],
+                        "form": "AA",
+                        "note": "hexadecimaal"
+                      },
+                      {
+                        "form_id": "44444444-4444-4444-4444-444444444444",
+                        "entry_id": "11111111-1111-1111-1111-111111111111",
+                        "tags": [],
+                        "form": "CLXX",
+                        "note": "Romeins"
+                      }
+                    ],
+                    "senses": [
+                      {
+                        "sense_id": "55555555-5555-5555-5555-555555555555",
+                        "entry_id": "11111111-1111-1111-1111-111111111111",
+                        "glosses": ["hundred seventy"],
+                        "tags": [],
+                        "examples": [],
+                        "sense_index_json": null
+                      }
+                    ],
+                    "translations": [],
+                    "word_linkages": []
+                  }
+                ]
+              }
+            }
+        """.trimIndent()
+
+        val builder = JsonIngestionBuilder(
+            translationDbProvider = { from, to -> serverDbManager.openTranslation(from, to) },
+            frequencyMap = mapOf(word to 3.0)
+        )
+
+        val dictDb = serverDbManager.openDictionary(lang)
+        val dictQ = dictDb.dictionaryQueries
+
+        builder.ingestRawOnly(rawJson, dictDb)
+
+        val lemmaId = JsonIngestionBuilder.generateLemmaId(word)
+        val lemmaPosEntries = dictQ.selectLemmaPosByLemmaId(lemmaId).executeAsList()
+        assertEquals(1, lemmaPosEntries.size, "Expected one POS entry for '$word'")
+        assertEquals(DictionaryPos.NUMERAL, lemmaPosEntries.first().pos, "Expected NUMERAL POS for '$word'")
+
+        val forms = dictQ.selectFormsByLemmaPosId(lemmaPosEntries.first().id).executeAsList()
+        assertTrue(forms.isEmpty(), "Expected numeric forms marked as binary, hexadecimal, or Roman to be ignored")
+    }
+}

--- a/server/src/test/kotlin/com/slovy/slovymovyapp/builder/IgnoredFormNotesIngestionTest.kt
+++ b/server/src/test/kotlin/com/slovy/slovymovyapp/builder/IgnoredFormNotesIngestionTest.kt
@@ -4,6 +4,7 @@ package com.slovy.slovymovyapp.builder
 
 import com.slovy.slovymovyapp.data.dictionary.DictionaryPos
 import com.slovy.slovymovyapp.ingestion.JsonIngestionBuilder
+import com.slovy.slovymovyapp.ingestion.uuidParse
 import java.nio.file.Files
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -88,4 +89,135 @@ class IgnoredFormNotesIngestionTest {
         val forms = dictQ.selectFormsByLemmaPosId(lemmaPosEntries.first().id).executeAsList()
         assertTrue(forms.isEmpty(), "Expected numeric forms marked as binary, hexadecimal, or Roman to be ignored")
     }
+
+    @Test
+    fun primary_cluster_counts_only_ingestible_forms() {
+        val outDir = Files.createTempDirectory("ignored_form_notes_primary_test").toFile()
+        val serverDbManager = ServerDbManager(outDir)
+
+        val lang = "nl"
+        val word = "primaircluster"
+        val rawJson = """
+            {
+              "word": "$word",
+              "lang_code": "$lang",
+              "source_file_to_entries": {
+                "nl-extract.jsonl": [
+                  {
+                    "entry_id": "11111111-1111-1111-1111-111111111111",
+                    "word": "$word",
+                    "pos": "num",
+                    "lang_code": "$lang",
+                    "forms": [
+                      {
+                        "form_id": "22222222-2222-2222-2222-222222222222",
+                        "entry_id": "11111111-1111-1111-1111-111111111111",
+                        "tags": [],
+                        "form": "primary-one"
+                      },
+                      {
+                        "form_id": "33333333-3333-3333-3333-333333333333",
+                        "entry_id": "11111111-1111-1111-1111-111111111111",
+                        "tags": [],
+                        "form": "10101010",
+                        "note": "binair"
+                      },
+                      {
+                        "form_id": "44444444-4444-4444-4444-444444444444",
+                        "entry_id": "11111111-1111-1111-1111-111111111111",
+                        "tags": [],
+                        "form": "AA",
+                        "note": "hexadecimaal"
+                      },
+                      {
+                        "form_id": "55555555-5555-5555-5555-555555555555",
+                        "entry_id": "11111111-1111-1111-1111-111111111111",
+                        "tags": [],
+                        "form": "CLXX",
+                        "note": "Romeins"
+                      }
+                    ],
+                    "senses": [],
+                    "translations": [],
+                    "word_linkages": []
+                  },
+                  {
+                    "entry_id": "66666666-6666-6666-6666-666666666666",
+                    "word": "$word",
+                    "pos": "num",
+                    "lang_code": "$lang",
+                    "forms": [
+                      {
+                        "form_id": "77777777-7777-7777-7777-777777777777",
+                        "entry_id": "66666666-6666-6666-6666-666666666666",
+                        "tags": [],
+                        "form": "primary-two"
+                      },
+                      {
+                        "form_id": "88888888-8888-8888-8888-888888888888",
+                        "entry_id": "66666666-6666-6666-6666-666666666666",
+                        "tags": [],
+                        "form": "primary-two-alt"
+                      }
+                    ],
+                    "senses": [],
+                    "translations": [],
+                    "word_linkages": []
+                  }
+                ]
+              }
+            }
+        """.trimIndent()
+        val processedJson = """
+            {
+              "entries": [
+                {
+                  "pos": "num",
+                  "senses": [
+                    {
+                      "sense_id": "99999999-9999-9999-9999-999999999999",
+                      "sense_definition": "fallback sense",
+                      "learner_level": "A1",
+                      "frequency": "HIGH",
+                      "semantic_group_id": "number",
+                      "examples": [],
+                      "synonyms": [],
+                      "antonyms": [],
+                      "common_phrases": [],
+                      "traits": [],
+                      "target_lang_definitions": {},
+                      "translations": {}
+                    }
+                  ]
+                }
+              ]
+            }
+        """.trimIndent()
+
+        val builder = JsonIngestionBuilder(
+            translationDbProvider = { from, to -> serverDbManager.openTranslation(from, to) },
+            frequencyMap = mapOf(word to 3.0)
+        )
+
+        val dictDb = serverDbManager.openDictionary(lang)
+        val dictQ = dictDb.dictionaryQueries
+
+        builder.ingest(processedJson, rawJson, dictDb)
+
+        val lemmaId = JsonIngestionBuilder.generateLemmaId(word)
+        val lemmaPosEntries = dictQ.selectLemmaPosByLemmaId(lemmaId).executeAsList()
+        assertEquals(2, lemmaPosEntries.size, "Expected two NUMERAL clusters for '$word'")
+
+        val expectedPrimaryLemmaPosId = lemmaPosEntries.firstOrNull { lemmaPos ->
+            dictQ.selectFormsWithIdByLemmaPosId(lemmaPos.id).executeAsList().any { it.form == "primary-two" }
+        }?.id ?: error("Expected to find the cluster with two ingestible forms")
+
+        val fallbackSenseId = uuidParse("99999999-9999-9999-9999-999999999999")
+        val sensesInExpectedPrimary = dictQ.selectSensesByLemmaPosId(expectedPrimaryLemmaPosId).executeAsList()
+        assertTrue(
+            sensesInExpectedPrimary.any { it.sense_id == fallbackSenseId },
+            "Expected fallback sense to route to the cluster with the most ingestible forms"
+        )
+    }
+
 }

--- a/shared/src/commonMain/kotlin/com/slovy/slovymovyapp/ingestion/JsonIngestionBuilder.kt
+++ b/shared/src/commonMain/kotlin/com/slovy/slovymovyapp/ingestion/JsonIngestionBuilder.kt
@@ -258,6 +258,14 @@ class JsonIngestionBuilder(
         val source: FormSource
     )
 
+    private val ignoredFormNotes = setOf("binair", "hexadecimaal", "romeins")
+
+    private fun shouldIgnoreForm(form: ExtractedWordForm): Boolean =
+        form.note?.trim()?.lowercase() in ignoredFormNotes
+
+    private fun ingestibleForms(entry: ExtractedWordEntry): List<ExtractedWordForm> =
+        entry.forms.filterNot(::shouldIgnoreForm)
+
     private fun selectEntries(raw: ExtractedWordData): EntriesSelection {
         val nativeKey = LANG_TO_SOURCE_FILE[raw.langCode]!!
         val enWiktionarySourceKey = LANG_TO_SOURCE_FILE[Language.ENGLISH.code]!!
@@ -316,8 +324,12 @@ class JsonIngestionBuilder(
             .mapKeys { it.key!! }
 
         byPos.forEach { (pos, entriesForPos) ->
-            val nativeWithForms = entriesForPos.filter { it.sourceFile == nativeSource && it.entry.forms.isNotEmpty() }
-            val nativeNoForms = entriesForPos.filter { it.sourceFile == nativeSource && it.entry.forms.isEmpty() }
+            val nativeWithForms = entriesForPos.filter {
+                it.sourceFile == nativeSource && ingestibleForms(it.entry).isNotEmpty()
+            }
+            val nativeNoForms = entriesForPos.filter {
+                it.sourceFile == nativeSource && ingestibleForms(it.entry).isEmpty()
+            }
             val nonNativeEntries = entriesForPos.filter { it.sourceFile != nativeSource }
 
             // All native entries with forms are active roots (raw data alone determines clustering)
@@ -326,11 +338,11 @@ class JsonIngestionBuilder(
             // Use raw form texts (not accent-stripped) so entries with different stress markers
             // (e.g., Dutch vóórkomen vs voorkómen) are correctly kept as separate clusters.
             val activeRoots: List<ExtractedWordEntry> = activeRootCandidates
-                .groupBy { entry -> entry.forms.map { it.form }.toSet() }
+                .groupBy { entry -> ingestibleForms(entry).map { it.form }.toSet() }
                 .values
                 .map { group ->
                     group.sortedWith(
-                        compareByDescending<ExtractedWordEntry> { it.forms.size }
+                        compareByDescending<ExtractedWordEntry> { ingestibleForms(it).size }
                             .thenBy { it.entryId.toString() }
                     ).first()
                 }
@@ -401,7 +413,7 @@ class JsonIngestionBuilder(
     }
 
     private fun formSet(entry: ExtractedWordEntry): Set<String> =
-        entry.forms.map { stripAccents(it.form) }.toSet()
+        ingestibleForms(entry).map { stripAccents(it.form) }.toSet()
 
     private fun jaccardSimilarity(a: Set<String>, b: Set<String>): Double {
         if (a.isEmpty() && b.isEmpty()) return 1.0
@@ -889,7 +901,7 @@ class JsonIngestionBuilder(
             val lemmaPosId = entryIdToLemmaPosId[entryId] ?: return@forEach
 
             val formsMap = lemmaPosIdToForms.getOrPut(lemmaPosId) { mutableMapOf() }
-            entry.forms.forEach { f ->
+            ingestibleForms(entry).forEach { f ->
                 val key = FormKey(f.form, stripAccents(f.form), f.tags.toSet(), source)
                 if (!formsMap.containsKey(key)) {
                     formsMap[key] = Pair(f, source)

--- a/shared/src/commonMain/kotlin/com/slovy/slovymovyapp/ingestion/JsonIngestionBuilder.kt
+++ b/shared/src/commonMain/kotlin/com/slovy/slovymovyapp/ingestion/JsonIngestionBuilder.kt
@@ -364,9 +364,9 @@ class JsonIngestionBuilder(
                     entryIdToLemmaPosId[uuidParse(e.entry.entryId.toString())] = lemmaPosId
                 }
             } else {
-                // Primary cluster = root with most forms; tie-break: alphabetically first entryId
+                // Primary cluster = root with most ingestible forms; tie-break: alphabetically first entryId
                 val primaryRoot = activeRoots.sortedWith(
-                    compareByDescending<ExtractedWordEntry> { it.forms.size }
+                    compareByDescending<ExtractedWordEntry> { ingestibleForms(it).size }
                         .thenBy { it.entryId.toString() }
                 ).first()
                 val primaryLemmaPosId = uuidParse(primaryRoot.entryId.toString())


### PR DESCRIPTION
### Motivation
- Prevent raw forms that represent numeric encodings (binary/hexadecimal/Roman) from affecting lemma clustering or being persisted as regular forms when ingesting extracted data.

### Description
- Add a normalized ignore list `ignoredFormNotes` and helper functions `shouldIgnoreForm` and `ingestibleForms` in `JsonIngestionBuilder` to filter forms by `note` values (`binair`, `hexadecimaal`, `romeins`).
- Apply the filtered form set to clustering and matching logic by using `ingestibleForms` in `collectLemmaPosMapping`, `formSet`, and when building `lemmaPosIdToForms` so ignored forms do not change clusters or get inserted.
- Add a regression test `IgnoredFormNotesIngestionTest` that ingests a Dutch numeric example (`honderdzeventig`) with `binair`/`hexadecimaal`/`Romeins` notes and asserts those forms are ignored while the POS is still created.

### Testing
- Ran `./gradlew :server:test --tests com.slovy.slovymovyapp.builder.IgnoredFormNotesIngestionTest` and the test passed (build successful).
- Ran `./gradlew :server:test --tests com.slovy.slovymovyapp.builder.FormDeduplicationTest --tests com.slovy.slovymovyapp.builder.FormsMappingByPosTest` and existing ingestion-related tests passed (build successful).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a05c5cb6ca48324bdba09f126bb807a)