### PR TITLE
Add favorite recovery controller and progress reporting for download finalization

### DIFF
--- a/composeApp/src/commonMain/composeResources/values-nl/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-nl/strings.xml
@@ -124,6 +124,7 @@
     <string name="download_subtitle_setting_up">Je bibliotheek wordt voorbereid.\nDit duurt even.</string>
     <string name="download_content_desc_loading_info">Downloadinformatie laden</string>
     <string name="download_content_desc_preparing">Download voorbereiden</string>
+    <string name="download_finalizing_recovering_progress">Favorieten bijwerken (%1$d/%2$d)</string>
     <string name="download_preparing">Voorbereiden...</string>
     <string name="download_item_accessibility">%1$s, %2$s</string>
     <string name="download_progress_with_percent">Downloaden, %1$d procent voltooid</string>

--- a/composeApp/src/commonMain/composeResources/values-nl/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-nl/strings.xml
@@ -125,6 +125,12 @@
     <string name="download_content_desc_loading_info">Downloadinformatie laden</string>
     <string name="download_content_desc_preparing">Download voorbereiden</string>
     <string name="download_finalizing_recovering_progress">Favorieten bijwerken (%1$d/%2$d)</string>
+    <plurals name="download_finalizing_recovering_progress_with_failures">
+        <item quantity="one">Favorieten bijwerken (%1$d/%2$d, %3$d mislukt)</item>
+        <item quantity="few">Favorieten bijwerken (%1$d/%2$d, %3$d mislukt)</item>
+        <item quantity="many">Favorieten bijwerken (%1$d/%2$d, %3$d mislukt)</item>
+        <item quantity="other">Favorieten bijwerken (%1$d/%2$d, %3$d mislukt)</item>
+    </plurals>
     <string name="download_preparing">Voorbereiden...</string>
     <string name="download_item_accessibility">%1$s, %2$s</string>
     <string name="download_progress_with_percent">Downloaden, %1$d procent voltooid</string>

--- a/composeApp/src/commonMain/composeResources/values-pl/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-pl/strings.xml
@@ -124,6 +124,7 @@
     <string name="download_subtitle_setting_up">Przygotowujemy Twoją bibliotekę.\nTo potrwa tylko chwilę.</string>
     <string name="download_content_desc_loading_info">Ładowanie informacji o pobieraniu</string>
     <string name="download_content_desc_preparing">Przygotowywanie pobierania</string>
+    <string name="download_finalizing_recovering_progress">Odświeżanie ulubionych (%1$d/%2$d)</string>
     <string name="download_preparing">Przygotowywanie...</string>
     <string name="download_item_accessibility">%1$s, %2$s</string>
     <string name="download_progress_with_percent">Pobieranie: %1$d%%</string>

--- a/composeApp/src/commonMain/composeResources/values-pl/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-pl/strings.xml
@@ -125,6 +125,12 @@
     <string name="download_content_desc_loading_info">Ładowanie informacji o pobieraniu</string>
     <string name="download_content_desc_preparing">Przygotowywanie pobierania</string>
     <string name="download_finalizing_recovering_progress">Odświeżanie ulubionych (%1$d/%2$d)</string>
+    <plurals name="download_finalizing_recovering_progress_with_failures">
+        <item quantity="one">Odświeżanie ulubionych (%1$d/%2$d, błędów: %3$d)</item>
+        <item quantity="few">Odświeżanie ulubionych (%1$d/%2$d, błędów: %3$d)</item>
+        <item quantity="many">Odświeżanie ulubionych (%1$d/%2$d, błędów: %3$d)</item>
+        <item quantity="other">Odświeżanie ulubionych (%1$d/%2$d, błędów: %3$d)</item>
+    </plurals>
     <string name="download_preparing">Przygotowywanie...</string>
     <string name="download_item_accessibility">%1$s, %2$s</string>
     <string name="download_progress_with_percent">Pobieranie: %1$d%%</string>

--- a/composeApp/src/commonMain/composeResources/values-ru/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-ru/strings.xml
@@ -124,6 +124,7 @@
     <string name="download_subtitle_setting_up">Готовим вашу библиотеку.\nЭто займёт пару минут.</string>
     <string name="download_content_desc_loading_info">Получение данных...</string>
     <string name="download_content_desc_preparing">Подготовка к скачиванию</string>
+    <string name="download_finalizing_recovering_progress">Обновление избранного (%1$d/%2$d)</string>
     <string name="download_preparing">Подготовка...</string>
     <string name="download_item_accessibility">%1$s, %2$s</string>
     <string name="download_progress_with_percent">Скачивание: %1$d процентов</string>

--- a/composeApp/src/commonMain/composeResources/values-ru/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-ru/strings.xml
@@ -125,6 +125,12 @@
     <string name="download_content_desc_loading_info">Получение данных...</string>
     <string name="download_content_desc_preparing">Подготовка к скачиванию</string>
     <string name="download_finalizing_recovering_progress">Обновление избранного (%1$d/%2$d)</string>
+    <plurals name="download_finalizing_recovering_progress_with_failures">
+        <item quantity="one">Обновление избранного (%1$d/%2$d, ошибок: %3$d)</item>
+        <item quantity="few">Обновление избранного (%1$d/%2$d, ошибок: %3$d)</item>
+        <item quantity="many">Обновление избранного (%1$d/%2$d, ошибок: %3$d)</item>
+        <item quantity="other">Обновление избранного (%1$d/%2$d, ошибок: %3$d)</item>
+    </plurals>
     <string name="download_preparing">Подготовка...</string>
     <string name="download_item_accessibility">%1$s, %2$s</string>
     <string name="download_progress_with_percent">Скачивание: %1$d процентов</string>

--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -125,6 +125,12 @@
     <string name="download_content_desc_loading_info">Loading download information</string>
     <string name="download_content_desc_preparing">Preparing download</string>
     <string name="download_finalizing_recovering_progress">Refreshing favorites (%1$d/%2$d)</string>
+    <plurals name="download_finalizing_recovering_progress_with_failures">
+        <item quantity="one">Refreshing favorites (%1$d/%2$d, %3$d failed)</item>
+        <item quantity="few">Refreshing favorites (%1$d/%2$d, %3$d failed)</item>
+        <item quantity="many">Refreshing favorites (%1$d/%2$d, %3$d failed)</item>
+        <item quantity="other">Refreshing favorites (%1$d/%2$d, %3$d failed)</item>
+    </plurals>
     <string name="download_preparing">Preparing...</string>
     <string name="download_item_accessibility">%1$s, %2$s</string>
     <string name="download_progress_with_percent">Downloading, %1$d percent complete</string>

--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -124,6 +124,7 @@
     <string name="download_subtitle_setting_up">Getting your library ready.\nWill take a moment.</string>
     <string name="download_content_desc_loading_info">Loading download information</string>
     <string name="download_content_desc_preparing">Preparing download</string>
+    <string name="download_finalizing_recovering_progress">Refreshing favorites (%1$d/%2$d)</string>
     <string name="download_preparing">Preparing...</string>
     <string name="download_item_accessibility">%1$s, %2$s</string>
     <string name="download_progress_with_percent">Downloading, %1$d percent complete</string>

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/App.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/App.kt
@@ -37,6 +37,7 @@ import com.slovy.slovymovyapp.ui.theme.AppTheme
 import com.slovy.slovymovyapp.ui.word.WordDetailScreen
 import com.slovy.slovymovyapp.ui.word.WordDetailViewModel
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
@@ -273,6 +274,9 @@ fun App(
     val favoriteLemmaRecovery = remember(favoritesRepository, dataManager, dictionaryRepository, wordFetchManager) {
         FavoriteLemmaRecovery(favoritesRepository, dataManager, dictionaryRepository, wordFetchManager)
     }
+    val favoriteRecoveryController = remember(favoriteLemmaRecovery, platform) {
+        FavoriteRecoveryController(favoriteLemmaRecovery, platform)
+    }
     val fsrsConfig = remember { FsrsDefaults.config() }
     val fsrsScheduler = remember(fsrsConfig) {
         FsrsScheduler(
@@ -316,7 +320,7 @@ fun App(
     val navBackStackEntry by navController.currentBackStackEntryAsState()
     var startDestination by remember { mutableStateOf<AppDestination?>(null) }
     val wordDetailViewModels = remember { linkedMapOf<AppDestination.WordDetail, WordDetailViewModel>() }
-    val coroutineScope = rememberCoroutineScope()
+    val appCoroutineScope = rememberCoroutineScope()
     var hasFavoritesToReview by remember { mutableStateOf(false) }
     val favoritesReviewCoordinator = remember { FavoritesReviewCoordinator() }
 
@@ -367,9 +371,7 @@ fun App(
                     favoritesReviewCoordinator.invalidateAllIntakeCache()
                     dictionaryRepository.clearSenseCache()
                     if (recoverFavorites) {
-                        platform.runWithProcessKeepAlive {
-                            favoriteLemmaRecovery.recoverAllInstalledFavorites()
-                        }
+                        favoriteRecoveryController.ensureStarted()
                     }
                     favoritesViewModel.dropCachedFavoriteDetails()
                 },
@@ -503,7 +505,7 @@ fun App(
                 WelcomeScreen(
                     viewModel = viewModel,
                     onGetStarted = {
-                        coroutineScope.launch {
+                        appCoroutineScope.launch {
                             try {
                                 settingsRepository.insert(
                                     Setting(
@@ -536,7 +538,7 @@ fun App(
                 LanguageSetupScreen(
                     viewModel = viewModel,
                     onNext = { learning, native ->
-                        coroutineScope.launch {
+                        appCoroutineScope.launch {
                             settingsRepository.insert(
                                 Setting(
                                     id = Setting.Name.LANGUAGE,
@@ -609,12 +611,22 @@ fun App(
                                     )
                                 }
                             },
-                            finalize = {
+                            finalize = { downloadViewModel ->
                                 favoritesReviewCoordinator.invalidateAllIntakeCache()
                                 dictionaryRepository.clearSenseCache()
-                                platform.runWithProcessKeepAlive {
-                                    withContext(Dispatchers.Default) {
-                                        favoriteLemmaRecovery.recoverAllInstalledFavorites()
+                                val recoveryJob = favoriteRecoveryController.ensureStarted()
+                                coroutineScope {
+                                    val observerJob = launch {
+                                        favoriteRecoveryController.progress.collect { progress ->
+                                            if (progress != null) {
+                                                downloadViewModel.updateRecoveryProgress(progress)
+                                            }
+                                        }
+                                    }
+                                    try {
+                                        recoveryJob.join()
+                                    } finally {
+                                        observerJob.cancel()
                                     }
                                 }
                                 favoritesViewModel.dropCachedFavoriteDetails()
@@ -785,7 +797,7 @@ fun App(
                         navController.navigate(AppDestination.StudySession(language.code))
                     },
                     onContinueStudyingNow = { language, action ->
-                        coroutineScope.launch {
+                        appCoroutineScope.launch {
                             val shouldStartStudy = when (action) {
                                 FavoritesStudyDoneAction.REVIEW_MORE -> {
                                     sessionService.continueDelayedCardsNow(language.code)
@@ -808,10 +820,10 @@ fun App(
                         // nav effects don't refire. remove() and undo's add() already update
                         // card.suspended in-DB, so a stats-only refresh shows correct counts
                         // without paying for intake on the dictionary-DB driver.
-                        coroutineScope.launch { refreshFavoritesDueCountsOnly() }
+                        appCoroutineScope.launch { refreshFavoritesDueCountsOnly() }
                     },
                     onRefreshReviewState = {
-                        coroutineScope.launch { refreshFavoritesDueCountsOnly() }
+                        appCoroutineScope.launch { refreshFavoritesDueCountsOnly() }
                     },
                 )
             }
@@ -866,7 +878,7 @@ fun App(
                             // A submitted review can push the card past today; refresh the
                             // bottom-nav dot from stats. No intake needed — review changes
                             // hit `card.due_at` directly.
-                            coroutineScope.launch { refreshFavoritesDueCountsOnly() }
+                            appCoroutineScope.launch { refreshFavoritesDueCountsOnly() }
                         },
                     )
                 }
@@ -952,7 +964,7 @@ fun App(
                             // Add creates a pending favorite with no SR cards yet — the dot
                             // catches up when the user navigates back and the delayed intake
                             // effect runs intake for this language.
-                            coroutineScope.launch { refreshFavoritesDueCountsOnly() }
+                            appCoroutineScope.launch { refreshFavoritesDueCountsOnly() }
                         },
                     ).also { created ->
                         wordDetailViewModels[args] = created

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/App.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/App.kt
@@ -37,8 +37,8 @@ import com.slovy.slovymovyapp.ui.theme.AppTheme
 import com.slovy.slovymovyapp.ui.word.WordDetailScreen
 import com.slovy.slovymovyapp.ui.word.WordDetailViewModel
 import kotlinx.coroutines.CancellationException
-import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
@@ -276,6 +276,9 @@ fun App(
     }
     val favoriteRecoveryController = remember(favoriteLemmaRecovery, platform) {
         FavoriteRecoveryController(favoriteLemmaRecovery, platform)
+    }
+    DisposableEffect(favoriteRecoveryController) {
+        onDispose { favoriteRecoveryController.close() }
     }
     val fsrsConfig = remember { FsrsDefaults.config() }
     val fsrsScheduler = remember(fsrsConfig) {
@@ -611,7 +614,7 @@ fun App(
                                     )
                                 }
                             },
-                            finalize = { downloadViewModel ->
+                            finalize = { onRecoveryProgress ->
                                 favoritesReviewCoordinator.invalidateAllIntakeCache()
                                 dictionaryRepository.clearSenseCache()
                                 val recoveryJob = favoriteRecoveryController.ensureStarted()
@@ -619,7 +622,7 @@ fun App(
                                     val observerJob = launch {
                                         favoriteRecoveryController.progress.collect { progress ->
                                             if (progress != null) {
-                                                downloadViewModel.updateRecoveryProgress(progress)
+                                                onRecoveryProgress(progress)
                                             }
                                         }
                                     }

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/data/remote/FavoriteLemmaRecovery.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/data/remote/FavoriteLemmaRecovery.kt
@@ -82,28 +82,29 @@ class FavoriteLemmaRecovery internal constructor(
         val progressMutex = Mutex()
         var completed = 0
         var failed = 0
+        val activeLemmas = linkedMapOf<FavoriteLemmaGroupKey, String>()
 
-        suspend fun emit(currentLemma: String?, deltaFailed: Int = 0) = progressMutex.withLock {
-            if (deltaFailed > 0) failed += deltaFailed
-            onProgress(FavoriteRecoveryProgress(currentLemma, completed, total, failed))
+        suspend fun markStarted(key: FavoriteLemmaGroupKey, lemma: String) = progressMutex.withLock {
+            activeLemmas[key] = lemma
+            onProgress(FavoriteRecoveryProgress(activeLemmas.values.firstOrNull(), completed, total, failed))
         }
 
-        suspend fun markDone(deltaFailed: Int) = progressMutex.withLock {
+        suspend fun markDone(key: FavoriteLemmaGroupKey, deltaFailed: Int) = progressMutex.withLock {
             completed++
             if (deltaFailed > 0) failed += deltaFailed
-            onProgress(FavoriteRecoveryProgress(currentLemma = null, completed, total, failed))
+            activeLemmas.remove(key)
+            onProgress(FavoriteRecoveryProgress(activeLemmas.values.firstOrNull(), completed, total, failed))
         }
 
-        emit(currentLemma = null)
         val semaphore = Semaphore(MAX_PARALLEL_RECOVERY_GROUPS)
 
         groupsToRecover.map { (key, groupFavorites) ->
             async {
                 semaphore.withPermit {
                     var failedGroup = false
-                    val lemma = groupFavorites.firstOrNull()?.lemma
+                    val lemma = groupFavorites.first().lemma.trim()
                     try {
-                        emit(currentLemma = lemma)
+                        markStarted(key, lemma)
                         recoverLemmaGroup(key.language, groupFavorites)
                     } catch (e: CancellationException) {
                         throw e
@@ -116,7 +117,7 @@ class FavoriteLemmaRecovery internal constructor(
                         )
                         // Best-effort recovery: broken or unavailable remote fetches must not block downloads.
                     } finally {
-                        markDone(deltaFailed = if (failedGroup) 1 else 0)
+                        markDone(key, deltaFailed = if (failedGroup) 1 else 0)
                     }
                 }
             }

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/data/remote/FavoriteLemmaRecovery.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/data/remote/FavoriteLemmaRecovery.kt
@@ -6,8 +6,11 @@ import com.slovy.slovymovyapp.data.favorites.FavoritesRepository
 import com.slovy.slovymovyapp.logging.AppLogger
 import kotlinx.coroutines.*
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.Semaphore
+import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.sync.withPermit
+import kotlin.time.Duration.Companion.seconds
 
 class FavoriteLemmaRecovery internal constructor(
     private val favoritesProvider: suspend () -> List<Favorite>,
@@ -34,7 +37,7 @@ class FavoriteLemmaRecovery internal constructor(
         },
         translationTargetsProvider = { language -> dictionaryRepository.defaultTranslationTargets(language) },
         fetchLemma = { language, lemma, translationTargets ->
-            wordFetchManager.getWord(
+            val terminal = wordFetchManager.getWord(
                 language = language,
                 lemma = lemma,
                 translationTargets = translationTargets,
@@ -42,12 +45,20 @@ class FavoriteLemmaRecovery internal constructor(
             ).first { result ->
                 !result.isWordLoading && !result.isTranslationLoading
             }
+            terminal.error?.let { err ->
+                if (err is DictionaryClientException.CancelledException) {
+                    throw CancellationException(err.message)
+                }
+                throw err
+            }
         },
     )
 
-    suspend fun recoverAllInstalledFavorites() {
+    suspend fun recoverAllInstalledFavorites(
+        onProgress: (FavoriteRecoveryProgress) -> Unit = {},
+    ) {
         try {
-            recover(favoritesProvider())
+            recover(favoritesProvider(), onProgress)
         } catch (e: CancellationException) {
             throw e
         } catch (e: Exception) {
@@ -56,7 +67,10 @@ class FavoriteLemmaRecovery internal constructor(
         }
     }
 
-    private suspend fun recover(favorites: List<Favorite>) = coroutineScope {
+    private suspend fun recover(
+        favorites: List<Favorite>,
+        onProgress: (FavoriteRecoveryProgress) -> Unit,
+    ) = coroutineScope {
         val groups = favorites
             .mapNotNull { favorite ->
                 val lemma = favorite.lemma.trim()
@@ -64,22 +78,45 @@ class FavoriteLemmaRecovery internal constructor(
             }
             .groupBy({ it.first }, { it.second })
         val groupsToRecover = groupsByDownloadedLemmaStatus(groups)
+        val total = groupsToRecover.size
+        val progressMutex = Mutex()
+        var completed = 0
+        var failed = 0
+
+        suspend fun emit(currentLemma: String?, deltaFailed: Int = 0) = progressMutex.withLock {
+            if (deltaFailed > 0) failed += deltaFailed
+            onProgress(FavoriteRecoveryProgress(currentLemma, completed, total, failed))
+        }
+
+        suspend fun markDone(deltaFailed: Int) = progressMutex.withLock {
+            completed++
+            if (deltaFailed > 0) failed += deltaFailed
+            onProgress(FavoriteRecoveryProgress(currentLemma = null, completed, total, failed))
+        }
+
+        emit(currentLemma = null)
         val semaphore = Semaphore(MAX_PARALLEL_RECOVERY_GROUPS)
 
         groupsToRecover.map { (key, groupFavorites) ->
             async {
                 semaphore.withPermit {
+                    var failedGroup = false
+                    val lemma = groupFavorites.firstOrNull()?.lemma
                     try {
+                        emit(currentLemma = lemma)
                         recoverLemmaGroup(key.language, groupFavorites)
                     } catch (e: CancellationException) {
                         throw e
                     } catch (e: Exception) {
+                        failedGroup = true
                         AppLogger.warn(
                             TAG,
-                            "Unable to recover favorite lemma '${groupFavorites.firstOrNull()?.lemma}' (${key.language.code})",
+                            "Unable to recover favorite lemma '$lemma' (${key.language.code})",
                             e,
                         )
                         // Best-effort recovery: broken or unavailable remote fetches must not block downloads.
+                    } finally {
+                        markDone(deltaFailed = if (failedGroup) 1 else 0)
                     }
                 }
             }
@@ -125,7 +162,42 @@ class FavoriteLemmaRecovery internal constructor(
         val translationTargets = translationTargetsProvider(language)
             .filter { it != language }
             .distinctBy { it.code }
-        fetchLemma(language, lemma, translationTargets)
+        fetchLemmaWithRetry(language, lemma, translationTargets)
+    }
+
+    private suspend fun fetchLemmaWithRetry(
+        language: Language,
+        lemma: String,
+        translationTargets: List<Language>,
+    ) {
+        val delays = listOf(1.seconds, 3.seconds)
+        var attempt = 0
+        while (true) {
+            try {
+                fetchLemma(language, lemma, translationTargets)
+                return
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                val classified = NetworkErrorClassifier.classify(e)
+                val retryable = when (classified) {
+                    is NetworkError.Offline,
+                    is NetworkError.Timeout -> true
+                    is NetworkError.ServerError -> classified.statusCode in 500..599 || classified.statusCode == 0
+                    is NetworkError.InsufficientStorage,
+                    is NetworkError.Unknown -> false
+                }
+                if (!retryable || attempt >= delays.size) throw e
+                val retryDelay = delays[attempt]
+                AppLogger.warn(
+                    TAG,
+                    "Retrying favorite lemma recovery for '$lemma' (${language.code}) after ${retryDelay.inWholeSeconds}s",
+                    e,
+                )
+                delay(retryDelay)
+                attempt++
+            }
+        }
     }
 
     private suspend fun downloadedFavoriteLemmasNeedingRecovery(
@@ -165,6 +237,13 @@ class FavoriteLemmaRecovery internal constructor(
         }
     }
 }
+
+data class FavoriteRecoveryProgress(
+    val currentLemma: String?,
+    val completed: Int,
+    val total: Int,
+    val failed: Int,
+)
 
 private data class FavoriteLemmaGroupKey(
     val language: Language,

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/data/remote/FavoriteRecoveryController.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/data/remote/FavoriteRecoveryController.kt
@@ -1,9 +1,11 @@
 package com.slovy.slovymovyapp.data.remote
 
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -36,25 +38,34 @@ class FavoriteRecoveryController private constructor(
 
     private val mutex = Mutex()
     private var currentJob: Job? = null
+    private var isClosed = false
 
     private val _progress = MutableStateFlow<FavoriteRecoveryProgress?>(null)
     val progress: StateFlow<FavoriteRecoveryProgress?> = _progress.asStateFlow()
 
     /** Starts a recovery run if none is in flight; otherwise returns the existing Job. */
     suspend fun ensureStarted(): Job = mutex.withLock {
+        if (isClosed) throw CancellationException("Favorite recovery controller is closed")
         currentJob?.takeIf { it.isActive }?.let { return@withLock it }
-        val handle = acquireKeepAlive()
         val job = scope.launch {
+            var handle: ProcessKeepAlive? = null
             try {
+                handle = acquireKeepAlive()
                 recovery.recoverAllInstalledFavorites { progress ->
                     _progress.value = progress
                 }
             } finally {
                 _progress.value = null
-                handle.release()
+                handle?.release()
             }
         }
         currentJob = job
         job
+    }
+
+    fun close() {
+        isClosed = true
+        scope.cancel()
+        _progress.value = null
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/data/remote/FavoriteRecoveryController.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/data/remote/FavoriteRecoveryController.kt
@@ -1,0 +1,60 @@
+package com.slovy.slovymovyapp.data.remote
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+
+class FavoriteRecoveryController private constructor(
+    private val recovery: FavoriteLemmaRecovery,
+    private val acquireKeepAlive: () -> ProcessKeepAlive,
+    private val scope: CoroutineScope,
+) {
+    constructor(
+        recovery: FavoriteLemmaRecovery,
+        platform: PlatformDbSupport,
+    ) : this(
+        recovery = recovery,
+        acquireKeepAlive = { platform.acquireProcessKeepAlive() },
+        scope = CoroutineScope(SupervisorJob() + Dispatchers.Default),
+    )
+
+    internal constructor(
+        recovery: FavoriteLemmaRecovery,
+        acquireKeepAlive: () -> ProcessKeepAlive,
+    ) : this(
+        recovery = recovery,
+        acquireKeepAlive = acquireKeepAlive,
+        scope = CoroutineScope(SupervisorJob() + Dispatchers.Default),
+    )
+
+    private val mutex = Mutex()
+    private var currentJob: Job? = null
+
+    private val _progress = MutableStateFlow<FavoriteRecoveryProgress?>(null)
+    val progress: StateFlow<FavoriteRecoveryProgress?> = _progress.asStateFlow()
+
+    /** Starts a recovery run if none is in flight; otherwise returns the existing Job. */
+    suspend fun ensureStarted(): Job = mutex.withLock {
+        currentJob?.takeIf { it.isActive }?.let { return@withLock it }
+        val handle = acquireKeepAlive()
+        val job = scope.launch {
+            try {
+                recovery.recoverAllInstalledFavorites { progress ->
+                    _progress.value = progress
+                }
+            } finally {
+                _progress.value = null
+                handle.release()
+            }
+        }
+        currentJob = job
+        job
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/DownloadScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/DownloadScreen.kt
@@ -51,7 +51,7 @@ class DownloadViewModel(
     private val downloadCoordinator: DownloadCoordinator,
     private val downloadKey: String,
     private val download: suspend (onProgress: (DownloadProgress) -> Unit, cancelToken: CancelToken) -> Unit,
-    private val finalize: suspend () -> Unit = {},
+    private val finalize: suspend (DownloadViewModel) -> Unit = {},
     private val onSuccess: suspend () -> Unit,
     private val onCancel: () -> Unit,
     private val onError: (Throwable) -> Unit,
@@ -178,8 +178,8 @@ class DownloadViewModel(
                                 ),
                             )
                             try {
-                                state = DownloadUiState.Finalizing
-                                finalize()
+                                state = DownloadUiState.Finalizing()
+                                finalize(this@DownloadViewModel)
                                 for (i in 3 downTo 1) {
                                     state = DownloadUiState.Done(countdown = i)
                                     delay(1_000.milliseconds)
@@ -224,6 +224,12 @@ class DownloadViewModel(
                     else -> Unit
                 }
             }
+        }
+    }
+
+    fun updateRecoveryProgress(progress: FavoriteRecoveryProgress) {
+        if (state is DownloadUiState.Finalizing) {
+            state = DownloadUiState.Finalizing(progress)
         }
     }
 
@@ -523,6 +529,29 @@ fun DownloadScreenContent(
                         style = MaterialTheme.typography.bodyMedium,
                         color = MaterialTheme.colorScheme.onSurfaceVariant
                     )
+                    val recovery = (state as? DownloadUiState.Finalizing)?.recovery
+                    if (recovery != null && recovery.total > 0) {
+                        Spacer(Modifier.height(AppSpacing.sm))
+                        Text(
+                            text = stringResource(
+                                Res.string.download_finalizing_recovering_progress,
+                                recovery.completed,
+                                recovery.total,
+                            ),
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            textAlign = TextAlign.Center,
+                        )
+                        recovery.currentLemma?.takeIf { it.isNotBlank() }?.let { lemma ->
+                            Spacer(Modifier.height(AppSpacing.xs))
+                            Text(
+                                text = lemma,
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                textAlign = TextAlign.Center,
+                            )
+                        }
+                    }
                 }
 
                 is DownloadUiState.Running -> {
@@ -595,7 +624,7 @@ sealed interface DownloadUiState {
     data class ReadyToDownload(val items: List<DownloadItem>) : DownloadUiState
     data object Idle : DownloadUiState
     data class Running(val percent: Int, val total: Long?, val currentFile: String? = null) : DownloadUiState
-    data object Finalizing : DownloadUiState
+    data class Finalizing(val recovery: FavoriteRecoveryProgress? = null) : DownloadUiState
     data class Failed(val error: Throwable) : DownloadUiState
     data object Cancelled : DownloadUiState
     data class Done(val countdown: Int) : DownloadUiState
@@ -655,7 +684,11 @@ private fun DownloadScreenPreviewFinalizing(
     @PreviewParameter(ThemePreviewProvider::class) isDark: Boolean
 ) {
     ThemedPreview(darkTheme = isDark) {
-        DownloadScreenContent(state = DownloadUiState.Finalizing)
+        DownloadScreenContent(
+            state = DownloadUiState.Finalizing(
+                FavoriteRecoveryProgress(currentLemma = "test", completed = 1, total = 3, failed = 0)
+            )
+        )
     }
 }
 

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/DownloadScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/DownloadScreen.kt
@@ -35,6 +35,7 @@ import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.launch
+import org.jetbrains.compose.resources.pluralStringResource
 import org.jetbrains.compose.resources.stringResource
 import slovymovyapp.composeapp.generated.resources.*
 import kotlin.time.Clock
@@ -51,7 +52,7 @@ class DownloadViewModel(
     private val downloadCoordinator: DownloadCoordinator,
     private val downloadKey: String,
     private val download: suspend (onProgress: (DownloadProgress) -> Unit, cancelToken: CancelToken) -> Unit,
-    private val finalize: suspend (DownloadViewModel) -> Unit = {},
+    private val finalize: suspend (onRecoveryProgress: (FavoriteRecoveryProgress) -> Unit) -> Unit = {},
     private val onSuccess: suspend () -> Unit,
     private val onCancel: () -> Unit,
     private val onError: (Throwable) -> Unit,
@@ -179,7 +180,7 @@ class DownloadViewModel(
                             )
                             try {
                                 state = DownloadUiState.Finalizing()
-                                finalize(this@DownloadViewModel)
+                                finalize(::updateRecoveryProgress)
                                 for (i in 3 downTo 1) {
                                     state = DownloadUiState.Done(countdown = i)
                                     delay(1_000.milliseconds)
@@ -228,6 +229,7 @@ class DownloadViewModel(
     }
 
     fun updateRecoveryProgress(progress: FavoriteRecoveryProgress) {
+        // Late controller emissions can arrive after finalization has moved to a terminal state.
         if (state is DownloadUiState.Finalizing) {
             state = DownloadUiState.Finalizing(progress)
         }
@@ -532,12 +534,23 @@ fun DownloadScreenContent(
                     val recovery = (state as? DownloadUiState.Finalizing)?.recovery
                     if (recovery != null && recovery.total > 0) {
                         Spacer(Modifier.height(AppSpacing.sm))
-                        Text(
-                            text = stringResource(
+                        val recoveryProgressText = if (recovery.failed > 0) {
+                            pluralStringResource(
+                                Res.plurals.download_finalizing_recovering_progress_with_failures,
+                                recovery.failed,
+                                recovery.completed,
+                                recovery.total,
+                                recovery.failed,
+                            )
+                        } else {
+                            stringResource(
                                 Res.string.download_finalizing_recovering_progress,
                                 recovery.completed,
                                 recovery.total,
-                            ),
+                            )
+                        }
+                        Text(
+                            text = recoveryProgressText,
                             style = MaterialTheme.typography.bodyMedium,
                             color = MaterialTheme.colorScheme.onSurfaceVariant,
                             textAlign = TextAlign.Center,

--- a/composeApp/src/commonTest/kotlin/com/slovy/slovymovyapp/data/remote/FavoriteLemmaRecoveryTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/slovy/slovymovyapp/data/remote/FavoriteLemmaRecoveryTest.kt
@@ -8,6 +8,7 @@ import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeout
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 import kotlin.time.Duration.Companion.seconds
 
@@ -216,6 +217,56 @@ class FavoriteLemmaRecoveryTest : BaseTest() {
             listOf(FetchCall(Language.ENGLISH, "alpha", listOf(Language.RUSSIAN))),
             fetches,
         )
+    }
+
+    @Test
+    fun recoverAllInstalledFavorites_reports_progress_for_each_lemma() = runBlocking {
+        val progressEvents = mutableListOf<FavoriteRecoveryProgress>()
+        val recovery = recovery(
+            favorites = listOf(
+                Favorite(sense1, Language.ENGLISH, "alpha"),
+                Favorite(sense2, Language.ENGLISH, "beta"),
+            ),
+            installedDictionaries = setOf(Language.ENGLISH),
+            lemmasNeedingRecovery = setOf("alpha", "beta"),
+            fetches = mutableListOf(),
+        )
+
+        recovery.recoverAllInstalledFavorites { progressEvents += it }
+
+        assertTrue(
+            progressEvents.any { it.total == 2 && it.completed == 0 },
+            "Recovery should report initial total before completing lemmas",
+        )
+        val finalProgress = progressEvents.lastOrNull()
+        assertNotNull(finalProgress, "Recovery should emit at least one progress event")
+        assertEquals(2, finalProgress.total)
+        assertEquals(finalProgress.total, finalProgress.completed)
+        assertEquals(null, finalProgress.currentLemma)
+    }
+
+    @Test
+    fun recoverAllInstalledFavorites_counts_failure_when_fetch_throws() = runBlocking {
+        val progressEvents = mutableListOf<FavoriteRecoveryProgress>()
+        val recovery = recovery(
+            favorites = listOf(
+                Favorite(sense1, Language.ENGLISH, "alpha"),
+                Favorite(sense2, Language.ENGLISH, "beta"),
+            ),
+            installedDictionaries = setOf(Language.ENGLISH),
+            lemmasNeedingRecovery = setOf("alpha", "beta"),
+            fetches = mutableListOf(),
+            failLemma = "alpha",
+        )
+
+        recovery.recoverAllInstalledFavorites { progressEvents += it }
+
+        val finalProgress = progressEvents.lastOrNull()
+        assertNotNull(finalProgress, "Recovery should emit a final progress event")
+        assertEquals(2, finalProgress.total)
+        assertEquals(finalProgress.total, finalProgress.completed)
+        assertEquals(1, finalProgress.failed)
+        assertEquals(null, finalProgress.currentLemma)
     }
 
     @Test

--- a/composeApp/src/commonTest/kotlin/com/slovy/slovymovyapp/data/remote/FavoriteLemmaRecoveryTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/slovy/slovymovyapp/data/remote/FavoriteLemmaRecoveryTest.kt
@@ -4,7 +4,9 @@ import com.slovy.slovymovyapp.data.Language
 import com.slovy.slovymovyapp.data.favorites.Favorite
 import com.slovy.slovymovyapp.test.BaseTest
 import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.withTimeout
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -267,6 +269,88 @@ class FavoriteLemmaRecoveryTest : BaseTest() {
         assertEquals(finalProgress.total, finalProgress.completed)
         assertEquals(1, finalProgress.failed)
         assertEquals(null, finalProgress.currentLemma)
+    }
+
+    @Test
+    fun recoverAllInstalledFavorites_keeps_current_lemma_while_parallel_group_is_active() = runBlocking {
+        val progressEvents = mutableListOf<FavoriteRecoveryProgress>()
+        val alphaStarted = CompletableDeferred<Unit>()
+        val betaStarted = CompletableDeferred<Unit>()
+        val allowBetaFinish = CompletableDeferred<Unit>()
+        val betaStillActive = CompletableDeferred<FavoriteRecoveryProgress>()
+        val recovery = FavoriteLemmaRecovery(
+            favoritesProvider = {
+                listOf(
+                    Favorite(sense1, Language.ENGLISH, "alpha"),
+                    Favorite(sense2, Language.ENGLISH, "beta"),
+                )
+            },
+            hasDownloadedDictionary = { language -> language == Language.ENGLISH },
+            downloadedLemmasNeedingRecovery = { _, lemmas -> lemmas },
+            downloadedFavoritesNeedingTranslationRecovery = { _, _, _ -> emptySet() },
+            translationTargetsProvider = { listOf(Language.RUSSIAN) },
+            fetchLemma = { _, lemma, _ ->
+                when (lemma) {
+                    "alpha" -> {
+                        alphaStarted.complete(Unit)
+                        betaStarted.await()
+                    }
+
+                    "beta" -> {
+                        betaStarted.complete(Unit)
+                        allowBetaFinish.await()
+                    }
+                }
+            },
+        )
+
+        val recoveryJob = launch {
+            recovery.recoverAllInstalledFavorites { progress ->
+                progressEvents += progress
+                if (progress.completed == 1 && progress.currentLemma == "beta") {
+                    betaStillActive.complete(progress)
+                }
+            }
+        }
+
+        withTimeout(1.seconds.inWholeMilliseconds) {
+            alphaStarted.await()
+            betaStarted.await()
+        }
+        withTimeout(1.seconds.inWholeMilliseconds) { betaStillActive.await() }
+        allowBetaFinish.complete(Unit)
+        withTimeout(1.seconds.inWholeMilliseconds) { recoveryJob.join() }
+
+        val finalProgress = progressEvents.lastOrNull()
+        assertNotNull(finalProgress, "Recovery should emit a final progress event")
+        assertEquals(finalProgress.total, finalProgress.completed)
+        assertEquals(null, finalProgress.currentLemma)
+    }
+
+    @Test
+    fun recoverAllInstalledFavorites_retries_transient_fetch_failure() = runTest {
+        var attempts = 0
+        val fetches = mutableListOf<FetchCall>()
+        val recovery = FavoriteLemmaRecovery(
+            favoritesProvider = { listOf(Favorite(sense1, Language.ENGLISH, "test")) },
+            hasDownloadedDictionary = { language -> language == Language.ENGLISH },
+            downloadedLemmasNeedingRecovery = { _, lemmas -> lemmas },
+            downloadedFavoritesNeedingTranslationRecovery = { _, _, _ -> emptySet() },
+            translationTargetsProvider = { listOf(Language.RUSSIAN) },
+            fetchLemma = { language, lemma, translationTargets ->
+                attempts++
+                if (attempts == 1) throw RuntimeException("HTTP 500")
+                fetches += FetchCall(language, lemma, translationTargets)
+            },
+        )
+
+        recovery.recoverAllInstalledFavorites()
+
+        assertEquals(2, attempts)
+        assertEquals(
+            listOf(FetchCall(Language.ENGLISH, "test", listOf(Language.RUSSIAN))),
+            fetches,
+        )
     }
 
     @Test

--- a/composeApp/src/commonTest/kotlin/com/slovy/slovymovyapp/data/remote/FavoriteRecoveryControllerTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/slovy/slovymovyapp/data/remote/FavoriteRecoveryControllerTest.kt
@@ -1,0 +1,141 @@
+package com.slovy.slovymovyapp.data.remote
+
+import com.slovy.slovymovyapp.data.Language
+import com.slovy.slovymovyapp.data.favorites.Favorite
+import com.slovy.slovymovyapp.test.BaseTest
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.seconds
+
+class FavoriteRecoveryControllerTest : BaseTest() {
+    private val senseId = "00000000-0000-0000-0000-000000000001"
+
+    @Test
+    fun ensureStarted_returns_same_job_when_already_running() = runBlocking {
+        val started = CompletableDeferred<Unit>()
+        val releaseFetch = CompletableDeferred<Unit>()
+        var recoveryRuns = 0
+        val keepAlive = CountingKeepAliveFactory()
+        val controller = FavoriteRecoveryController(
+            recovery = recovery(
+                onFavoritesLoaded = { recoveryRuns++ },
+                onFetch = {
+                    started.complete(Unit)
+                    releaseFetch.await()
+                },
+            ),
+            acquireKeepAlive = keepAlive::acquire,
+        )
+
+        val firstJob = controller.ensureStarted()
+        val secondJob = controller.ensureStarted()
+        withTimeout(1.seconds.inWholeMilliseconds) { started.await() }
+        releaseFetch.complete(Unit)
+        withTimeout(1.seconds.inWholeMilliseconds) { firstJob.join() }
+
+        assertTrue(firstJob === secondJob, "An in-flight recovery should be reused")
+        assertEquals(1, recoveryRuns)
+        assertEquals(1, keepAlive.acquired)
+        assertEquals(1, keepAlive.released)
+    }
+
+    @Test
+    fun ensureStarted_starts_new_job_after_previous_completes() = runBlocking {
+        var recoveryRuns = 0
+        val keepAlive = CountingKeepAliveFactory()
+        val controller = FavoriteRecoveryController(
+            recovery = recovery(onFavoritesLoaded = { recoveryRuns++ }),
+            acquireKeepAlive = keepAlive::acquire,
+        )
+
+        val firstJob = controller.ensureStarted()
+        withTimeout(1.seconds.inWholeMilliseconds) { firstJob.join() }
+        val secondJob = controller.ensureStarted()
+        withTimeout(1.seconds.inWholeMilliseconds) { secondJob.join() }
+
+        assertTrue(firstJob !== secondJob, "A completed recovery should not be reused")
+        assertEquals(2, recoveryRuns)
+        assertEquals(2, keepAlive.acquired)
+        assertEquals(2, keepAlive.released)
+    }
+
+    @Test
+    fun caller_cancellation_does_not_cancel_controller_job() = runBlocking {
+        val started = CompletableDeferred<Unit>()
+        val releaseFetch = CompletableDeferred<Unit>()
+        val keepAlive = CountingKeepAliveFactory()
+        val controller = FavoriteRecoveryController(
+            recovery = recovery(
+                onFetch = {
+                    started.complete(Unit)
+                    releaseFetch.await()
+                },
+            ),
+            acquireKeepAlive = keepAlive::acquire,
+        )
+        val callerScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        val controllerJobDeferred = CompletableDeferred<kotlinx.coroutines.Job>()
+
+        val callerJob = callerScope.launch {
+            controllerJobDeferred.complete(controller.ensureStarted())
+        }
+        val controllerJob = withTimeout(1.seconds.inWholeMilliseconds) { controllerJobDeferred.await() }
+        withTimeout(1.seconds.inWholeMilliseconds) { started.await() }
+        callerScope.cancel()
+        callerJob.cancel()
+
+        assertTrue(controllerJob.isActive, "Controller-owned recovery should survive caller cancellation")
+        releaseFetch.complete(Unit)
+        withTimeout(1.seconds.inWholeMilliseconds) { controllerJob.join() }
+        assertTrue(controllerJob.isCompleted)
+        assertEquals(1, keepAlive.acquired)
+        assertEquals(1, keepAlive.released)
+    }
+
+    private fun recovery(
+        onFavoritesLoaded: () -> Unit = {},
+        onFetch: suspend () -> Unit = {},
+    ): FavoriteLemmaRecovery {
+        return FavoriteLemmaRecovery(
+            favoritesProvider = {
+                onFavoritesLoaded()
+                listOf(Favorite(senseId, Language.ENGLISH, "test"))
+            },
+            hasDownloadedDictionary = { language -> language == Language.ENGLISH },
+            downloadedLemmasNeedingRecovery = { _, lemmas -> lemmas },
+            downloadedFavoritesNeedingTranslationRecovery = { _, _, _ -> emptySet() },
+            translationTargetsProvider = { listOf(Language.RUSSIAN) },
+            fetchLemma = { _, _, _ -> onFetch() },
+        )
+    }
+
+    private class CountingKeepAliveFactory {
+        var acquired = 0
+            private set
+        var released = 0
+            private set
+
+        fun acquire(): ProcessKeepAlive {
+            acquired++
+            return object : ProcessKeepAlive {
+                private var isReleased = false
+
+                override fun release() {
+                    if (!isReleased) {
+                        isReleased = true
+                        released++
+                    }
+                }
+            }
+        }
+    }
+}

--- a/composeApp/src/commonTest/kotlin/com/slovy/slovymovyapp/data/remote/FavoriteRecoveryControllerTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/slovy/slovymovyapp/data/remote/FavoriteRecoveryControllerTest.kt
@@ -101,6 +101,31 @@ class FavoriteRecoveryControllerTest : BaseTest() {
         assertEquals(1, keepAlive.released)
     }
 
+    @Test
+    fun close_cancels_in_flight_job_and_releases_keep_alive() = runBlocking {
+        val started = CompletableDeferred<Unit>()
+        val releaseFetch = CompletableDeferred<Unit>()
+        val keepAlive = CountingKeepAliveFactory()
+        val controller = FavoriteRecoveryController(
+            recovery = recovery(
+                onFetch = {
+                    started.complete(Unit)
+                    releaseFetch.await()
+                },
+            ),
+            acquireKeepAlive = keepAlive::acquire,
+        )
+
+        val controllerJob = controller.ensureStarted()
+        withTimeout(1.seconds.inWholeMilliseconds) { started.await() }
+        controller.close()
+        withTimeout(1.seconds.inWholeMilliseconds) { controllerJob.join() }
+
+        assertTrue(controllerJob.isCancelled, "Closing the controller should cancel in-flight recovery")
+        assertEquals(1, keepAlive.acquired)
+        assertEquals(1, keepAlive.released)
+    }
+
     private fun recovery(
         onFavoritesLoaded: () -> Unit = {},
         onFetch: suspend () -> Unit = {},


### PR DESCRIPTION
### Motivation

- Make favorite-lemma recovery resilient and observable during library downloads so the UI can show progress and the recovery run is single-instance and keep-alive protected.

### Description

- Introduce `FavoriteRecoveryController` to run a single controller-owned recovery job with process keep-alive and expose a `progress` `StateFlow` and `ensureStarted()` API. 
- Enhance `FavoriteLemmaRecovery` to report progress via `FavoriteRecoveryProgress`, count failures, retry transient network errors with backoff (`fetchLemmaWithRetry`), and propagate cancellation semantics for `CancelledException`.
- Wire the controller into the app: add `favoriteRecoveryController` to `App.kt`, replace ad-hoc `favoriteLemmaRecovery` starts with `favoriteRecoveryController.ensureStarted()`, and observe progress to update the download UI during finalization.
- Update `DownloadViewModel` and `DownloadScreen` to accept/propagate finalization state: change `finalize` to `suspend (DownloadViewModel) -> Unit`, add `updateRecoveryProgress`, add `DownloadUiState.Finalizing(FavoriteRecoveryProgress?)` and render progress and current lemma text in the finalizing UI.
- Add a new localized string `download_finalizing_recovering_progress` to English, Dutch, Polish, and Russian resources.
- Rename local coroutine scope variable in `App.kt` to `appCoroutineScope` and replace usages to avoid confusion with `coroutineScope` from kotlinx.coroutines.

### Testing

- Ran unit tests under `commonTest`: `FavoriteLemmaRecoveryTest` updated tests and new progress/failure assertions passed.
- Added `FavoriteRecoveryControllerTest` verifying single-job reuse, new-job after completion, and controller-owned lifetime; all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a086c325c78832480d38300f94924ed)