### PR TITLE
Enable R8 shrinking and run instrumentation tests against a minified release-like build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -234,7 +234,7 @@ jobs:
           disk-size: 2048
           emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           disable-animations: true
-          script: ./gradlew :composeApp:connectedAndroidDeviceTest :androidApp:connectedDebugAndroidTest; status=$?; killall -INT crashpad_handler 2>/dev/null || true; exit $status
+          script: ./gradlew :composeApp:connectedAndroidDeviceTest :androidApp:connectedMinifiedAndroidTest; status=$?; killall -INT crashpad_handler 2>/dev/null || true; exit $status
 
       - name: Upload test results and reports (Android connected)
         if: always()

--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -14,6 +14,8 @@ kotlin {
     }
 }
 
+val releaseR8Rules = layout.projectDirectory.file("proguard-rules.pro")
+
 android {
     namespace = "com.slovy.slovymovyapp.androidApp"
     compileSdk = libs.versions.android.compileSdk.get().toInt()
@@ -21,6 +23,10 @@ android {
     buildFeatures {
         buildConfig = true
     }
+
+    // Run androidTest against a release-like, minified build type so instrumentation
+    // tests exercise the same R8/resource shrinking path as production.
+    testBuildType = "minifiedTest"
 
     defaultConfig {
         applicationId = "com.slovy.slovymovyapp"
@@ -41,12 +47,29 @@ android {
             isMinifyEnabled = false
         }
         release {
-            isMinifyEnabled = false // XXX: implement later?
+            isMinifyEnabled = true
+            isShrinkResources = true
+            proguardFiles(
+                getDefaultProguardFile("proguard-android-optimize.txt"),
+                releaseR8Rules.asFile
+            )
+        }
+        create("minifiedTest") {
+            // Mirrors release shrinking/optimization, but uses debug signing and the
+            // debug application ID so connected tests can install it safely in CI.
+            initWith(getByName("release"))
+            matchingFallbacks += listOf("release", "debug")
+            signingConfig = signingConfigs.getByName("debug")
+            applicationIdSuffix = ".debug"
+            versionNameSuffix = "-minified-test"
         }
     }
 
     sourceSets {
         getByName("debug") {
+            res.srcDirs("src/debug/res")
+        }
+        getByName("minifiedTest") {
             res.srcDirs("src/debug/res")
         }
     }
@@ -62,6 +85,20 @@ android {
             excludes += "/META-INF/{AL2.0,LGPL2.1}"
         }
     }
+}
+
+tasks.register("checkReleaseOptimizedBuild") {
+    group = "verification"
+    description = "Runs release unit tests and assembles the minified, resource-shrunk release APK."
+
+    dependsOn("testReleaseUnitTest", "testMinifiedTestUnitTest", "assembleRelease")
+}
+
+tasks.register("connectedMinifiedAndroidTest") {
+    group = "verification"
+    description = "Runs Android instrumentation tests against a signed, minified, resource-shrunk build."
+
+    dependsOn("connectedMinifiedTestAndroidTest")
 }
 
 dependencies {

--- a/androidApp/proguard-rules.pro
+++ b/androidApp/proguard-rules.pro
@@ -1,0 +1,10 @@
+# Slovy Movy is open source, so release builds should optimize and shrink code
+# without obfuscating class, method, or field names. This keeps stack traces
+# readable by humans while still letting R8 remove unused code and apply
+# optimizations.
+-dontobfuscate
+
+# Keep source/line metadata for Crashlytics and retrace after R8 optimizations
+# such as inlining. Keep the Android/Kotlin metadata attributes that libraries
+# commonly rely on so this project file does not narrow the default rules.
+-keepattributes SourceFile,LineNumberTable,SourceDebugExtension,*Annotation*,Signature,InnerClasses,EnclosingMethod

--- a/androidApp/src/androidTest/kotlin/com/slovy/slovymovyapp/MainActivitySmokeTest.kt
+++ b/androidApp/src/androidTest/kotlin/com/slovy/slovymovyapp/MainActivitySmokeTest.kt
@@ -1,0 +1,19 @@
+package com.slovy.slovymovyapp
+
+import androidx.test.core.app.ActivityScenario
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Assert.assertFalse
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class MainActivitySmokeTest {
+    @Test
+    fun launchesMainActivity() {
+        ActivityScenario.launch(MainActivity::class.java).use { scenario ->
+            scenario.onActivity { activity ->
+                assertFalse("MainActivity should stay open after launch.", activity.isFinishing)
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Motivation
- Ensure Android instrumentation tests exercise the same R8/resource shrinking and optimization path as production builds while keeping stack traces readable.

### Description
- Enable code shrinking for `release` by setting `isMinifyEnabled = true`, enabling `isShrinkResources`, and adding `proguard-rules.pro` with `-dontobfuscate` and `-keepattributes` rules.
- Add a `minifiedTest` build type that `initWith` the `release` config but uses debug signing and `applicationIdSuffix = ".debug"` so connected tests can be installed in CI, and set `testBuildType = "minifiedTest"` to run `androidTest` against it.
- Add Gradle tasks `checkReleaseOptimizedBuild` (depends on `testReleaseUnitTest`, `testMinifiedTestUnitTest`, `assembleRelease`) and `connectedMinifiedAndroidTest` (depends on `connectedMinifiedTestAndroidTest`) to streamline verification and instrumentation runs.
- Update CI workflow to run `:composeApp:connectedAndroidDeviceTest` and `:androidApp:connectedMinifiedAndroidTest` in the Android connected job.

### Testing
- The CI job is configured to run `:composeApp:connectedAndroidDeviceTest` and `:androidApp:connectedMinifiedAndroidTest` as part of the matrix connected Android tests.
- The new Gradle verification tasks invoke `testReleaseUnitTest`, `testMinifiedTestUnitTest`, `assembleRelease`, and `connectedMinifiedTestAndroidTest` to exercise unit and instrumentation test paths.
- No automated test execution results were provided in the supplied rollout transcript, so test outcomes are not available here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08de9c9ab483249444b4cdec1b36d2)