### PR TITLE
Review us in settings

### DIFF
--- a/composeApp/src/androidMain/kotlin/com/slovy/slovymovyapp/ui/StoreReviewTarget.android.kt
+++ b/composeApp/src/androidMain/kotlin/com/slovy/slovymovyapp/ui/StoreReviewTarget.android.kt
@@ -1,3 +1,7 @@
 package com.slovy.slovymovyapp.ui
 
+private const val RATE_URL = "https://play.google.com/store/apps/details?id=com.slovy.slovymovyapp"
+
 actual fun storeReviewTarget(): StoreReviewTarget? = StoreReviewTarget.GOOGLE_PLAY
+
+actual fun storeReviewUrl(): String? = RATE_URL

--- a/composeApp/src/androidMain/kotlin/com/slovy/slovymovyapp/ui/StoreReviewTarget.android.kt
+++ b/composeApp/src/androidMain/kotlin/com/slovy/slovymovyapp/ui/StoreReviewTarget.android.kt
@@ -1,0 +1,3 @@
+package com.slovy.slovymovyapp.ui
+
+actual fun storeReviewTarget(): StoreReviewTarget? = StoreReviewTarget.GOOGLE_PLAY

--- a/composeApp/src/commonMain/composeResources/values-nl/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-nl/strings.xml
@@ -235,9 +235,7 @@
 
     <string name="voice_setup_title">Verbeter je uitspraak</string>
     <string name="voice_setup_description">De standaardstem kan robotachtig klinken. Zo krijg je een betere:</string>
-    <string name="voice_setup_step_android">Open de tekst-naar-spraakinstellingen op je telefoon en download een
-        hoogwaardige stem voor %1$s.
-    </string>
+    <string name="voice_setup_step_android">Open de tekst-naar-spraakinstellingen op je telefoon en download een hoogwaardige stem voor %1$s.</string>
     <string name="voice_setup_step_ios">Ga naar iPhone-instellingen > Toegankelijkheid > Gesproken inhoud > Stemmen en download een stem voor %1$s.</string>
     <string name="voice_setup_step_other">Download een hoogwaardige stem voor %1$s via je systeeminstellingen.</string>
     <string name="voice_setup_step_two">Ga terug naar de Open Words-instellingen > Stemmen en schakel de nieuwe stem in.</string>
@@ -248,9 +246,7 @@
     <string name="voice_many_enabled">%1$d stemmen ingeschakeld</string>
     <string name="voice_no_voices_available">Geen stemmen beschikbaar</string>
     <string name="voice_download_more_title">Download meer stemmen</string>
-    <string name="voice_download_more_step_android">Open de tekst-naar-spraakinstellingen op je telefoon en download een
-        hoogwaardige stem.
-    </string>
+    <string name="voice_download_more_step_android">Open de tekst-naar-spraakinstellingen op je telefoon en download een hoogwaardige stem.</string>
     <string name="voice_download_more_step_ios">Ga naar iPhone-instellingen > Toegankelijkheid > Gesproken inhoud > Stemmen en download een hoogwaardige stem.</string>
     <string name="voice_download_more_step_other">Download een hoogwaardige stem via je systeeminstellingen.</string>
     <string name="voice_download_more_step_two">Ga terug naar de Open Words-instellingen > Stem en schakel de nieuwe stem in.</string>
@@ -261,10 +257,13 @@
     <string name="voice_test_action">Test stem</string>
     <string name="voice_enable_label">Schakel %1$s in</string>
 
-    <string name="about_send_feedback_title">Stuur ons feedback</string>
-    <string name="about_send_feedback_subtitle">We horen graag van je</string>
+    <string name="about_send_feedback_title">Functie aanvragen</string>
+    <string name="about_send_feedback_subtitle">Deel je ideeën om OpenWords te verbeteren</string>
     <string name="about_acknowledgements_title">Met dank aan</string>
     <string name="about_acknowledgements_subtitle">Gegevensbronnen &amp; credits</string>
+    <string name="about_review_google_play_title">Beoordeel ons op Google Play</string>
+    <string name="about_review_app_store_title">Beoordeel ons in de App Store</string>
+    <string name="about_review_subtitle">Vind je OpenWords nuttig? Steun ons met een beoordeling!</string>
     <string name="about_version_title">Versie</string>
     <string name="acknowledgements_title">Met dank aan</string>
     <string name="acknowledgements_vocab_data_title">Woordenschatgegevens</string>
@@ -288,9 +287,7 @@
     <string name="acknowledgements_thanks">Onze dank gaat uit naar de Wiktionary-community en Tatu Ylonen voor het gratis beschikbaar stellen van deze gegevens.</string>
 
     <string name="app_data_backup_title">Maak een back-up van je opgeslagen woorden</string>
-    <string name="app_data_backup_description">Exporteert je opgeslagen woorden en app-instellingen naar een archief.
-        Handig om een kopie te bewaren of te verhuizen naar een nieuw apparaat.
-    </string>
+    <string name="app_data_backup_description">Exporteert je opgeslagen woorden en app-instellingen naar een archief. Handig om een kopie te bewaren of te verhuizen naar een nieuw apparaat.</string>
     <string name="app_data_exporting">Bezig met exporteren...</string>
     <string name="app_data_export_now">Exporteer nu</string>
 

--- a/composeApp/src/commonMain/composeResources/values-pl/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-pl/strings.xml
@@ -235,14 +235,9 @@
 
     <string name="voice_setup_title">Lepsza wymowa</string>
     <string name="voice_setup_description">Domyślny głos może brzmieć mechanicznie. Oto jak to zmienić:</string>
-    <string name="voice_setup_step_android">Otwórz ustawienia syntezy mowy w telefonie i pobierz wysokiej jakości głos
-        dla języka %1$s.
-    </string>
-    <string name="voice_setup_step_ios">Przejdź do: Ustawienia > Dostępność > Czytaj zawartość > Głosy i pobierz głos
-        dla języka %1$s.
-    </string>
-    <string name="voice_setup_step_other">Pobierz wysokiej jakości głos dla języka %1$s w ustawieniach systemowych.
-    </string>
+    <string name="voice_setup_step_android">Otwórz ustawienia syntezy mowy w telefonie i pobierz wysokiej jakości głos dla języka %1$s.</string>
+    <string name="voice_setup_step_ios">Przejdź do: Ustawienia > Dostępność > Czytaj zawartość > Głosy i pobierz głos dla języka %1$s.</string>
+    <string name="voice_setup_step_other">Pobierz wysokiej jakości głos dla języka %1$s w ustawieniach systemowych.</string>
     <string name="voice_setup_step_two">Wróć do: Ustawienia Open Words > Głosy i włącz nowy głos.</string>
 
     <string name="voice_no_voices_enabled">Brak włączonych głosów</string>
@@ -251,12 +246,8 @@
     <string name="voice_many_enabled">%1$d aktywnych głosów</string>
     <string name="voice_no_voices_available">Brak dostępnych głosów</string>
     <string name="voice_download_more_title">Pobierz więcej głosów</string>
-    <string name="voice_download_more_step_android">Otwórz ustawienia syntezy mowy w telefonie i pobierz wysokiej
-        jakości głos.
-    </string>
-    <string name="voice_download_more_step_ios">Przejdź do: Ustawienia > Dostępność > Czytaj zawartość > Głosy i pobierz
-        wysokiej jakości głos.
-    </string>
+    <string name="voice_download_more_step_android">Otwórz ustawienia syntezy mowy w telefonie i pobierz wysokiej jakości głos.</string>
+    <string name="voice_download_more_step_ios">Przejdź do: Ustawienia > Dostępność > Czytaj zawartość > Głosy i pobierz wysokiej jakości głos.</string>
     <string name="voice_download_more_step_other">Pobierz wysokiej jakości głos w ustawieniach systemowych.</string>
     <string name="voice_download_more_step_two">Wróć do: Ustawienia Open Words > Głos i włącz nowy głos.</string>
     <string name="voice_quality_high">Wysoka</string>
@@ -266,10 +257,13 @@
     <string name="voice_test_action">Przetestuj</string>
     <string name="voice_enable_label">Włącz %1$s</string>
 
-    <string name="about_send_feedback_title">Wyślij opinię</string>
-    <string name="about_send_feedback_subtitle">Chętnie poznamy Twoją opinię</string>
+    <string name="about_send_feedback_title">Zaproponuj funkcję</string>
+    <string name="about_send_feedback_subtitle">Podziel się pomysłami na ulepszenie OpenWords</string>
     <string name="about_acknowledgements_title">Podziękowania</string>
     <string name="about_acknowledgements_subtitle">Źródła danych i autorzy</string>
+    <string name="about_review_google_play_title">Oceń nas w Google Play</string>
+    <string name="about_review_app_store_title">Oceń nas w App Store</string>
+    <string name="about_review_subtitle">Czy OpenWords jest pomocne? Wesprzyj nas oceną!</string>
     <string name="about_version_title">Wersja</string>
     <string name="acknowledgements_title">Podziękowania</string>
     <string name="acknowledgements_vocab_data_title">Dane słownikowe</string>
@@ -294,9 +288,7 @@
     </string>
 
     <string name="app_data_backup_title">Kopia zapasowa Twoich słów</string>
-    <string name="app_data_backup_description">Eksportuj zapisane słowa i ustawienia do archiwum. Przydatne, aby
-        zachować kopię lub przenieść dane na nowe urządzenie.
-    </string>
+    <string name="app_data_backup_description">Eksportuj zapisane słowa i ustawienia do archiwum. Przydatne, aby zachować kopię lub przenieść dane na nowe urządzenie.</string>
     <string name="app_data_exporting">Eksportowanie...</string>
     <string name="app_data_export_now">Eksportuj teraz</string>
 

--- a/composeApp/src/commonMain/composeResources/values-ru/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-ru/strings.xml
@@ -236,12 +236,8 @@
 
     <string name="voice_setup_title">Качество озвучки</string>
     <string name="voice_setup_description">Стандартный голос может звучать механически. Вот как это исправить:</string>
-    <string name="voice_setup_step_android">Откройте настройки синтеза речи на телефоне и скачайте качественный голос
-        для %1$s.
-    </string>
-    <string name="voice_setup_step_ios">Перейдите в Настройки > Универсальный доступ > Устный контент > Голоса. Скачайте
-        улучшенный голос для %1$s.
-    </string>
+    <string name="voice_setup_step_android">Откройте настройки синтеза речи на телефоне и скачайте качественный голос для %1$s.</string>
+    <string name="voice_setup_step_ios">Перейдите в Настройки > Универсальный доступ > Устный контент > Голоса. Скачайте улучшенный голос для %1$s.</string>
     <string name="voice_setup_step_other">Скачайте качественный голос для %1$s в системных настройках.</string>
     <string name="voice_setup_step_two">Вернитесь в OpenWords (Настройки > Озвучка) и выберите новый голос.</string>
 
@@ -251,12 +247,8 @@
     <string name="voice_many_enabled">%1$d голосов включено</string>
     <string name="voice_no_voices_available">Нет доступных голосов</string>
     <string name="voice_download_more_title">Добавить новые голоса</string>
-    <string name="voice_download_more_step_android">Откройте настройки синтеза речи на телефоне и загрузите качественный
-        голос.
-    </string>
-    <string name="voice_download_more_step_ios">Настройки > Универсальный доступ > Устный контент > Голоса. Скачайте
-        один из улучшенных голосов.
-    </string>
+    <string name="voice_download_more_step_android">Откройте настройки синтеза речи на телефоне и загрузите качественный голос.</string>
+    <string name="voice_download_more_step_ios">Настройки > Универсальный доступ > Устный контент > Голоса. Скачайте один из улучшенных голосов.</string>
     <string name="voice_download_more_step_other">Загрузите качественный голос в системных настройках.</string>
     <string name="voice_download_more_step_two">Вернитесь в OpenWords (Настройки > Озвучка) и включите его.</string>
     <string name="voice_quality_high">Высокое</string>
@@ -266,10 +258,13 @@
     <string name="voice_test_action">Проверить</string>
     <string name="voice_enable_label">Включить %1$s</string>
 
-    <string name="about_send_feedback_title">Написать нам</string>
-    <string name="about_send_feedback_subtitle">Будем рады узнать ваше мнение</string>
+    <string name="about_send_feedback_title">Предложить функцию</string>
+    <string name="about_send_feedback_subtitle">Поделитесь идеями по улучшению OpenWords</string>
     <string name="about_acknowledgements_title">Благодарности</string>
     <string name="about_acknowledgements_subtitle">Источники данных и авторы</string>
+    <string name="about_review_google_play_title">Оценить в Google Play</string>
+    <string name="about_review_app_store_title">Оценить в App Store</string>
+    <string name="about_review_subtitle">OpenWords помогает в учёбе? Поддержите нас оценкой!</string>
     <string name="about_version_title">Версия</string>
     <string name="acknowledgements_title">Благодарности</string>
     <string name="acknowledgements_vocab_data_title">Словарные данные</string>
@@ -293,9 +288,7 @@
     </string>
 
     <string name="app_data_backup_title">Резервная копия</string>
-    <string name="app_data_backup_description">Создаёт архив с вашими словами и настройками. Пригодится, чтобы сохранить
-        данные или перенести их на новое устройство.
-    </string>
+    <string name="app_data_backup_description">Создаёт архив с вашими словами и настройками. Пригодится, чтобы сохранить данные или перенести их на новое устройство.</string>
     <string name="app_data_exporting">Экспорт...</string>
     <string name="app_data_export_now">Экспортировать сейчас</string>
 

--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -235,14 +235,9 @@
     <string name="feedback_dialog_send">Send</string>
 
     <string name="voice_setup_title">Get better pronunciation</string>
-    <string name="voice_setup_description">The default voice may sound robotic. Here is how to get a better one:
-    </string>
-    <string name="voice_setup_step_android">Open your phone text-to-speech settings and download a high-quality voice
-        for %1$s.
-    </string>
-    <string name="voice_setup_step_ios">Go to iPhone Settings - Accessibility - Read &amp; Speak - Voices and download a
-        voice for %1$s.
-    </string>
+    <string name="voice_setup_description">The default voice may sound robotic. Here is how to get a better one:</string>
+    <string name="voice_setup_step_android">Open your phone text-to-speech settings and download a high-quality voice for %1$s.</string>
+    <string name="voice_setup_step_ios">Go to iPhone Settings - Accessibility - Read &amp; Speak - Voices and download a voice for %1$s.</string>
     <string name="voice_setup_step_other">Download a high-quality voice for %1$s from your system settings.</string>
     <string name="voice_setup_step_two">Come back to Open Words Settings - Voices and enable the new voice.</string>
 
@@ -252,15 +247,10 @@
     <string name="voice_many_enabled">%1$d voices enabled</string>
     <string name="voice_no_voices_available">No voices available</string>
     <string name="voice_download_more_title">Download more voices</string>
-    <string name="voice_download_more_step_android">Open your phone text-to-speech settings and download a high-quality
-        voice.
-    </string>
-    <string name="voice_download_more_step_ios">Go to iPhone Settings - Accessibility - Read &amp; Speak - Voices and
-        download a high-quality voice.
-    </string>
+    <string name="voice_download_more_step_android">Open your phone text-to-speech settings and download a high-quality voice.</string>
+    <string name="voice_download_more_step_ios">Go to iPhone Settings - Accessibility - Read &amp; Speak - Voices and download a high-quality voice.</string>
     <string name="voice_download_more_step_other">Download a high-quality voice from your system settings.</string>
-    <string name="voice_download_more_step_two">Come back to Open Words Settings - Voice and enable the new voice.
-    </string>
+    <string name="voice_download_more_step_two">Come back to Open Words Settings - Voice and enable the new voice.</string>
     <string name="voice_quality_high">High</string>
     <string name="voice_quality_good">Good</string>
     <string name="voice_quality_medium">Medium</string>
@@ -268,10 +258,13 @@
     <string name="voice_test_action">Test Voice</string>
     <string name="voice_enable_label">Enable %1$s</string>
 
-    <string name="about_send_feedback_title">Send us feedback</string>
-    <string name="about_send_feedback_subtitle">We would love to hear from you</string>
+    <string name="about_send_feedback_title">Request a feature</string>
+    <string name="about_send_feedback_subtitle">Share your ideas on how to improve OpenWords</string>
     <string name="about_acknowledgements_title">Acknowledgements</string>
     <string name="about_acknowledgements_subtitle">Data sources &amp; credits</string>
+    <string name="about_review_google_play_title">Review us on Google Play</string>
+    <string name="about_review_app_store_title">Review us on the App Store</string>
+    <string name="about_review_subtitle">Find OpenWords helpful? Support us with a rating!</string>
     <string name="about_version_title">Version</string>
     <string name="acknowledgements_title">Acknowledgements</string>
     <string name="acknowledgements_vocab_data_title">Vocabulary data</string>
@@ -295,9 +288,7 @@
     </string>
 
     <string name="app_data_backup_title">Back up your saved words</string>
-    <string name="app_data_backup_description">Exports your saved words and app settings to an archive. Useful for
-        keeping a copy or moving to a new device.
-    </string>
+    <string name="app_data_backup_description">Exports your saved words and app settings to an archive. Useful for keeping a copy or moving to a new device.</string>
     <string name="app_data_exporting">Exporting...</string>
     <string name="app_data_export_now">Export now</string>
 

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/AboutSection.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/AboutSection.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Feedback
 import androidx.compose.material.icons.outlined.Info
+import androidx.compose.material.icons.outlined.StarBorder
 import androidx.compose.material.icons.outlined.VolunteerActivism
 import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
@@ -29,6 +30,24 @@ fun AboutSection(
     onSendFeedback: () -> Unit = {},
     onAcknowledgements: () -> Unit = {}
 ) {
+    val uriHandler = LocalUriHandler.current
+    AboutSectionContent(
+        buildConfig = buildConfig,
+        reviewTarget = storeReviewTarget(),
+        onReview = { uriHandler.openUri(it.reviewUrl()) },
+        onSendFeedback = onSendFeedback,
+        onAcknowledgements = onAcknowledgements
+    )
+}
+
+@Composable
+private fun AboutSectionContent(
+    buildConfig: AppBuildConfig,
+    reviewTarget: StoreReviewTarget?,
+    onReview: (StoreReviewTarget) -> Unit,
+    onSendFeedback: () -> Unit,
+    onAcknowledgements: () -> Unit
+) {
     ElevatedCard(
         modifier = Modifier.fillMaxWidth(),
         shape = MaterialTheme.shapes.extraLarge,
@@ -38,6 +57,22 @@ fun AboutSection(
         elevation = CardDefaults.elevatedCardElevation(defaultElevation = 0.dp)
     ) {
         Column(modifier = Modifier.fillMaxWidth()) {
+            if (reviewTarget != null) {
+                AboutItem(
+                    icon = Icons.Outlined.StarBorder,
+                    title = when (reviewTarget) {
+                        StoreReviewTarget.GOOGLE_PLAY -> stringResource(Res.string.about_review_google_play_title)
+                        StoreReviewTarget.APP_STORE -> stringResource(Res.string.about_review_app_store_title)
+                    },
+                    subtitle = stringResource(Res.string.about_review_subtitle),
+                    onClick = { onReview(reviewTarget) }
+                )
+                HorizontalDivider(
+                    modifier = Modifier.padding(horizontal = AppSpacing.lg),
+                    thickness = 0.5.dp,
+                    color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f)
+                )
+            }
             AboutItem(
                 icon = Icons.Outlined.Feedback,
                 title = stringResource(Res.string.about_send_feedback_title),
@@ -219,6 +254,38 @@ fun AboutItem(
 
 @Preview
 @Composable
+private fun AboutSectionPreviewWithReview(
+    @PreviewParameter(ThemePreviewProvider::class) isDark: Boolean
+) {
+    ThemedPreview(darkTheme = isDark) {
+        AboutSectionContent(
+            buildConfig = previewBuildConfig,
+            reviewTarget = StoreReviewTarget.GOOGLE_PLAY,
+            onReview = {},
+            onSendFeedback = {},
+            onAcknowledgements = {}
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun AboutSectionPreviewWithoutReview(
+    @PreviewParameter(ThemePreviewProvider::class) isDark: Boolean
+) {
+    ThemedPreview(darkTheme = isDark) {
+        AboutSectionContent(
+            buildConfig = previewBuildConfig,
+            reviewTarget = null,
+            onReview = {},
+            onSendFeedback = {},
+            onAcknowledgements = {}
+        )
+    }
+}
+
+@Preview
+@Composable
 private fun AcknowledgementsBottomSheetPreview(
     @PreviewParameter(ThemePreviewProvider::class) isDark: Boolean
 ) {
@@ -226,3 +293,10 @@ private fun AcknowledgementsBottomSheetPreview(
         AcknowledgementsBottomSheetContent()
     }
 }
+
+private val previewBuildConfig = AppBuildConfig(
+    versionName = "1.2.345",
+    versionCode = 345,
+    isDebug = false,
+    applicationId = "com.slovy.slovymovyapp"
+)

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/AboutSection.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/AboutSection.kt
@@ -34,7 +34,8 @@ fun AboutSection(
     AboutSectionContent(
         buildConfig = buildConfig,
         reviewTarget = storeReviewTarget(),
-        onReview = { uriHandler.openUri(it.reviewUrl()) },
+        reviewUrl = storeReviewUrl(),
+        onReview = { uriHandler.openUri(it) },
         onSendFeedback = onSendFeedback,
         onAcknowledgements = onAcknowledgements
     )
@@ -44,7 +45,8 @@ fun AboutSection(
 private fun AboutSectionContent(
     buildConfig: AppBuildConfig,
     reviewTarget: StoreReviewTarget?,
-    onReview: (StoreReviewTarget) -> Unit,
+    reviewUrl: String?,
+    onReview: (String) -> Unit,
     onSendFeedback: () -> Unit,
     onAcknowledgements: () -> Unit
 ) {
@@ -57,7 +59,7 @@ private fun AboutSectionContent(
         elevation = CardDefaults.elevatedCardElevation(defaultElevation = 0.dp)
     ) {
         Column(modifier = Modifier.fillMaxWidth()) {
-            if (reviewTarget != null) {
+            if (reviewTarget != null && reviewUrl != null) {
                 AboutItem(
                     icon = Icons.Outlined.StarBorder,
                     title = when (reviewTarget) {
@@ -65,7 +67,7 @@ private fun AboutSectionContent(
                         StoreReviewTarget.APP_STORE -> stringResource(Res.string.about_review_app_store_title)
                     },
                     subtitle = stringResource(Res.string.about_review_subtitle),
-                    onClick = { onReview(reviewTarget) }
+                    onClick = { onReview(reviewUrl) }
                 )
                 HorizontalDivider(
                     modifier = Modifier.padding(horizontal = AppSpacing.lg),
@@ -261,6 +263,7 @@ private fun AboutSectionPreviewWithReview(
         AboutSectionContent(
             buildConfig = previewBuildConfig,
             reviewTarget = StoreReviewTarget.GOOGLE_PLAY,
+            reviewUrl = "https://example.com",
             onReview = {},
             onSendFeedback = {},
             onAcknowledgements = {}
@@ -277,6 +280,7 @@ private fun AboutSectionPreviewWithoutReview(
         AboutSectionContent(
             buildConfig = previewBuildConfig,
             reviewTarget = null,
+            reviewUrl = null,
             onReview = {},
             onSendFeedback = {},
             onAcknowledgements = {}

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/StoreReviewTarget.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/StoreReviewTarget.kt
@@ -7,8 +7,4 @@ enum class StoreReviewTarget {
 
 expect fun storeReviewTarget(): StoreReviewTarget?
 
-fun StoreReviewTarget.reviewUrl(): String = when (this) {
-    // Google Play has no public external URL that opens the rating dialog directly.
-    StoreReviewTarget.GOOGLE_PLAY -> "https://play.google.com/store/apps/details?id=com.slovy.slovymovyapp"
-    StoreReviewTarget.APP_STORE -> "https://apps.apple.com/app/openwords/id6754798978?action=write-review"
-}
+expect fun storeReviewUrl(): String?

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/StoreReviewTarget.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/StoreReviewTarget.kt
@@ -1,0 +1,14 @@
+package com.slovy.slovymovyapp.ui
+
+enum class StoreReviewTarget {
+    GOOGLE_PLAY,
+    APP_STORE
+}
+
+expect fun storeReviewTarget(): StoreReviewTarget?
+
+fun StoreReviewTarget.reviewUrl(): String = when (this) {
+    // Google Play has no public external URL that opens the rating dialog directly.
+    StoreReviewTarget.GOOGLE_PLAY -> "https://play.google.com/store/apps/details?id=com.slovy.slovymovyapp"
+    StoreReviewTarget.APP_STORE -> "https://apps.apple.com/app/openwords/id6754798978?action=write-review"
+}

--- a/composeApp/src/desktopMain/kotlin/com/slovy/slovymovyapp/ui/StoreReviewTarget.desktop.kt
+++ b/composeApp/src/desktopMain/kotlin/com/slovy/slovymovyapp/ui/StoreReviewTarget.desktop.kt
@@ -1,0 +1,3 @@
+package com.slovy.slovymovyapp.ui
+
+actual fun storeReviewTarget(): StoreReviewTarget? = null

--- a/composeApp/src/desktopMain/kotlin/com/slovy/slovymovyapp/ui/StoreReviewTarget.desktop.kt
+++ b/composeApp/src/desktopMain/kotlin/com/slovy/slovymovyapp/ui/StoreReviewTarget.desktop.kt
@@ -1,3 +1,5 @@
 package com.slovy.slovymovyapp.ui
 
 actual fun storeReviewTarget(): StoreReviewTarget? = null
+
+actual fun storeReviewUrl(): String? = null

--- a/composeApp/src/iosMain/kotlin/com/slovy/slovymovyapp/ui/StoreReviewTarget.ios.kt
+++ b/composeApp/src/iosMain/kotlin/com/slovy/slovymovyapp/ui/StoreReviewTarget.ios.kt
@@ -1,0 +1,3 @@
+package com.slovy.slovymovyapp.ui
+
+actual fun storeReviewTarget(): StoreReviewTarget? = StoreReviewTarget.APP_STORE

--- a/composeApp/src/iosMain/kotlin/com/slovy/slovymovyapp/ui/StoreReviewTarget.ios.kt
+++ b/composeApp/src/iosMain/kotlin/com/slovy/slovymovyapp/ui/StoreReviewTarget.ios.kt
@@ -1,3 +1,7 @@
 package com.slovy.slovymovyapp.ui
 
+private const val RATE_URL = "https://apps.apple.com/app/openwords/id6754798978?action=write-review"
+
 actual fun storeReviewTarget(): StoreReviewTarget? = StoreReviewTarget.APP_STORE
+
+actual fun storeReviewUrl(): String? = RATE_URL


### PR DESCRIPTION
- Adds “Review us” as the first row in Settings > About.
  - Uses platform-specific targets:
      - Android: Google Play listing
      - iOS: App Store write-review URL
      - Desktop: row hidden
  - Changes “Send us feedback” copy to “Request a feature”.
  - Fixes Settings Voice/Data text indentation caused by multiline XML resource strings.
  - Adds themed previews for About with and without the review row.
