### PR TITLE
Settings: dictionary_download_changes

### DIFF
--- a/composeApp/src/commonMain/composeResources/values-nl/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-nl/strings.xml
@@ -326,9 +326,7 @@
     <string name="settings_languages_more">+%1$d meer</string>
     <string name="settings_toggle_translation_for_language">Schakel %1$s-vertaling in of uit</string>
     <string name="settings_remove_language_confirm_title">%1$s verwijderen?</string>
-    <string name="settings_remove_language_confirm_message">Het woordenboek en alle vertalingen worden verwijderd. Je
-        kunt ze altijd opnieuw downloaden.
-    </string>
+    <string name="settings_remove_language_confirm_message">Het woordenboek en alle vertalingen worden verwijderd. Je kunt ze altijd opnieuw downloaden.</string>
     <plurals name="settings_remove_language_warning">
         <item quantity="one">Hierdoor wordt ook %1$d vertaling verwijderd.</item>
         <item quantity="few">Hierdoor worden ook %1$d vertalingen verwijderd.</item>

--- a/composeApp/src/commonMain/composeResources/values-pl/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-pl/strings.xml
@@ -332,9 +332,7 @@
     <string name="settings_languages_more">+%1$d więcej</string>
     <string name="settings_toggle_translation_for_language">Przełącz tłumaczenie %1$s</string>
     <string name="settings_remove_language_confirm_title">Usunąć %1$s?</string>
-    <string name="settings_remove_language_confirm_message">Słownik i wszystkie jego tłumaczenia zostaną usunięte.
-        Możesz je pobrać ponownie w dowolnym momencie.
-    </string>
+    <string name="settings_remove_language_confirm_message">Słownik i wszystkie jego tłumaczenia zostaną usunięte. Możesz je pobrać ponownie w dowolnym momencie.</string>
     <plurals name="settings_remove_language_warning">
         <item quantity="one">To usunie również %1$d tłumaczenie.</item>
         <item quantity="few">To usunie również %1$d tłumaczenia.</item>

--- a/composeApp/src/commonMain/composeResources/values-ru/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-ru/strings.xml
@@ -331,9 +331,7 @@
     <string name="settings_languages_more">+%1$d еще</string>
     <string name="settings_toggle_translation_for_language">Переключить перевод %1$s</string>
     <string name="settings_remove_language_confirm_title">Удалить %1$s?</string>
-    <string name="settings_remove_language_confirm_message">Словарь и все его переводы будут удалены. Вы сможете скачать
-        их снова в любое время.
-    </string>
+    <string name="settings_remove_language_confirm_message">Словарь и все его переводы будут удалены. Вы сможете скачать их снова в любое время.</string>
     <plurals name="settings_remove_language_warning">
         <item quantity="one">Это также удалит %1$d перевод.</item>
         <item quantity="few">Это также удалит %1$d перевода.</item>

--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -333,9 +333,7 @@
     <string name="settings_languages_more">+%1$d more</string>
     <string name="settings_toggle_translation_for_language">Toggle %1$s translation</string>
     <string name="settings_remove_language_confirm_title">Remove %1$s?</string>
-    <string name="settings_remove_language_confirm_message">The dictionary and all its translations will be deleted. You
-        can re-download anytime.
-    </string>
+    <string name="settings_remove_language_confirm_message">The dictionary and all its translations will be deleted. You can download them again anytime.</string>
     <plurals name="settings_remove_language_warning">
         <item quantity="one">This will also remove %1$d translation.</item>
         <item quantity="few">This will also remove %1$d translations.</item>

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/SettingsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/SettingsScreen.kt
@@ -26,6 +26,7 @@ import com.slovy.slovymovyapp.data.settings.Setting
 import com.slovy.slovymovyapp.data.settings.SettingsRepository
 import com.slovy.slovymovyapp.i18n.UiText
 import com.slovy.slovymovyapp.i18n.resolve
+import com.slovy.slovymovyapp.logging.AppLogger
 import com.slovy.slovymovyapp.speech.*
 import com.slovy.slovymovyapp.ui.theme.AppSpacing
 import com.slovy.slovymovyapp.ui.theme.serifFontFamily
@@ -127,6 +128,10 @@ class SettingsViewModel(
     private var translationSaveJob: Job? = null
     private var loadLearningLanguagesJob: Job? = null
     private var loadLanguagesJob: Job? = null
+
+    companion object {
+        private const val TAG = "SettingsViewModel"
+    }
 
     init {
         loadLearningLanguages()
@@ -336,6 +341,9 @@ class SettingsViewModel(
                 settingsRepository.insert(Setting(Setting.Name.LANGUAGE, jsonArray))
                 onDictionaryDataChanged(false)
                 loadLearningLanguages()
+                if (language !in previous) {
+                    downloadMissingTranslationsForInstalledLearningLanguages(current)
+                }
             } catch (e: CancellationException) {
                 throw e
             } catch (e: Exception) {
@@ -473,21 +481,92 @@ class SettingsViewModel(
         ) {
             onDictionaryDataChanged(true)
             reloadSettings()
+            downloadMissingTranslationsForLearningLanguage(language)
         }
     }
 
     fun downloadTranslation(sourceLanguage: Language, targetLanguage: Language) {
+        startTranslationDownload(
+            sourceLanguage = sourceLanguage,
+            targetLanguage = targetLanguage,
+            logUserClick = true
+        )
+    }
+
+    private suspend fun downloadMissingTranslationsForLearningLanguage(language: Language) {
+        val translationLanguages = try {
+            loadTranslationLanguages()
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            AppLogger.warn(TAG, "Unable to load translation languages for automatic download", e)
+            return
+        }
+        if (translationLanguages.isEmpty()) return
+
+        downloadMissingTranslationsForLearningLanguage(language, translationLanguages.toList())
+    }
+
+    private suspend fun downloadMissingTranslationsForInstalledLearningLanguages(
+        translationLanguages: Collection<Language>
+    ) {
+        if (translationLanguages.isEmpty()) return
+
+        val translationList = translationLanguages.toList()
+        val installedLearningLanguages = dataDbManager.listDownloadedDatabases()
+            .filterIsInstance<DatabaseFileInfo.Dictionary>()
+            .map { it.language }
+            .sortedBy { it.ordinal }
+
+        installedLearningLanguages.forEach { language ->
+            downloadMissingTranslationsForLearningLanguage(language, translationList)
+        }
+    }
+
+    private suspend fun downloadMissingTranslationsForLearningLanguage(
+        language: Language,
+        translationLanguages: List<Language>
+    ) {
+        if (translationLanguages.isEmpty()) return
+
+        val downloadableTargets = try {
+            dataDbManager.downloadableTranslationTargets(language, translationLanguages)
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            AppLogger.warn(TAG, "Unable to load downloadable translations for ${language.code}", e)
+            emptyList()
+        }
+
+        downloadableTargets
+            .filter { !dataDbManager.hasTranslation(language, it) }
+            .forEach { target ->
+                startTranslationDownload(
+                    sourceLanguage = language,
+                    targetLanguage = target,
+                    logUserClick = false
+                )
+            }
+    }
+
+    private fun startTranslationDownload(
+        sourceLanguage: Language,
+        targetLanguage: Language,
+        logUserClick: Boolean
+    ) {
         val downloadKey = "trans_${sourceLanguage.code}_${targetLanguage.code}"
         if (downloadCoordinator.isRunning(downloadKey)) return
 
-        Analytics.logEvent(
-            AnalyticsEvent.SETTINGS_DOWNLOAD_TRANSLATION_CLICK,
-            mapOf(
-                "kind" to "translation",
-                "src_lang" to sourceLanguage.code,
-                "tgt_lang" to targetLanguage.code,
-            ),
-        )
+        if (logUserClick) {
+            Analytics.logEvent(
+                AnalyticsEvent.SETTINGS_DOWNLOAD_TRANSLATION_CLICK,
+                mapOf(
+                    "kind" to "translation",
+                    "src_lang" to sourceLanguage.code,
+                    "tgt_lang" to targetLanguage.code,
+                ),
+            )
+        }
         val keepAlive = platform.acquireProcessKeepAlive()
         val downloadFlow = downloadCoordinator.startDownload(downloadKey) { onProgress, cancelToken ->
             dataDbManager.ensureTranslation(

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/SettingsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/SettingsScreen.kt
@@ -486,25 +486,13 @@ class SettingsViewModel(
     }
 
     fun downloadTranslation(sourceLanguage: Language, targetLanguage: Language) {
-        startTranslationDownload(
-            sourceLanguage = sourceLanguage,
-            targetLanguage = targetLanguage,
-            logUserClick = true
-        )
+        logTranslationDownloadClick(sourceLanguage, targetLanguage)
+        startTranslationDownload(sourceLanguage, targetLanguage)
     }
 
     private suspend fun downloadMissingTranslationsForLearningLanguage(language: Language) {
-        val translationLanguages = try {
-            loadTranslationLanguages()
-        } catch (e: CancellationException) {
-            throw e
-        } catch (e: Exception) {
-            AppLogger.warn(TAG, "Unable to load translation languages for automatic download", e)
-            return
-        }
-        if (translationLanguages.isEmpty()) return
-
-        downloadMissingTranslationsForLearningLanguage(language, translationLanguages.toList())
+        val translationLanguages = loadTranslationLanguagesForAutoDownload() ?: return
+        downloadMissingTranslationsForLearningLanguage(language, translationLanguages)
     }
 
     private suspend fun downloadMissingTranslationsForInstalledLearningLanguages(
@@ -528,45 +516,52 @@ class SettingsViewModel(
         translationLanguages: List<Language>
     ) {
         if (translationLanguages.isEmpty()) return
-
-        val downloadableTargets = try {
-            dataDbManager.downloadableTranslationTargets(language, translationLanguages)
-        } catch (e: CancellationException) {
-            throw e
-        } catch (e: Exception) {
-            AppLogger.warn(TAG, "Unable to load downloadable translations for ${language.code}", e)
-            emptyList()
-        }
-
-        downloadableTargets
+        loadDownloadableTranslationTargets(language, translationLanguages)
             .filter { !dataDbManager.hasTranslation(language, it) }
             .forEach { target ->
-                startTranslationDownload(
-                    sourceLanguage = language,
-                    targetLanguage = target,
-                    logUserClick = false
-                )
+                startTranslationDownload(language, target)
             }
     }
 
-    private fun startTranslationDownload(
+    private fun logTranslationDownloadClick(sourceLanguage: Language, targetLanguage: Language) {
+        Analytics.logEvent(
+            AnalyticsEvent.SETTINGS_DOWNLOAD_TRANSLATION_CLICK,
+            mapOf(
+                "kind" to "translation",
+                "src_lang" to sourceLanguage.code,
+                "tgt_lang" to targetLanguage.code,
+            ),
+        )
+    }
+
+    private suspend fun loadTranslationLanguagesForAutoDownload(): List<Language>? {
+        val translationLanguages = try {
+            loadTranslationLanguages()
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            AppLogger.warn(TAG, "Unable to load translation languages for automatic download", e)
+            return null
+        }
+        return translationLanguages.takeIf { it.isNotEmpty() }?.toList()
+    }
+
+    private suspend fun loadDownloadableTranslationTargets(
         sourceLanguage: Language,
-        targetLanguage: Language,
-        logUserClick: Boolean
-    ) {
+        translationLanguages: List<Language>
+    ): List<Language> = try {
+        dataDbManager.downloadableTranslationTargets(sourceLanguage, translationLanguages)
+    } catch (e: CancellationException) {
+        throw e
+    } catch (e: Exception) {
+        AppLogger.warn(TAG, "Unable to load downloadable translations for ${sourceLanguage.code}", e)
+        emptyList()
+    }
+
+    private fun startTranslationDownload(sourceLanguage: Language, targetLanguage: Language) {
         val downloadKey = "trans_${sourceLanguage.code}_${targetLanguage.code}"
         if (downloadCoordinator.isRunning(downloadKey)) return
 
-        if (logUserClick) {
-            Analytics.logEvent(
-                AnalyticsEvent.SETTINGS_DOWNLOAD_TRANSLATION_CLICK,
-                mapOf(
-                    "kind" to "translation",
-                    "src_lang" to sourceLanguage.code,
-                    "tgt_lang" to targetLanguage.code,
-                ),
-            )
-        }
         val keepAlive = platform.acquireProcessKeepAlive()
         val downloadFlow = downloadCoordinator.startDownload(downloadKey) { onProgress, cancelToken ->
             dataDbManager.ensureTranslation(


### PR DESCRIPTION
Included changes:

  - Settings now auto-downloads available translation DBs after downloading a new learning dictionary.
  - Settings now auto-downloads missing translation DBs when a translation language is added.
  - Automatic flows log non-fatal lookup failures with AppLogger.warn.
  - Manual translation download analytics remain user-click only.
  - Remove-language confirmation localization whitespace fixed across base/NL/PL/RU.
