### PR TITLE
Log and trace DictionaryClient remote error emissions

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/data/remote/DictionaryClient.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/data/remote/DictionaryClient.kt
@@ -203,6 +203,8 @@ class DictionaryClient(
                         localCard.online
                     )
                 } catch (e: CancellationException) {
+                    markResult("remote_cancelled")
+                    AppLogger.warn(TAG, "getWord cancelled for $language/$lemma", e)
                     // Emit error for cancellation, then re-throw to propagate
                     emitMeasured(
                         WordResult(
@@ -215,6 +217,7 @@ class DictionaryClient(
                     throw e
                 } catch (e: Exception) {
                     markResult("remote_error")
+                    AppLogger.error(TAG, "getWord remote fetch failed for $language/$lemma", e)
                     // Emit error result - preserve loading context so UI knows where error occurred
                     emitMeasured(
                         WordResult(
@@ -568,9 +571,14 @@ class DictionaryClient(
             val body = response.bodyAsText()
             return json.decodeFromString(FeedbackResponse.serializer(), body)
         } catch (e: CancellationException) {
+            AppLogger.warn(TAG, "sendFeedback cancelled for $language/$lemma", e)
             throw e
         } catch (e: Exception) {
-            if (e is DictionaryClientException) throw e
+            if (e is DictionaryClientException) {
+                AppLogger.error(TAG, "sendFeedback failed for $language/$lemma", e)
+                throw e
+            }
+            AppLogger.error(TAG, "sendFeedback failed for $language/$lemma", e)
             throw DictionaryClientException.NetworkException(
                 NetworkErrorClassifier.userMessage(e),
                 e
@@ -604,9 +612,14 @@ class DictionaryClient(
             val body = response.bodyAsText()
             return json.decodeFromString(GeneralFeedbackResponse.serializer(), body)
         } catch (e: CancellationException) {
+            AppLogger.warn(TAG, "sendGeneralFeedback cancelled", e)
             throw e
         } catch (e: Exception) {
-            if (e is DictionaryClientException) throw e
+            if (e is DictionaryClientException) {
+                AppLogger.error(TAG, "sendGeneralFeedback failed", e)
+                throw e
+            }
+            AppLogger.error(TAG, "sendGeneralFeedback failed", e)
             throw DictionaryClientException.NetworkException(
                 NetworkErrorClassifier.userMessage(e),
                 e


### PR DESCRIPTION
### Motivation
- Ensure that when `DictionaryClient.getWord` emits an error `WordResult` (cancellation or other remote failure) the event is paired with monitoring and diagnostic logs so failures are observable. 
- Improve observability for other client-side network flows that previously surfaced exceptions without structured logging. 

### Description
- Mark remote cancellation in monitoring with `markResult("remote_cancelled")` and log a warning via `AppLogger.warn` before emitting a cancellation `WordResult` in `getWord`. 
- Log remote fetch failures with `AppLogger.error` and still emit an error `WordResult` while calling `markResult("remote_error")` in `getWord`. 
- Add `AppLogger.warn`/`AppLogger.error` calls to `sendFeedback` and `sendGeneralFeedback` cancellation and exception paths so failures are logged and diagnostic context is available. 

### Testing
- Ran `./gradlew :composeApp:compileKotlinMetadata` and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0eca56bac48324af3a6a6a96496a43)