### PR TITLE
Handle data-version re-download errors without crashing iOS app

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/App.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/App.kt
@@ -1038,14 +1038,20 @@ fun App(
                 DataVersionMismatchScreen(
                     onRedownload = {
                         coroutineScope.launch {
-                            dataManager.deleteAllDownloadedData()
-                            localDbManager.deleteAll()
-                            dictionaryRepository.clearSenseCache()
-                            favoritesReviewCoordinator.invalidateAllIntakeCache()
-                            favoritesViewModel.dropCachedFavoriteDetails()
-                            val target = selectInitialDestination()
-                            navController.navigate(target) {
-                                popUpTo<AppDestination.DataVersionMismatch> { inclusive = true }
+                            try {
+                                dataManager.deleteAllDownloadedData()
+                                localDbManager.deleteAll()
+                                dictionaryRepository.clearSenseCache()
+                                favoritesReviewCoordinator.invalidateAllIntakeCache()
+                                favoritesViewModel.dropCachedFavoriteDetails()
+                                val target = selectInitialDestination()
+                                navController.navigate(target) {
+                                    popUpTo<AppDestination.DataVersionMismatch> { inclusive = true }
+                                }
+                            } catch (e: CancellationException) {
+                                throw e
+                            } catch (e: Throwable) {
+                                navController.navigate(AppDestination.Error(e.message ?: "Failed to refresh dictionaries"))
                             }
                         }
                     }


### PR DESCRIPTION
### Motivation
- Prevent Kotlin/Native process termination caused by an unhandled coroutine exception during the data-version re-download/cleanup flow by surfacing failures as a recoverable UI error while preserving coroutine cancellation semantics.

### Description
- Wrap the `DataVersionMismatchScreen` `onRedownload` coroutine body in a `try/catch` in `composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/App.kt`, rethrow `CancellationException`, and route other exceptions to `AppDestination.Error(...)` instead of letting them propagate.

### Testing
- Ran `./gradlew :composeApp:compileKotlinMetadata` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ec88b626c832487bbc826f355d835)