### PR TITLE
Add translation cloze hint for CLOZE_TRANSLATION cards

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/data/learning/session/ExamplePicker.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/data/learning/session/ExamplePicker.kt
@@ -2,7 +2,7 @@ package com.slovy.slovymovyapp.data.learning.session
 
 import com.slovy.slovymovyapp.data.Language
 import com.slovy.slovymovyapp.data.remote.LanguageCardExample
-import com.slovy.slovymovyapp.data.util.HtmlTagParser
+import com.slovy.slovymovyapp.data.util.parseClozeFromTaggedText
 import com.slovy.slovymovyapp.db.FavoritesQueries
 import kotlin.uuid.Uuid
 
@@ -33,9 +33,11 @@ class ExamplePicker(private val learning: FavoritesQueries) {
 
     private fun pickFromCandidates(senseId: Uuid, candidates: List<ExampleCandidate>): ExamplePair? {
         val clozeCandidates = candidates.mapNotNull { candidate ->
-            clozeText(candidate.text)?.let { cloze ->
-                ClozeCandidate(candidate.exampleIndex, cloze.text, cloze.ranges)
-            }
+            parseClozeFromTaggedText(candidate.text)
+                ?.takeIf { it.answerRanges.isNotEmpty() }
+                ?.let { cloze ->
+                    ClozeCandidate(candidate.exampleIndex, cloze.plainText, cloze.answerRanges)
+                }
         }
         if (clozeCandidates.isEmpty()) return null
         val recentDesc = learning.selectRecentReviewedExampleIdsBySense(senseId, clozeCandidates.size.toLong())
@@ -48,27 +50,6 @@ class ExamplePicker(private val learning: FavoritesQueries) {
             ?: clozeCandidates.first()
         return ExamplePair(candidate.exampleIndex, candidate.text, candidate.ranges)
     }
-
-    private fun clozeText(text: String): ClozeText? {
-        var output = ""
-        val ranges = mutableListOf<IntRange>()
-        HtmlTagParser.parseTextSegments(text).forEach { segment ->
-            val start = output.length
-            val segmentText = HtmlTagParser.plainText(segment.text)
-            output += segmentText
-            if (segment.isTagged && segmentText.isNotBlank()) {
-                val leadingWhitespace = segmentText.indexOfFirst { !it.isWhitespace() }
-                val trailingWhitespace = segmentText.indexOfLast { !it.isWhitespace() }
-                ranges.add((start + leadingWhitespace)..(start + trailingWhitespace))
-            }
-        }
-        return ranges.takeIf { it.isNotEmpty() }?.let { ClozeText(text = output, ranges = it) }
-    }
-
-    private data class ClozeText(
-        val text: String,
-        val ranges: List<IntRange>,
-    )
 
     private data class ExampleCandidate(
         val exampleIndex: Long,

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/data/util/ClozeTextParser.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/data/util/ClozeTextParser.kt
@@ -1,0 +1,25 @@
+package com.slovy.slovymovyapp.data.util
+
+data class ClozeParseResult(
+    val plainText: String,
+    val answerRanges: List<IntRange>,
+)
+
+fun parseClozeFromTaggedText(text: String): ClozeParseResult? {
+    if (text.isBlank()) return null
+    val output = StringBuilder()
+    val ranges = mutableListOf<IntRange>()
+    HtmlTagParser.parseTextSegments(text).forEach { segment ->
+        val start = output.length
+        val segmentText = HtmlTagParser.plainText(segment.text)
+        output.append(segmentText)
+        if (segment.isTagged && segmentText.isNotBlank()) {
+            val leading = segmentText.indexOfFirst { !it.isWhitespace() }
+            val trailing = segmentText.indexOfLast { !it.isWhitespace() }
+            ranges.add((start + leading)..(start + trailing))
+        }
+    }
+    val plain = output.toString()
+    if (plain.isBlank()) return null
+    return ClozeParseResult(plainText = plain, answerRanges = ranges)
+}

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/study/StudySessionMapper.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/study/StudySessionMapper.kt
@@ -154,8 +154,8 @@ fun SessionCard.toStudyCardUiState(): StudyCardUiState? {
                 translationHint = sense.examples
                     .firstOrNull { HtmlTagParser.plainText(it.text) == example.text }
                     ?.targetLangTranslations
-                    ?.values
-                    ?.firstOrNull(),
+                    ?.get(target)
+                    ?.toTranslationHintCloze(),
                 senses = senses,
                 activeSenseId = sense.senseId,
                 back = activeBack,
@@ -165,14 +165,13 @@ fun SessionCard.toStudyCardUiState(): StudyCardUiState? {
         CardKind.CLOZE_TRANSLATION -> {
             val target = targetLanguage ?: return null
             val cloze = example?.toClozeText() ?: return null
-            val backExamples = sense.examples[example.exampleIndex.toInt()].let {
-                listOf(
-                    StudyExampleUiState(
-                        text = it.text,
-                        translation = it.targetLangTranslations[target],
-                    )
+            val sourceExample = sense.examples[example.exampleIndex.toInt()]
+            val backExamples = listOf(
+                StudyExampleUiState(
+                    text = sourceExample.text,
+                    translation = sourceExample.targetLangTranslations[target],
                 )
-            }
+            )
             val activeBack = sourceClozeBack(
                 lemma = lemma,
                 sense = sense,
@@ -192,7 +191,7 @@ fun SessionCard.toStudyCardUiState(): StudyCardUiState? {
                     listOf(sourceLanguage.studyCode()),
                 ),
                 prompt = cloze.copy(filled = true),
-                translationHint = null,
+                translationHint = sourceExample.text.toTranslationHintCloze(),
                 senses = senses,
                 activeSenseId = sense.senseId,
                 back = activeBack,
@@ -346,6 +345,25 @@ private fun ExamplePair.toClozeText(): StudyClozeTextUiState? {
         text = text,
         answerRanges = clozeRanges,
     )
+}
+
+private fun String.toTranslationHintCloze(): StudyClozeTextUiState? {
+    if (isBlank()) return null
+    val output = StringBuilder()
+    val ranges = mutableListOf<IntRange>()
+    HtmlTagParser.parseTextSegments(this).forEach { segment ->
+        val start = output.length
+        val segmentText = HtmlTagParser.plainText(segment.text)
+        output.append(segmentText)
+        if (segment.isTagged && segmentText.isNotBlank()) {
+            val leading = segmentText.indexOfFirst { !it.isWhitespace() }
+            val trailing = segmentText.indexOfLast { !it.isWhitespace() }
+            ranges.add((start + leading)..(start + trailing))
+        }
+    }
+    val plain = output.toString()
+    if (plain.isBlank()) return null
+    return StudyClozeTextUiState(text = plain, answerRanges = ranges)
 }
 
 internal fun String.firstLetterHint(): FirstLetterHint? {

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/study/StudySessionMapper.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/study/StudySessionMapper.kt
@@ -9,6 +9,7 @@ import com.slovy.slovymovyapp.data.learning.session.SessionCard
 import com.slovy.slovymovyapp.data.learning.session.SessionCardLoadState
 import com.slovy.slovymovyapp.data.remote.LanguageCardResponseSense
 import com.slovy.slovymovyapp.data.util.HtmlTagParser
+import com.slovy.slovymovyapp.data.util.parseClozeFromTaggedText
 import com.slovy.slovymovyapp.i18n.UiText
 import slovymovyapp.composeapp.generated.resources.*
 import kotlin.math.roundToLong
@@ -155,7 +156,7 @@ fun SessionCard.toStudyCardUiState(): StudyCardUiState? {
                     .firstOrNull { HtmlTagParser.plainText(it.text) == example.text }
                     ?.targetLangTranslations
                     ?.get(target)
-                    ?.toTranslationHintCloze(),
+                    ?.let { toTranslationHintCloze(it) },
                 senses = senses,
                 activeSenseId = sense.senseId,
                 back = activeBack,
@@ -191,7 +192,7 @@ fun SessionCard.toStudyCardUiState(): StudyCardUiState? {
                     listOf(sourceLanguage.studyCode()),
                 ),
                 prompt = cloze.copy(filled = true),
-                translationHint = sourceExample.text.toTranslationHintCloze(),
+                translationHint = toTranslationHintCloze(sourceExample.text),
                 senses = senses,
                 activeSenseId = sense.senseId,
                 back = activeBack,
@@ -347,23 +348,9 @@ private fun ExamplePair.toClozeText(): StudyClozeTextUiState? {
     )
 }
 
-private fun String.toTranslationHintCloze(): StudyClozeTextUiState? {
-    if (isBlank()) return null
-    val output = StringBuilder()
-    val ranges = mutableListOf<IntRange>()
-    HtmlTagParser.parseTextSegments(this).forEach { segment ->
-        val start = output.length
-        val segmentText = HtmlTagParser.plainText(segment.text)
-        output.append(segmentText)
-        if (segment.isTagged && segmentText.isNotBlank()) {
-            val leading = segmentText.indexOfFirst { !it.isWhitespace() }
-            val trailing = segmentText.indexOfLast { !it.isWhitespace() }
-            ranges.add((start + leading)..(start + trailing))
-        }
-    }
-    val plain = output.toString()
-    if (plain.isBlank()) return null
-    return StudyClozeTextUiState(text = plain, answerRanges = ranges)
+private fun toTranslationHintCloze(text: String): StudyClozeTextUiState? {
+    val parsed = parseClozeFromTaggedText(text) ?: return null
+    return StudyClozeTextUiState(text = parsed.plainText, answerRanges = parsed.answerRanges)
 }
 
 internal fun String.firstLetterHint(): FirstLetterHint? {

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/study/StudySessionModels.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/study/StudySessionModels.kt
@@ -83,7 +83,7 @@ sealed interface StudyCardUiState {
         override val id: String,
         override val chipLabel: UiText,
         val prompt: StudyClozeTextUiState,
-        val translationHint: String? = null,
+        val translationHint: StudyClozeTextUiState? = null,
         val translationHintRevealed: Boolean = false,
         override val senses: List<StudyCardSenseUiState> = emptyList(),
         override val activeSenseId: String? = null,

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/study/StudySessionScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/study/StudySessionScreen.kt
@@ -1878,6 +1878,32 @@ private fun clozeCard() = StudyCardUiState.Cloze(
     ),
 )
 
+private fun translationClozeCard() = StudyCardUiState.Cloze(
+    id = "cloze-translation",
+    chipLabel = UiText.Plain("Recall NL"),
+    prompt = StudyClozeTextUiState(
+        text = "It was so lovely at your place.",
+        answerRanges = listOf(10..15),
+        filled = true,
+    ),
+    translationHint = StudyClozeTextUiState(
+        text = "Het was zo gezellig bij jullie thuis.",
+        answerRanges = listOf(11..18),
+    ),
+    back = StudyCardBackUiState(
+        headline = "gezellig",
+        isLemmaHeadline = true,
+        secondary = "cosy, sociable",
+        definition = "a feeling of warmth and conviviality from being together",
+        examples = listOf(
+            StudyExampleUiState(
+                text = "Het was zo gezellig bij jullie thuis.",
+                translation = "It was so lovely at your place.",
+            ),
+        ),
+    ),
+)
+
 private fun listeningCard() = StudyCardUiState.Listening(
     id = "listening",
     chipLabel = UiText.Resource(Res.string.study_chip_listen),
@@ -2136,6 +2162,38 @@ private fun StudySessionClozeBackPreview(
     ThemedPreview(darkTheme = isDark) {
         StudySessionScreenContent(
             state = activeState(clozeCard(), StudyCardSide.BACK, current = 6),
+            onCancel = {},
+            onEnd = {},
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun StudySessionTranslationClozeFrontPreview(
+    @PreviewParameter(ThemePreviewProvider::class) isDark: Boolean,
+) {
+    ThemedPreview(darkTheme = isDark) {
+        StudySessionScreenContent(
+            state = activeState(translationClozeCard(), StudyCardSide.FRONT, current = 6),
+            onCancel = {},
+            onEnd = {},
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun StudySessionTranslationClozeFrontHintRevealedPreview(
+    @PreviewParameter(ThemePreviewProvider::class) isDark: Boolean,
+) {
+    ThemedPreview(darkTheme = isDark) {
+        StudySessionScreenContent(
+            state = activeState(
+                translationClozeCard().copy(translationHintRevealed = true),
+                StudyCardSide.FRONT,
+                current = 6,
+            ),
             onCancel = {},
             onEnd = {},
         )

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/study/StudySessionScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/study/StudySessionScreen.kt
@@ -971,9 +971,7 @@ private fun ClozeFront(
             )
             card.translationHint?.let { hint ->
                 if (card.translationHintRevealed) {
-                    StudyExampleBlock(
-                        example = StudyExampleUiState(text = hint),
-                    )
+                    StudyTranslationHintBlock(cloze = hint)
                 } else {
                     HintRevealPill(
                         contentDescription = stringResource(Res.string.study_hint_show_translation_description),
@@ -1276,6 +1274,36 @@ private fun StudySpeakerButton(
                 )
             }
         }
+    }
+}
+
+@Composable
+private fun StudyTranslationHintBlock(
+    cloze: StudyClozeTextUiState,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .height(IntrinsicSize.Min),
+        horizontalArrangement = Arrangement.spacedBy(AppSpacing.sm),
+    ) {
+        Box(
+            modifier = Modifier
+                .width(3.dp)
+                .fillMaxHeight()
+                .clip(RoundedCornerShape(1.5.dp))
+                .background(MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.6f)),
+        )
+        StudyClozeText(
+            cloze = cloze,
+            style = MaterialTheme.typography.bodyLarge.copy(
+                fontFamily = MaterialTheme.serifFontFamily,
+                fontStyle = FontStyle.Normal,
+                lineHeight = MaterialTheme.typography.bodyLarge.lineHeight * 1.1f,
+            ),
+            modifier = Modifier.weight(1f),
+        )
     }
 }
 
@@ -1834,7 +1862,10 @@ private fun clozeCard() = StudyCardUiState.Cloze(
         text = "Het was zo gezellig bij jullie thuis.",
         answerRanges = listOf(11..18),
     ),
-    translationHint = "It was so <w>lovely</w> at your place.",
+    translationHint = StudyClozeTextUiState(
+        text = "It was so lovely at your place.",
+        answerRanges = listOf(10..15),
+    ),
     back = StudyCardBackUiState(
         headline = "gezellig",
         secondary = "cosy, sociable",

--- a/composeApp/src/commonTest/kotlin/com/slovy/slovymovyapp/ui/study/StudySessionMapperTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/slovy/slovymovyapp/ui/study/StudySessionMapperTest.kt
@@ -208,9 +208,29 @@ class StudySessionMapperTest {
 
         assertEquals("Het was zo gezellig.", mapped.prompt.text)
         assertEquals(listOf(11..18), mapped.prompt.answerRanges)
-        assertEquals("It was so cosy.", mapped.translationHint)
+        val hint = assertNotNull(mapped.translationHint)
+        assertEquals("It was so cosy.", hint.text)
+        assertEquals(emptyList(), hint.answerRanges)
         assertNotNull(mapped.back.cloze)
         assertEquals("gezellig", mapped.back.headline)
+    }
+
+    @Test
+    fun translationClozeCardExposesSourceExampleAsClozeHint() {
+        val sessionCard = sessionCard(
+            variant = CardVariant(CardKind.CLOZE_TRANSLATION, targetLang = Language.ENGLISH.code),
+            example = ExamplePair(
+                exampleIndex = 0,
+                text = "It was so cosy.",
+                clozeRanges = listOf(10..13),
+            ),
+        )
+
+        val mapped = assertIs<StudyCardUiState.Cloze>(sessionCard.toStudyCardUiState())
+
+        val hint = assertNotNull(mapped.translationHint)
+        assertEquals("Het was zo gezellig.", hint.text)
+        assertEquals(listOf(11..18), hint.answerRanges)
     }
 
     @Test


### PR DESCRIPTION
## Contributor terms

- [x] I have read and agree to the contributor terms in `CONTRIBUTING.md`.
- [x] I have the right to submit these changes under those terms.

## Summary

The "Recall EN" cloze card (`CLOZE_TRANSLATION`) shows the target-language sentence with the answer word revealed and asks the user to recall the source-language word. Until now this card had no hint affordance — unlike `CLOZE_SOURCE`, which has had a translation hint pill.

This PR:

- Adds a hint to `CLOZE_TRANSLATION` cards. When revealed, the hint shows the source-language version of the example sentence with the answer word **blanked out** (cloze styling), matching the main prompt's look.
- Changes `Cloze.translationHint` from `String?` to `StudyClozeTextUiState?` so the hint carries its own answer ranges.
- Replaces the previous `StudyExampleBlock`-with-bold rendering with a new `StudyTranslationHintBlock` that wraps `StudyClozeText` in the same left-bar frame.
- `CLOZE_SOURCE` hints now render with cloze blanking too when the underlying translation string contains `<w>` markers (real DB data does). When the translation has no `<w>` markers, it falls back to plain text — no visual regression.
- Fixes an incidental bug in `CLOZE_SOURCE` hint lookup: previously used `targetLangTranslations.values.firstOrNull()` (could pick a wrong language); now uses `targetLangTranslations[target]`.

## Testing

- `gradlew.bat :composeApp:desktopTest` — all green.
- Updated `mapsSourceClozeCard` assertion for the new `StudyClozeTextUiState` shape.
- Added `translationClozeCardExposesSourceExampleAsClozeHint` covering the new code path: maps a CLOZE_TRANSLATION card and asserts the hint exposes the source example text with the `<w>`-derived answer range.

🤖 Generated with [Claude Code](https://claude.com/claude-code)