### PR TITLE
a few UI tweaks

### DIFF
--- a/composeApp/src/commonMain/composeResources/values-nl/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-nl/strings.xml
@@ -632,7 +632,7 @@
     <string name="study_chip_listen">Luisteren</string>
     <string name="study_prompt_recall_word">Bedenk het woord</string>
     <string name="study_prompt_translate_to">Vertaal naar %1$s</string>
-    <string name="study_chip_recall">Wat betekent %1$s?</string>
+    <string name="study_chip_recall">Herinner %1$s</string>
     <string name="guess_by_context">Raad op basis van de context</string>
     <string name="study_play_word_audio">Speel woord af</string>
     <string name="study_play_prompt_audio">Speel opdracht af</string>
@@ -640,7 +640,6 @@
     <string name="study_hint_show">Hint</string>
     <string name="study_hint_show_description">Toon eerste-letterhint</string>
     <string name="study_hint_show_translation_description">Toon vertaalhint</string>
-    <string name="study_listen_prompt">Tik om af te spelen. Welk woord hoor je?</string>
     <string name="study_cant_listen_now">Nu even niet luisteren</string>
     <string name="study_listening_postponed_message">Luisterkaarten uitgesteld tot je volgende herhaling</string>
     <plurals name="study_hint_starts_with">

--- a/composeApp/src/commonMain/composeResources/values-pl/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-pl/strings.xml
@@ -641,7 +641,6 @@
     <string name="study_hint_show">Podpowiedź</string>
     <string name="study_hint_show_description">Pokaż podpowiedź z pierwszą literą</string>
     <string name="study_hint_show_translation_description">Pokaż podpowiedź z tłumaczeniem</string>
-    <string name="study_listen_prompt">Dotknij, aby odtworzyć. Jakie słowo słyszysz?</string>
     <string name="study_cant_listen_now">Nie mogę teraz słuchać</string>
     <string name="study_listening_postponed_message">Karty ze słuchania odłożone do następnej powtórki</string>
     <plurals name="study_hint_starts_with">

--- a/composeApp/src/commonMain/composeResources/values-ru/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-ru/strings.xml
@@ -639,7 +639,6 @@
     <string name="study_hint_show">Подсказка</string>
     <string name="study_hint_show_description">Показать подсказку с первой буквой</string>
     <string name="study_hint_show_translation_description">Показать подсказку с переводом</string>
-    <string name="study_listen_prompt">Нажмите для воспроизведения. Какое слово вы слышите?</string>
     <string name="study_cant_listen_now">Не могу сейчас слушать</string>
     <string name="study_listening_postponed_message">Карточки на аудирование отложены до следующего повторения</string>
     <plurals name="study_hint_starts_with">

--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -645,7 +645,6 @@
         <item quantity="many">Hint: starts with %1$s, %2$d letters</item>
         <item quantity="other">Hint: starts with %1$s, %2$d letters</item>
     </plurals>
-    <string name="study_listen_prompt">Tap to play. What word do you hear?</string>
     <string name="study_cant_listen_now">Can&apos;t listen right now</string>
     <string name="study_listening_postponed_message">Listening cards paused until your next review</string>
     <string name="study_rating_prompt">How well did you remember this?</string>

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/study/StudySessionMapper.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/study/StudySessionMapper.kt
@@ -8,7 +8,6 @@ import com.slovy.slovymovyapp.data.learning.session.ExamplePair
 import com.slovy.slovymovyapp.data.learning.session.SessionCard
 import com.slovy.slovymovyapp.data.learning.session.SessionCardLoadState
 import com.slovy.slovymovyapp.data.remote.LanguageCardResponseSense
-import com.slovy.slovymovyapp.data.util.HtmlTagParser
 import com.slovy.slovymovyapp.data.util.parseClozeFromTaggedText
 import com.slovy.slovymovyapp.i18n.UiText
 import slovymovyapp.composeapp.generated.resources.*
@@ -152,11 +151,7 @@ fun SessionCard.toStudyCardUiState(): StudyCardUiState? {
                 id = card.id.toString(),
                 chipLabel = UiText.Resource(Res.string.study_chip_fill_in),
                 prompt = cloze,
-                translationHint = sense.examples
-                    .firstOrNull { HtmlTagParser.plainText(it.text) == example.text }
-                    ?.targetLangTranslations
-                    ?.get(target)
-                    ?.let { toTranslationHintCloze(it) },
+                firstLetterHint = cloze.firstAnswerText().firstLetterHint(),
                 senses = senses,
                 activeSenseId = sense.senseId,
                 back = activeBack,
@@ -351,6 +346,13 @@ private fun ExamplePair.toClozeText(): StudyClozeTextUiState? {
 private fun toTranslationHintCloze(text: String): StudyClozeTextUiState? {
     val parsed = parseClozeFromTaggedText(text) ?: return null
     return StudyClozeTextUiState(text = parsed.plainText, answerRanges = parsed.answerRanges)
+}
+
+private fun StudyClozeTextUiState.firstAnswerText(): String {
+    val range = answerRanges.firstOrNull() ?: return ""
+    val start = range.first.coerceIn(0, text.length)
+    val endExclusive = (range.last + 1).coerceIn(start, text.length)
+    return text.substring(start, endExclusive)
 }
 
 internal fun String.firstLetterHint(): FirstLetterHint? {

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/study/StudySessionModels.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/study/StudySessionModels.kt
@@ -90,6 +90,8 @@ sealed interface StudyCardUiState {
         override val id: String,
         override val chipLabel: UiText,
         val prompt: StudyClozeTextUiState,
+        val firstLetterHint: FirstLetterHint? = null,
+        val firstLetterHintRevealed: Boolean = false,
         val translationHint: StudyClozeTextUiState? = null,
         val translationHintRevealed: Boolean = false,
         override val senses: List<StudyCardSenseUiState> = emptyList(),

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/study/StudySessionScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/study/StudySessionScreen.kt
@@ -31,6 +31,7 @@ import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.selection.toggleable
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.animation.core.animateFloatAsState
@@ -137,7 +138,6 @@ import slovymovyapp.composeapp.generated.resources.study_error_title
 import slovymovyapp.composeapp.generated.resources.study_chip_fill_in
 import slovymovyapp.composeapp.generated.resources.study_chip_listen
 import slovymovyapp.composeapp.generated.resources.study_cant_listen_now
-import slovymovyapp.composeapp.generated.resources.study_listen_prompt
 import slovymovyapp.composeapp.generated.resources.study_listening_postponed_message
 import slovymovyapp.composeapp.generated.resources.study_loading
 import slovymovyapp.composeapp.generated.resources.study_multi_sense_front_hint
@@ -163,6 +163,7 @@ import slovymovyapp.composeapp.generated.resources.study_tap_to_check
 import slovymovyapp.composeapp.generated.resources.study_tap_to_flip
 
 private val MultiSenseFrontHintTopSpacing = 20.dp
+private val ListeningFrontStackGap = 28.dp
 
 @Composable
 fun StudySessionScreen(
@@ -849,8 +850,11 @@ private fun StudySessionOverflowSheet(
                         Switch(
                             checked = autoplayEnabled,
                             onCheckedChange = { onToggleAutoplay() },
+                            modifier = Modifier.clearAndSetSemantics {},
                         )
                     },
+                    role = Role.Switch,
+                    toggleValue = autoplayEnabled,
                     onClick = onToggleAutoplay,
                 )
                 StudyOverflowMenuItem(
@@ -931,6 +935,8 @@ private fun StudyOverflowMenuItem(
     supporting: String? = null,
     trailing: (@Composable () -> Unit)? = null,
     destructive: Boolean = false,
+    role: Role = Role.Button,
+    toggleValue: Boolean? = null,
 ) {
     val contentColor = if (destructive) {
         MaterialTheme.colorScheme.error
@@ -942,39 +948,58 @@ private fun StudyOverflowMenuItem(
     } else {
         MaterialTheme.colorScheme.onSurfaceVariant
     }
+    val itemModifier = Modifier
+        .fillMaxWidth()
+        .heightIn(min = 56.dp)
+        .padding(horizontal = AppSpacing.xl, vertical = AppSpacing.sm)
+
     Row(
-        modifier = Modifier
-            .fillMaxWidth()
-            .heightIn(min = 56.dp)
-            .clickable(role = Role.Button, onClick = onClick)
-            .padding(horizontal = AppSpacing.xl, vertical = AppSpacing.sm),
+        modifier = itemModifier,
         horizontalArrangement = Arrangement.spacedBy(AppSpacing.md),
         verticalAlignment = Alignment.CenterVertically,
     ) {
-        Box(
-            modifier = Modifier.size(24.dp),
-            contentAlignment = Alignment.Center,
+        Row(
+            modifier = Modifier
+                .weight(1f)
+                .let { base ->
+                    if (toggleValue != null) {
+                        base.toggleable(
+                            value = toggleValue,
+                            role = role,
+                            onValueChange = { onClick() },
+                        )
+                    } else {
+                        base.clickable(role = role, onClick = onClick)
+                    }
+                }
+                .padding(vertical = AppSpacing.xs),
+            horizontalArrangement = Arrangement.spacedBy(AppSpacing.md),
+            verticalAlignment = Alignment.CenterVertically,
         ) {
-            CompositionLocalProviderForIconTint(contentColor) {
-                icon()
+            Box(
+                modifier = Modifier.size(24.dp),
+                contentAlignment = Alignment.Center,
+            ) {
+                CompositionLocalProviderForIconTint(contentColor) {
+                    icon()
+                }
             }
-        }
-        Column(
-            modifier = Modifier.weight(1f),
-            verticalArrangement = Arrangement.spacedBy(2.dp),
-        ) {
-            Text(
-                text = label,
-                style = MaterialTheme.typography.bodyLarge,
-                fontWeight = FontWeight.Medium,
-                color = contentColor,
-            )
-            supporting?.let { text ->
+            Column(
+                verticalArrangement = Arrangement.spacedBy(2.dp),
+            ) {
                 Text(
-                    text = text,
-                    style = MaterialTheme.typography.bodySmall,
-                    color = supportingColor,
+                    text = label,
+                    style = MaterialTheme.typography.bodyLarge,
+                    fontWeight = FontWeight.Medium,
+                    color = contentColor,
                 )
+                supporting?.let { text ->
+                    Text(
+                        text = text,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = supportingColor,
+                    )
+                }
             }
         }
         trailing?.invoke()
@@ -1265,6 +1290,7 @@ private fun StudyCardFront(
 
         is StudyCardUiState.Cloze -> ClozeFront(
             card = card,
+            onRevealFirstLetterHint = onRevealFirstLetterHint,
             onRevealTranslationHint = onRevealTranslationHint,
             modifier = modifier,
         )
@@ -1381,6 +1407,7 @@ private fun ProductionFront(
 @Composable
 private fun ClozeFront(
     card: StudyCardUiState.Cloze,
+    onRevealFirstLetterHint: () -> Unit,
     onRevealTranslationHint: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -1404,6 +1431,14 @@ private fun ClozeFront(
                     fontFamily = MaterialTheme.serifFontFamily,
                 ),
             )
+            card.firstLetterHint?.let { hint ->
+                FirstLetterHintView(
+                    hint = hint,
+                    revealed = card.firstLetterHintRevealed,
+                    onReveal = onRevealFirstLetterHint,
+                    modifier = Modifier.align(Alignment.CenterHorizontally),
+                )
+            }
             card.translationHint?.let { hint ->
                 if (card.translationHintRevealed) {
                     StudyTranslationHintBlock(cloze = hint)
@@ -1435,7 +1470,7 @@ private fun ListeningFront(
     ) {
         Column(
             horizontalAlignment = Alignment.CenterHorizontally,
-            verticalArrangement = Arrangement.spacedBy(AppSpacing.xl),
+            verticalArrangement = Arrangement.spacedBy(ListeningFrontStackGap),
         ) {
             Surface(
                 modifier = Modifier
@@ -1468,24 +1503,7 @@ private fun ListeningFront(
                     }
                 }
             }
-            Column(
-                horizontalAlignment = Alignment.CenterHorizontally,
-                verticalArrangement = Arrangement.spacedBy(6.dp),
-            ) {
-                Text(
-                    text = stringResource(Res.string.study_listen_prompt),
-                    style = MaterialTheme.typography.bodySmall.copy(
-                        fontFamily = MaterialTheme.serifFontFamily,
-                        fontSize = 13.5.sp,
-                        fontWeight = FontWeight.Medium,
-                        fontStyle = FontStyle.Normal,
-                        lineHeight = 19.sp,
-                    ),
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    textAlign = TextAlign.Center,
-                )
-                ListeningMultiSenseByline(card = card)
-            }
+            ListeningMultiSenseByline(card = card)
             CantListenNowButton(onClick = onPostponeListeningCards)
         }
     }
@@ -1496,28 +1514,26 @@ private fun CantListenNowButton(
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    OutlinedButton(
-        onClick = onClick,
-        modifier = modifier,
-        shape = CircleShape,
-        colors = ButtonDefaults.outlinedButtonColors(
-            containerColor = Color.Transparent,
-            contentColor = MaterialTheme.colorScheme.onSurfaceVariant,
-        ),
-        border = BorderStroke(1.dp, MaterialTheme.colorScheme.onSurface.copy(alpha = 0.18f)),
-        contentPadding = PaddingValues(horizontal = 18.dp, vertical = 10.dp),
+    Row(
+        modifier = modifier
+            .clip(RoundedCornerShape(6.dp))
+            .clickable(role = Role.Button, onClick = onClick)
+            .padding(horizontal = 10.dp, vertical = 6.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(5.dp),
     ) {
         Icon(
             imageVector = SpeakerOffVector,
             contentDescription = null,
             modifier = Modifier.size(15.dp),
+            tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f),
         )
-        Spacer(Modifier.width(8.dp))
         Text(
             text = stringResource(Res.string.study_cant_listen_now),
             fontSize = 13.sp,
             fontWeight = FontWeight.Medium,
-            letterSpacing = 0.1.sp,
+            letterSpacing = 0.sp,
+            color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f),
         )
     }
 }
@@ -2335,10 +2351,7 @@ private fun clozeCard() = StudyCardUiState.Cloze(
         text = "Het was zo gezellig bij jullie thuis.",
         answerRanges = listOf(11..18),
     ),
-    translationHint = StudyClozeTextUiState(
-        text = "It was so lovely at your place.",
-        answerRanges = listOf(10..15),
-    ),
+    firstLetterHint = FirstLetterHint(letter = 'g', letterCount = 8, dotCount = 7),
     back = StudyCardBackUiState(
         headline = "gezellig",
         secondary = "cosy, sociable",
@@ -2617,7 +2630,7 @@ private fun StudySessionClozeFrontHintRevealedPreview(
     ThemedPreview(darkTheme = isDark) {
         StudySessionScreenContent(
             state = activeState(
-                clozeCard().copy(translationHintRevealed = true),
+                clozeCard().copy(firstLetterHintRevealed = true),
                 StudyCardSide.FRONT,
                 current = 6,
             ),

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/study/StudySessionScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/study/StudySessionScreen.kt
@@ -951,6 +951,17 @@ private fun StudyOverflowMenuItem(
     val itemModifier = Modifier
         .fillMaxWidth()
         .heightIn(min = 56.dp)
+        .let { base ->
+            if (toggleValue != null) {
+                base.toggleable(
+                    value = toggleValue,
+                    role = role,
+                    onValueChange = { onClick() },
+                )
+            } else {
+                base.clickable(role = role, onClick = onClick)
+            }
+        }
         .padding(horizontal = AppSpacing.xl, vertical = AppSpacing.sm)
 
     Row(
@@ -961,17 +972,6 @@ private fun StudyOverflowMenuItem(
         Row(
             modifier = Modifier
                 .weight(1f)
-                .let { base ->
-                    if (toggleValue != null) {
-                        base.toggleable(
-                            value = toggleValue,
-                            role = role,
-                            onValueChange = { onClick() },
-                        )
-                    } else {
-                        base.clickable(role = role, onClick = onClick)
-                    }
-                }
                 .padding(vertical = AppSpacing.xs),
             horizontalArrangement = Arrangement.spacedBy(AppSpacing.md),
             verticalAlignment = Alignment.CenterVertically,

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/study/StudySessionViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/study/StudySessionViewModel.kt
@@ -401,13 +401,22 @@ class StudySessionViewModel(
     fun revealFirstLetterHint() {
         val active = state as? StudySessionUiState.Active ?: return
         if (active.side != StudyCardSide.FRONT) return
-        val production = active.card as? StudyCardUiState.Production ?: return
-        if (production.firstLetterHint == null || production.firstLetterHintRevealed) return
+        val updatedCard = when (val card = active.card) {
+            is StudyCardUiState.Production -> {
+                if (card.firstLetterHint == null || card.firstLetterHintRevealed) return
+                card.copy(firstLetterHintRevealed = true)
+            }
 
-        state = active.copy(
-            card = production.copy(firstLetterHintRevealed = true),
-        )
-        logHintRevealed(production.id, production.back.headline, hintKind = "first_letter")
+            is StudyCardUiState.Cloze -> {
+                if (card.firstLetterHint == null || card.firstLetterHintRevealed) return
+                card.copy(firstLetterHintRevealed = true)
+            }
+
+            else -> return
+        }
+
+        state = active.copy(card = updatedCard)
+        logHintRevealed(updatedCard.id, updatedCard.back.headline, hintKind = "first_letter")
     }
 
     fun revealTranslationHint() {

--- a/composeApp/src/commonTest/kotlin/com/slovy/slovymovyapp/ui/study/StudySessionMapperTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/slovy/slovymovyapp/ui/study/StudySessionMapperTest.kt
@@ -21,6 +21,7 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
 import kotlin.test.assertNotNull
+import kotlin.test.assertNull
 import kotlin.uuid.Uuid
 
 private const val PrimarySenseId = "00000000-0000-0000-0000-000000000101"
@@ -208,9 +209,11 @@ class StudySessionMapperTest {
 
         assertEquals("Het was zo gezellig.", mapped.prompt.text)
         assertEquals(listOf(11..18), mapped.prompt.answerRanges)
-        val hint = assertNotNull(mapped.translationHint)
-        assertEquals("It was so cosy.", hint.text)
-        assertEquals(emptyList(), hint.answerRanges)
+        val hint = assertNotNull(mapped.firstLetterHint)
+        assertEquals('g', hint.letter)
+        assertEquals(8, hint.letterCount)
+        assertEquals(7, hint.dotCount)
+        assertNull(mapped.translationHint)
         assertNotNull(mapped.back.cloze)
         assertEquals("gezellig", mapped.back.headline)
     }
@@ -248,6 +251,10 @@ class StudySessionMapperTest {
 
         assertEquals("Vergeet niet om je paspoort mee te nemen.", mapped.prompt.text)
         assertEquals(listOf(28..30, 35..39), mapped.prompt.answerRanges)
+        val hint = assertNotNull(mapped.firstLetterHint)
+        assertEquals('m', hint.letter)
+        assertEquals(3, hint.letterCount)
+        assertEquals(2, hint.dotCount)
         assertNotNull(mapped.back.cloze)
         assertEquals(listOf(28..30, 35..39), mapped.back.cloze.answerRanges)
     }


### PR DESCRIPTION
Summary of changes:

- Source cloze cards now show a first-letter hint instead of the English translation sentence.
- Cloze first-letter hints are derived from the first hidden answer range and covered by tests.
- Listening card front was simplified:
    - removed the “Tap to play…” prompt
    - kept only the conditional multi-sense byline
    - changed the “Can’t listen right now” action from an outlined pill to a subtle text-link style
    - used a named ListeningFrontStackGap
- Autoplay in the overflow menu was improved:
    - switch remains draggable/tappable
    - label/icon area is also a large toggle target
    - duplicate accessibility semantics removed from the visual switch
- Removed unused study_listen_prompt resources from all locale files.
- Updated Dutch recall chip from Wat betekent %1$s? to Herinner %1$s.
- Removed stale unused HtmlTagParser import.