### PR TITLE
Localize list title/subtitle/labels by UI locale

### DIFF
--- a/server/src/main/kotlin/com/slovy/slovymovyapp/server/lists/LanguageListsLoader.kt
+++ b/server/src/main/kotlin/com/slovy/slovymovyapp/server/lists/LanguageListsLoader.kt
@@ -15,6 +15,9 @@ private val log = LoggerFactory.getLogger("LanguageListsLoader")
 
 private val json = Json { ignoreUnknownKeys = true }
 
+/** UI locale every list should provide; clients fall back to it for unknown locales. */
+private const val BASE_LOCALE = "en"
+
 private val ICON_EXTENSIONS = mapOf(
     "svg" to "image/svg+xml",
     "png" to "image/png",
@@ -78,6 +81,12 @@ class LanguageListsLoader {
         val iconPayload = raw.icon?.let { iconsByName[it] }
         if (raw.icon != null && iconPayload == null) {
             log.warn("List '{}' in lists/{}/ references missing icon '{}'", id, lang, raw.icon)
+        }
+        if (!raw.title.containsKey(BASE_LOCALE) || !raw.subtitle.containsKey(BASE_LOCALE)) {
+            log.warn(
+                "List '{}' in lists/{}/ is missing the '{}' base locale for title/subtitle; clients fall back to it",
+                id, lang, BASE_LOCALE,
+            )
         }
         return ListContent(
             id = id,

--- a/server/src/main/kotlin/com/slovy/slovymovyapp/server/lists/LanguageListsModels.kt
+++ b/server/src/main/kotlin/com/slovy/slovymovyapp/server/lists/LanguageListsModels.kt
@@ -2,11 +2,17 @@ package com.slovy.slovymovyapp.server.lists
 
 import kotlinx.serialization.Serializable
 
+/**
+ * On-disk shape. [title], [subtitle], and [labels] are keyed by UI locale code
+ * (e.g. "en", "ru") so the same list renders in the user's interface language,
+ * independently of the studied language in the folder path. The client resolves
+ * the active locale with an "en" fallback, so every list should provide "en".
+ */
 @Serializable
 internal data class RawListFile(
-    val title: String,
-    val subtitle: String,
-    val labels: List<String> = emptyList(),
+    val title: Map<String, String>,
+    val subtitle: Map<String, String>,
+    val labels: Map<String, List<String>> = emptyMap(),
     val icon: String? = null,
     val senseIds: List<String> = emptyList(),
 )
@@ -17,12 +23,17 @@ data class IconPayload(
     val data: String,
 )
 
+/**
+ * Wire shape. [title], [subtitle], and [labels] carry every available UI locale;
+ * resolution is left to the client (it picks the active UI locale with an "en"
+ * fallback) so the server cache and version SHA stay locale-independent.
+ */
 @Serializable
 data class ListContent(
     val id: String,
-    val title: String,
-    val subtitle: String,
-    val labels: List<String>,
+    val title: Map<String, String>,
+    val subtitle: Map<String, String>,
+    val labels: Map<String, List<String>>,
     val icon: IconPayload?,
     val senseIds: List<String>,
 )

--- a/server/src/test/kotlin/com/slovy/slovymovyapp/server/lists/LanguageListsLoaderTest.kt
+++ b/server/src/test/kotlin/com/slovy/slovymovyapp/server/lists/LanguageListsLoaderTest.kt
@@ -40,7 +40,9 @@ class LanguageListsLoaderTest {
         )
         bundle.lists.forEach { list ->
             assertTrue(list.id.isNotBlank(), "List id must not be blank")
-            assertTrue(list.title.isNotBlank(), "List '${list.id}' title must not be blank")
+            val enTitle = list.title["en"]
+            assertNotNull(enTitle, "List '${list.id}' must provide an 'en' title")
+            assertTrue(enTitle.isNotBlank(), "List '${list.id}' 'en' title must not be blank")
             list.icon?.let { icon ->
                 assertNotNull(icon.mimeType, "Icon for '${list.id}' must have mimeType")
                 assertTrue(icon.data.isNotBlank(), "Icon for '${list.id}' must have base64 data")


### PR DESCRIPTION
## Summary

Localizes the per-language word lists' display metadata (`title`, `subtitle`, `labels`) so it renders in the user's **UI locale** rather than the studied language in the `lists/{lang}/` path. A Russian user studying English should see Russian list titles.

These fields become locale maps on both shapes:
- `RawListFile` (on-disk JSON parsed from GitHub): `title`/`subtitle` are `Map<String, String>`, `labels` is `Map<String, List<String>>`.
- `ListContent` (wire): same maps, returned **untouched**.

The server deliberately does **not** resolve a locale. Returning the full maps keeps the bundle — and its tree-SHA `version` — locale-independent, so caching stays keyed only by studied language and the version endpoint never disagrees with a download. The client resolves the active UI locale at the ViewModel/state boundary with an `en` fallback.

The loader logs a warning when a list omits the `en` base locale for title/subtitle, since clients rely on it as the fallback.

## Scope

Server-side only, per request. Client (iOS/Android) consumption is out of scope. Labels are treated as free editorial text (not a controlled vocabulary).

## On-disk JSON shape

```json
{
  "title": { "en": "A1 basics", "ru": "База A1" },
  "subtitle": { "en": "First 200 everyday words", "ru": "Первые 200 слов" },
  "labels": { "en": ["beginner", "core"], "ru": ["начальный", "основное"] },
  "icon": "a1-basics.svg",
  "senseIds": ["..."]
}
```

## Test plan

- [x] `:server:compileTestKotlin` passes.
- [x] Updated `LanguageListsLoaderTest` to assert each list provides a non-blank `en` title.
- Loader/route tests run against real GitHub when `ACCESS_TO_GH_TOKEN` / `.github_key` is set.

> Note: editorial list JSONs on `slovymovy/words` must now provide the `en` key; a missing base locale logs a warning rather than failing ingestion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
