### PR TITLE
Add "Suggest a list" + list analytics + Search empty-state loading gate

### DIFF
--- a/composeApp/src/commonMain/composeResources/values-nl/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-nl/strings.xml
@@ -25,6 +25,9 @@
     <string name="search_section_recently_saved">Onlangs opgeslagen</string>
     <string name="search_section_lists_for_you">Klaar om te leren</string>
     <string name="search_empty_start_typing">Begin met typen om te zoeken</string>
+    <string name="search_suggest_list_button">Stel een lijst voor</string>
+    <string name="search_suggest_list_dialog_title">Stel een lijst voor</string>
+    <string name="search_suggest_list_placeholder">Beschrijf hier de woordenlijst die je graag zou willen zien...</string>
     <string name="search_no_dictionary_title">Geen woordenboek gedownload</string>
     <string name="search_no_dictionary_description">Download een woordenboek om te beginnen met zoeken</string>
     <string name="search_go_to_settings">Ga naar Instellingen</string>

--- a/composeApp/src/commonMain/composeResources/values-pl/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-pl/strings.xml
@@ -25,6 +25,9 @@
     <string name="search_section_recently_saved">Ostatnio zapisane</string>
     <string name="search_section_lists_for_you">Gotowe do nauki</string>
     <string name="search_empty_start_typing">Zacznij pisać, aby wyszukać</string>
+    <string name="search_suggest_list_button">Zaproponuj listę</string>
+    <string name="search_suggest_list_dialog_title">Zaproponuj listę</string>
+    <string name="search_suggest_list_placeholder">Opisz tutaj listę słów, którą chcesz zobaczyć...</string>
     <string name="search_no_dictionary_title">Brak pobranego słownika</string>
     <string name="search_no_dictionary_description">Pobierz słownik, aby zacząć szukać słów</string>
     <string name="search_go_to_settings">Przejdź do ustawień</string>

--- a/composeApp/src/commonMain/composeResources/values-ru/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-ru/strings.xml
@@ -25,6 +25,9 @@
     <string name="search_section_recently_saved">Недавно сохраненные</string>
     <string name="search_section_lists_for_you">Учите прямо сейчас</string>
     <string name="search_empty_start_typing">Введите слово для поиска</string>
+    <string name="search_suggest_list_button">Предложить список</string>
+    <string name="search_suggest_list_dialog_title">Предложить список</string>
+    <string name="search_suggest_list_placeholder">Опишите список слов, который вы хотели бы здесь увидеть...</string>
     <string name="search_no_dictionary_title">Словарь не скачан</string>
     <string name="search_no_dictionary_description">Скачайте словарь, чтобы начать поиск слов</string>
     <string name="search_go_to_settings">Перейти в настройки</string>

--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -25,6 +25,9 @@
     <string name="search_section_recently_saved">Recently saved</string>
     <string name="search_section_lists_for_you">Ready to Learn</string>
     <string name="search_empty_start_typing">Start typing to search</string>
+    <string name="search_suggest_list_button">Suggest a list</string>
+    <string name="search_suggest_list_dialog_title">Suggest a list</string>
+    <string name="search_suggest_list_placeholder">Describe the word list you'd like to see here...</string>
     <string name="search_no_dictionary_title">No dictionary downloaded</string>
     <string name="search_no_dictionary_description">Download a dictionary to start searching for words</string>
     <string name="search_go_to_settings">Go to Settings</string>

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/App.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/App.kt
@@ -821,6 +821,10 @@ fun App(
                         onListClick = { list ->
                             val lang = viewModel.state.selectedLanguage
                             if (lang != null) {
+                                logEvent(
+                                    AnalyticsEvent.LIST_CARD_CLICK,
+                                    mapOf("lang" to lang.code, "list_id" to list.id)
+                                )
                                 navController.navigate(AppDestination.ListDetail(lang.code, list.id))
                             }
                         },

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/App.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/App.kt
@@ -773,7 +773,7 @@ fun App(
                     val viewModel = viewModel(
                         viewModelStoreOwner = backStackEntry
                     ) {
-                        SearchViewModel(dictionaryRepository, settingsRepository, listsService)
+                        SearchViewModel(dictionaryRepository, settingsRepository, listsService, dictionaryClient)
                     }
 
                     LaunchedEffect(pendingSearchQuery) {

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/analytics/Analytics.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/analytics/Analytics.kt
@@ -41,7 +41,10 @@ enum class AnalyticsEvent {
     TTS_PLAY_FAILED,
     SETTING_CHANGED,
     REVIEW_APP_CLICK,
-    LANGUAGE_REQUEST_OPEN
+    LANGUAGE_REQUEST_OPEN,
+    LIST_CARD_CLICK,
+    LIST_ADD_ALL,
+    LIST_REMOVE_ALL
 }
 
 expect object Analytics {

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/data/remote/DictionaryClient.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/data/remote/DictionaryClient.kt
@@ -586,6 +586,48 @@ class DictionaryClient(
         }
     }
 
+    suspend fun sendListSuggestion(
+        language: Language,
+        comment: String,
+        email: String? = null
+    ): FeedbackResponse {
+        val url = "$serverBaseUrl/list-suggestion/${language.code}"
+
+        try {
+            val response = httpClient.post(url) {
+                contentType(ContentType.Application.Json)
+                val trimmedEmail = email?.trim()?.takeIf { it.isNotBlank() }
+                setBody(
+                    json.encodeToString(
+                        FeedbackRequest.serializer(),
+                        FeedbackRequest(comment.trim(), trimmedEmail)
+                    )
+                )
+            }
+
+            if (!response.status.isSuccess()) {
+                val body = response.bodyAsText()
+                throw DictionaryClientException.ServerException(response.status.value, body)
+            }
+
+            val body = response.bodyAsText()
+            return json.decodeFromString(FeedbackResponse.serializer(), body)
+        } catch (e: CancellationException) {
+            AppLogger.warn(TAG, "sendListSuggestion cancelled for ${language.code}", e)
+            throw e
+        } catch (e: Exception) {
+            if (e is DictionaryClientException) {
+                AppLogger.error(TAG, "sendListSuggestion failed for ${language.code}", e)
+                throw e
+            }
+            AppLogger.error(TAG, "sendListSuggestion failed for ${language.code}", e)
+            throw DictionaryClientException.NetworkException(
+                NetworkErrorClassifier.userMessage(e),
+                e
+            )
+        }
+    }
+
     suspend fun sendGeneralFeedback(
         comment: String,
         email: String? = null

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/ListDetailScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/ListDetailScreen.kt
@@ -40,6 +40,8 @@ import androidx.lifecycle.viewModelScope
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.withStyle
+import com.slovy.slovymovyapp.analytics.Analytics
+import com.slovy.slovymovyapp.analytics.AnalyticsEvent
 import com.slovy.slovymovyapp.data.Language
 import com.slovy.slovymovyapp.data.favorites.FavoritesRepository
 import com.slovy.slovymovyapp.data.favorites.NewFavorite
@@ -257,6 +259,10 @@ class ListDetailViewModel(
         if (state.isLoading || state.bulkActionInProgress) return
         val toAdd = state.items.filter { !it.isFavorited }
         if (toAdd.isEmpty()) return
+        Analytics.logEvent(
+            AnalyticsEvent.LIST_ADD_ALL,
+            mapOf("lang" to language.code, "list_id" to listId)
+        )
         state = state.copy(bulkActionInProgress = true)
         viewModelScope.launch {
             favoritesRepository.addAll(language, toAdd.map { NewFavorite(senseId = it.senseId, lemma = it.lemma) })
@@ -276,6 +282,10 @@ class ListDetailViewModel(
             favorited
         }
         if (targets.isEmpty()) return
+        Analytics.logEvent(
+            AnalyticsEvent.LIST_REMOVE_ALL,
+            mapOf("lang" to language.code, "list_id" to listId)
+        )
         state = state.copy(bulkActionInProgress = true)
         viewModelScope.launch {
             favoritesRepository.removeAll(targets.map { it.senseId }, language)

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/SearchScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/SearchScreen.kt
@@ -16,6 +16,7 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Flag
 import androidx.compose.material.icons.filled.Favorite
 import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material.icons.filled.Settings
@@ -55,7 +56,9 @@ import com.slovy.slovymovyapp.analytics.PerformanceMonitoring
 import com.slovy.slovymovyapp.analytics.putAttributes
 import com.slovy.slovymovyapp.analytics.useWithResult
 import com.slovy.slovymovyapp.data.Language
+import com.slovy.slovymovyapp.data.remote.DictionaryClient
 import com.slovy.slovymovyapp.data.remote.DictionaryRepository
+import com.slovy.slovymovyapp.data.remote.NetworkErrorClassifier
 import com.slovy.slovymovyapp.data.settings.Setting
 import com.slovy.slovymovyapp.data.settings.SettingsRepository
 import kotlinx.serialization.json.JsonPrimitive
@@ -70,6 +73,7 @@ import com.slovy.slovymovyapp.ui.theme.LocalIsDarkTheme
 import com.slovy.slovymovyapp.ui.theme.serifFontFamily
 import com.slovy.slovymovyapp.ui.word.Badge
 import com.slovy.slovymovyapp.ui.word.colorForLemma
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.*
@@ -92,13 +96,20 @@ data class SearchUiState(
     val isSuggestionsRefreshing: Boolean = false,
     val wordSuggestions: List<String> = emptyList(),
     val favoriteLemmas: List<String> = emptyList(),
-    val curatedLists: List<WordList> = emptyList()
+    val curatedLists: List<WordList> = emptyList(),
+    val listSuggestionDialogVisible: Boolean = false,
+    val listSuggestionComment: String = "",
+    val listSuggestionEmail: String = "",
+    val listSuggestionSubmitting: Boolean = false,
+    val listSuggestionError: String? = null,
+    val listSuggestionIssueUrl: String? = null
 )
 
 class SearchViewModel(
     private val repository: DictionaryRepository,
     private val settingsRepository: SettingsRepository,
     private val listsService: ListsService,
+    private val dictionaryClient: DictionaryClient,
 ) : ViewModel() {
 
     data class Search(
@@ -249,6 +260,67 @@ class SearchViewModel(
                 if (state.selectedLanguage == language) {
                     state = state.copy(curatedLists = updated)
                 }
+            }
+        }
+    }
+
+    fun openListSuggestionDialog() {
+        state = state.copy(
+            listSuggestionDialogVisible = true,
+            listSuggestionComment = "",
+            listSuggestionEmail = "",
+            listSuggestionSubmitting = false,
+            listSuggestionError = null,
+            listSuggestionIssueUrl = null
+        )
+    }
+
+    fun dismissListSuggestionDialog() {
+        if (state.listSuggestionSubmitting) return
+        state = state.copy(
+            listSuggestionDialogVisible = false,
+            listSuggestionComment = "",
+            listSuggestionEmail = "",
+            listSuggestionError = null,
+            listSuggestionIssueUrl = null
+        )
+    }
+
+    fun updateListSuggestionComment(comment: String) {
+        state = state.copy(listSuggestionComment = comment, listSuggestionError = null)
+    }
+
+    fun updateListSuggestionEmail(email: String) {
+        state = state.copy(listSuggestionEmail = email)
+    }
+
+    fun submitListSuggestion() {
+        if (state.listSuggestionSubmitting) return
+        val language = state.selectedLanguage ?: return
+
+        val comment = state.listSuggestionComment.trim()
+        if (comment.isBlank()) return
+
+        state = state.copy(listSuggestionSubmitting = true, listSuggestionError = null)
+        viewModelScope.launch {
+            try {
+                val response = dictionaryClient.sendListSuggestion(
+                    language = language,
+                    comment = comment,
+                    email = state.listSuggestionEmail.trim().takeIf { it.isNotBlank() }
+                )
+                state = state.copy(
+                    listSuggestionSubmitting = false,
+                    listSuggestionError = null,
+                    listSuggestionIssueUrl = response.issueUrl
+                )
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                state = state.copy(
+                    listSuggestionSubmitting = false,
+                    listSuggestionError = NetworkErrorClassifier.userMessage(e)
+                )
             }
         }
     }
@@ -407,6 +479,11 @@ fun SearchScreen(
         onSetLanguageDropdownExpanded = { viewModel.setLanguageDropdownExpanded(it) },
         onRefreshSuggestions = { viewModel.refreshSuggestionsFromPull() },
         onListClick = onListClick,
+        onSuggestListClick = { viewModel.openListSuggestionDialog() },
+        onListSuggestionCommentChange = { viewModel.updateListSuggestionComment(it) },
+        onListSuggestionEmailChange = { viewModel.updateListSuggestionEmail(it) },
+        onDismissListSuggestion = { viewModel.dismissListSuggestionDialog() },
+        onSubmitListSuggestion = { viewModel.submitListSuggestion() },
         onNavigateToFavorites = onNavigateToFavorites,
         onNavigateToStats = onNavigateToStats,
         onNavigateToSettings = onNavigateToSettings,
@@ -426,6 +503,11 @@ fun SearchScreenContent(
     onSetLanguageDropdownExpanded: (Boolean) -> Unit = {},
     onRefreshSuggestions: () -> Unit = {},
     onListClick: (WordList) -> Unit = {},
+    onSuggestListClick: () -> Unit = {},
+    onListSuggestionCommentChange: (String) -> Unit = {},
+    onListSuggestionEmailChange: (String) -> Unit = {},
+    onDismissListSuggestion: () -> Unit = {},
+    onSubmitListSuggestion: () -> Unit = {},
     onNavigateToFavorites: () -> Unit = {},
     onNavigateToStats: () -> Unit = {},
     onNavigateToSettings: () -> Unit = {},
@@ -561,7 +643,8 @@ fun SearchScreenContent(
                                     favoriteLemmas = state.favoriteLemmas,
                                     curatedLists = state.curatedLists,
                                     onWordClick = onSuggestionSelected,
-                                    onListClick = onListClick
+                                    onListClick = onListClick,
+                                    onSuggestListClick = onSuggestListClick
                                 )
                             }
                         }
@@ -590,6 +673,25 @@ fun SearchScreenContent(
                 }
             }
         }
+
+    if (state.listSuggestionDialogVisible) {
+        FeedbackDialog(
+            title = stringResource(Res.string.search_suggest_list_dialog_title),
+            commentPlaceholder = stringResource(Res.string.search_suggest_list_placeholder),
+            commentLabel = stringResource(Res.string.feedback_dialog_comment_label),
+            successCopy = null,
+            allowDismissWhileSending = false,
+            comment = state.listSuggestionComment,
+            email = state.listSuggestionEmail,
+            isSending = state.listSuggestionSubmitting,
+            error = state.listSuggestionError,
+            resultUrl = state.listSuggestionIssueUrl,
+            onCommentChange = onListSuggestionCommentChange,
+            onEmailChange = onListSuggestionEmailChange,
+            onDismiss = onDismissListSuggestion,
+            onSend = onSubmitListSuggestion
+        )
+    }
 }
 
 @Composable
@@ -668,7 +770,8 @@ private fun EmptySearchState(
     favoriteLemmas: List<String>,
     curatedLists: List<WordList>,
     onWordClick: (String) -> Unit,
-    onListClick: (WordList) -> Unit
+    onListClick: (WordList) -> Unit,
+    onSuggestListClick: () -> Unit
 ) {
     val isDark = LocalIsDarkTheme.current
     Column(
@@ -745,6 +848,26 @@ private fun EmptySearchState(
                     featured = index == 0,
                     isDark = isDark,
                     onClick = { onListClick(list) }
+                )
+            }
+            TextButton(
+                onClick = onSuggestListClick,
+                modifier = Modifier
+                    .align(Alignment.CenterHorizontally)
+                    .padding(top = 4.dp),
+                colors = ButtonDefaults.textButtonColors(
+                    contentColor = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            ) {
+                Icon(
+                    imageVector = Icons.Outlined.Flag,
+                    contentDescription = null,
+                    modifier = Modifier.size(18.dp)
+                )
+                Spacer(modifier = Modifier.width(6.dp))
+                Text(
+                    text = stringResource(Res.string.search_suggest_list_button),
+                    style = MaterialTheme.typography.bodyMedium
                 )
             }
         } else if (favoriteLemmas.isNotEmpty()) {

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/SearchScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/SearchScreen.kt
@@ -97,6 +97,9 @@ data class SearchUiState(
     val wordSuggestions: List<String> = emptyList(),
     val favoriteLemmas: List<String> = emptyList(),
     val curatedLists: List<WordList> = emptyList(),
+    // Gates the empty-state body so it renders once fully populated instead of flashing
+    // the favorites/"start typing" fallback before curated lists finish loading.
+    val isEmptyStateLoading: Boolean = false,
     val listSuggestionDialogVisible: Boolean = false,
     val listSuggestionComment: String = "",
     val listSuggestionEmail: String = "",
@@ -127,7 +130,8 @@ class SearchViewModel(
                 results = emptyList(),
                 showNoResults = false,
                 availableLanguages = installed,
-                selectedLanguage = installed.firstOrNull()
+                selectedLanguage = installed.firstOrNull(),
+                isEmptyStateLoading = installed.isNotEmpty()
             )
         }
     )
@@ -201,7 +205,11 @@ class SearchViewModel(
                 // This bypasses setSelectedLanguage (the preference must not be re-saved),
                 // so drop anything the screen-open refresh loaded for the pre-restore
                 // language and reload lists for the restored one.
-                state = state.copy(selectedLanguage = savedLang, curatedLists = emptyList())
+                state = state.copy(
+                    selectedLanguage = savedLang,
+                    curatedLists = emptyList(),
+                    isEmptyStateLoading = true
+                )
                 queryFlow.value = queryFlow.value.copy(language = savedLang)
                 refreshLists()
             }
@@ -253,13 +261,24 @@ class SearchViewModel(
             // Render suggestions for this language first, then lists below them.
             suggestionsLoadedForLanguage.first { it == language }
             if (state.selectedLanguage == language) {
-                state = state.copy(curatedLists = cached)
+                // Lift the loading gate as soon as we have cached lists so the empty
+                // state renders once, fully populated. With an empty cache (first launch)
+                // keep waiting through the server sync so the favorites/"start typing"
+                // fallback does not flash before lists arrive.
+                state = if (cached.isNotEmpty()) {
+                    state.copy(curatedLists = cached, isEmptyStateLoading = false)
+                } else {
+                    state.copy(curatedLists = cached)
+                }
             }
             if (listsService.sync(language)) {
                 val updated = listsService.getLists(language)
                 if (state.selectedLanguage == language) {
                     state = state.copy(curatedLists = updated)
                 }
+            }
+            if (state.selectedLanguage == language) {
+                state = state.copy(isEmptyStateLoading = false)
             }
         }
     }
@@ -362,7 +381,19 @@ class SearchViewModel(
         }
         val languageChanged = currentLanguage != target
         // Do not call setSelectedLanguage — that would overwrite the saved preference.
-        state = state.copy(availableLanguages = installed, selectedLanguage = target)
+        // On a language switch, drop the previous language's lists and re-gate so the
+        // empty state shows a spinner (not stale wrong-language lists) until the caller's
+        // refreshLists() repopulates. Safe because the only caller follows with refreshLists().
+        state = if (languageChanged) {
+            state.copy(
+                availableLanguages = installed,
+                selectedLanguage = target,
+                curatedLists = emptyList(),
+                isEmptyStateLoading = target != null
+            )
+        } else {
+            state.copy(availableLanguages = installed, selectedLanguage = target)
+        }
         queryFlow.value = queryFlow.value.copy(language = target)
         if (languageChanged) {
             viewModelScope.launch { loadSuggestionsForCurrentLanguage() }
@@ -396,7 +427,9 @@ class SearchViewModel(
         }
         // Load suggestions and lists for new language
         if (langChanged) {
-            state = state.copy(curatedLists = emptyList())
+            // No per-language lists in "All languages" mode, so don't gate on loading there
+            // (refreshLists/loadSuggestions early-return for a null language).
+            state = state.copy(curatedLists = emptyList(), isEmptyStateLoading = language != null)
             viewModelScope.launch { loadSuggestionsForCurrentLanguage() }
             refreshLists()
         }
@@ -642,6 +675,7 @@ fun SearchScreenContent(
                                     wordSuggestions = state.wordSuggestions,
                                     favoriteLemmas = state.favoriteLemmas,
                                     curatedLists = state.curatedLists,
+                                    isLoading = state.isEmptyStateLoading,
                                     onWordClick = onSuggestionSelected,
                                     onListClick = onListClick,
                                     onSuggestListClick = onSuggestListClick
@@ -769,10 +803,20 @@ private fun EmptySearchState(
     wordSuggestions: List<String>,
     favoriteLemmas: List<String>,
     curatedLists: List<WordList>,
+    isLoading: Boolean,
     onWordClick: (String) -> Unit,
     onListClick: (WordList) -> Unit,
     onSuggestListClick: () -> Unit
 ) {
+    if (isLoading) {
+        Box(
+            modifier = Modifier.fillMaxSize(),
+            contentAlignment = Alignment.Center
+        ) {
+            CircularProgressIndicator()
+        }
+        return
+    }
     val isDark = LocalIsDarkTheme.current
     Column(
         modifier = Modifier

--- a/server/src/main/kotlin/com/slovy/slovymovyapp/Application.kt
+++ b/server/src/main/kotlin/com/slovy/slovymovyapp/Application.kt
@@ -61,6 +61,19 @@ private data class FeedbackIssueResponse(
 )
 
 @Serializable
+private data class ListSuggestionRequest(
+    val comment: String,
+    val email: String? = null
+)
+
+@Serializable
+private data class ListSuggestionResponse(
+    val issueNumber: Int,
+    val issueTitle: String,
+    val issueUrl: String
+)
+
+@Serializable
 private data class GeneralFeedbackRequest(
     val comment: String,
     val email: String? = null
@@ -313,6 +326,61 @@ fun Application.module() {
                     e
                 )
                 call.respond(HttpStatusCode.InternalServerError, "Failed to create feedback discussion")
+            }
+        }
+
+        post("/list-suggestion/{lang}") {
+            val lang = call.parameters["lang"]?.trim()
+
+            if (lang.isNullOrBlank()) {
+                call.respond(HttpStatusCode.BadRequest, "Missing lang parameter")
+                return@post
+            }
+
+            if (!GitHubClient.isAvailable()) {
+                call.respond(HttpStatusCode.ServiceUnavailable, "GitHub token not configured")
+                return@post
+            }
+
+            val json = Json { ignoreUnknownKeys = true }
+            val suggestionRequest = try {
+                json.decodeFromString(
+                    ListSuggestionRequest.serializer(),
+                    call.receiveText()
+                )
+            } catch (_: Exception) {
+                call.respond(HttpStatusCode.BadRequest, "Invalid request body")
+                return@post
+            }
+
+            val comment = suggestionRequest.comment.trim()
+            if (comment.isBlank()) {
+                call.respond(HttpStatusCode.BadRequest, "Missing comment")
+                return@post
+            }
+
+            try {
+                val createdIssue = GitHubClient.createListSuggestionIssue(
+                    lang = lang,
+                    comment = comment,
+                    email = suggestionRequest.email
+                )
+                val response = ListSuggestionResponse(
+                    issueNumber = createdIssue.number,
+                    issueTitle = createdIssue.title,
+                    issueUrl = createdIssue.htmlUrl
+                )
+                call.respondText(
+                    text = json.encodeToString(ListSuggestionResponse.serializer(), response),
+                    contentType = ContentType.Application.Json,
+                    status = HttpStatusCode.Created
+                )
+            } catch (e: Exception) {
+                call.application.environment.log.error(
+                    "Failed to create list suggestion issue for $lang: ${e.message}",
+                    e
+                )
+                call.respond(HttpStatusCode.InternalServerError, "Failed to create list suggestion issue")
             }
         }
 

--- a/server/src/main/kotlin/com/slovy/slovymovyapp/server/github/GitHubClient.kt
+++ b/server/src/main/kotlin/com/slovy/slovymovyapp/server/github/GitHubClient.kt
@@ -34,6 +34,9 @@ object GitHubClient {
     private const val FEEDBACK_LABEL = "feedback"
     private const val FEEDBACK_LABEL_COLOR = "0E8A16"
     private const val FEEDBACK_LABEL_DESCRIPTION = "Feedback reported from application users"
+    private const val LIST_SUGGESTION_LABEL = "list-suggestion"
+    private const val LIST_SUGGESTION_LABEL_COLOR = "1D76DB"
+    private const val LIST_SUGGESTION_LABEL_DESCRIPTION = "Word list ideas suggested from application users"
 
     private const val GRAPHQL_ENDPOINT = "https://api.github.com/graphql"
     private const val FEEDBACK_DISCUSSION_CATEGORY = "Feedback"
@@ -392,6 +395,34 @@ object GitHubClient {
     }
 
     /**
+     * Creates a word-list suggestion issue in the words repository, tagged with the language,
+     * and applies the "list-suggestion" label.
+     */
+    fun createListSuggestionIssue(
+        lang: String,
+        comment: String,
+        email: String? = null
+    ): CreatedIssue {
+        val repository = client().getRepository("$REPO_OWNER/$REPO_NAME")
+        ensureListSuggestionLabelExists(repository)
+        val title = buildListSuggestionIssueTitle(lang = lang)
+        val body = buildListSuggestionIssueBody(
+            lang = lang,
+            comment = comment,
+            email = email
+        )
+        val issue = repository.createIssue(title)
+            .body(body)
+            .label(LIST_SUGGESTION_LABEL)
+            .create()
+        return CreatedIssue(
+            number = issue.number,
+            title = issue.title,
+            htmlUrl = issue.htmlUrl.toString()
+        )
+    }
+
+    /**
      * Closes an issue in the words repository.
      */
     fun closeIssue(issueNumber: Int) {
@@ -430,6 +461,29 @@ object GitHubClient {
         }
     }
 
+    internal fun buildListSuggestionIssueTitle(lang: String): String {
+        return "List suggestion: [$lang]"
+    }
+
+    internal fun buildListSuggestionIssueBody(
+        lang: String,
+        comment: String,
+        email: String? = null
+    ): String {
+        return buildString {
+            appendLine("Word list suggestion submitted from application.")
+            appendLine()
+            appendLine("- Language: `$lang`")
+            if (!email.isNullOrBlank()) {
+                val obfuscated = email.trim().replace("@", " [$lang] ")
+                appendLine("- Email: `$obfuscated`")
+            }
+            appendLine()
+            appendLine("Comment:")
+            appendLine(comment.trim())
+        }
+    }
+
     private fun normalizeTranslationCodes(translationCodes: List<String>): List<String> {
         return translationCodes
             .map { it.trim() }
@@ -445,6 +499,18 @@ object GitHubClient {
                 FEEDBACK_LABEL,
                 FEEDBACK_LABEL_COLOR,
                 FEEDBACK_LABEL_DESCRIPTION
+            )
+        }
+    }
+
+    private fun ensureListSuggestionLabelExists(repository: GHRepository) {
+        try {
+            repository.getLabel(LIST_SUGGESTION_LABEL)
+        } catch (_: GHFileNotFoundException) {
+            repository.createLabel(
+                LIST_SUGGESTION_LABEL,
+                LIST_SUGGESTION_LABEL_COLOR,
+                LIST_SUGGESTION_LABEL_DESCRIPTION
             )
         }
     }

--- a/server/src/test/kotlin/com/slovy/slovymovyapp/server/github/GitHubClientTest.kt
+++ b/server/src/test/kotlin/com/slovy/slovymovyapp/server/github/GitHubClientTest.kt
@@ -294,6 +294,54 @@ class GitHubClientTest {
     }
 
     @Test
+    fun buildListSuggestionIssueTitle_includesLanguage() {
+        val title = GitHubClient.buildListSuggestionIssueTitle("en")
+        assertEquals("List suggestion: [en]", title)
+    }
+
+    @Test
+    fun buildListSuggestionIssueBody_withEmail() {
+        val body = GitHubClient.buildListSuggestionIssueBody(
+            lang = "en",
+            comment = "A list of cooking verbs",
+            email = "user@example.com"
+        )
+        assertTrue(body.contains("Word list suggestion submitted from application."), "Body should contain header")
+        assertTrue(body.contains("- Language: `en`"), "Body should contain language line")
+        assertTrue(body.contains("A list of cooking verbs"), "Body should contain comment")
+        assertTrue(body.contains("[en]"), "Email should be obfuscated with [en]")
+        assertFalse(body.contains("@example"), "Email @ should be replaced")
+    }
+
+    @Test
+    fun buildListSuggestionIssueBody_withoutEmail() {
+        val body = GitHubClient.buildListSuggestionIssueBody(
+            lang = "ru",
+            comment = "Travel phrases",
+            email = null
+        )
+        assertTrue(body.contains("- Language: `ru`"), "Body should contain language line")
+        assertTrue(body.contains("Travel phrases"), "Body should contain comment")
+        assertFalse(body.contains("Email"), "Body should not contain Email line")
+    }
+
+    @Test
+    @Ignore("prevent repo pollution")
+    fun createListSuggestionIssue_createsAndReturns() {
+        if (!GitHubClient.isAvailable()) return
+
+        val issue = GitHubClient.createListSuggestionIssue(
+            lang = "en",
+            comment = "Integration test list suggestion - please ignore",
+            email = null
+        )
+
+        assertTrue(issue.number > 0, "Issue number should be positive")
+        assertTrue(issue.title.contains("[en]"), "Title should contain language")
+        assertTrue(issue.htmlUrl.contains("github.com"), "URL should be a GitHub URL")
+    }
+
+    @Test
     fun fileOperations_throwsForNonExistentFileOnBranch() {
         val testBranch = "test-${UUID.randomUUID()}"
 


### PR DESCRIPTION
## Summary

Three related changes to the curated word lists surface on the Search screen:

1. **Suggest a list** — adds a "Suggest a list" affordance at the bottom of the curated-lists section, reusing the existing `FeedbackDialog`. On submit it creates a labeled GitHub issue on `slovymovy/words` tagged with the current dictionary language, mirroring the word-detail "suggest a correction" flow.
2. **List analytics** — tracks previously-unlogged curated-list actions: `LIST_CARD_CLICK`, `LIST_ADD_ALL`, `LIST_REMOVE_ALL` (each with `lang` + `list_id`).
3. **Empty-state loading gate** — the Search landing assembled itself from three independently-arriving sources and flashed the favorites/"start typing" fallback before lists appeared. Adds an `isEmptyStateLoading` gate so it renders once, fully populated.

## Details

### Suggest a list
- **Server**: new `POST /list-suggestion/{lang}` route + `GitHubClient.createListSuggestionIssue` with a dedicated `list-suggestion` label and title/body builders. Path chosen to avoid overlap with `/feedback/{lang}/{word}`.
- **Client**: `DictionaryClient.sendListSuggestion`.
- **UI**: `SearchViewModel` state + handlers; suggest-list button styled to match word-detail (Flag icon, `bodyMedium`, `onSurfaceVariant`); `FeedbackDialog` wired in.
- **Localization**: en/nl/pl/ru.
- **Tests**: unit tests for the issue title/body builders.

### Loading gate
- Lifts the gate as soon as cached lists are read (common case → instant); with an empty cache keeps it up through the server sync so the fallback never flashes before lists arrive.
- Re-gates on first load and language change (including the `refreshLanguageIndicators` dictionary-change path), but not on screen re-open.
- "All languages" mode is never gated.

## ⚠️ Deploy note
The `/list-suggestion/{lang}` route requires a **server redeploy** to `backend.openwords.ai` before the in-app submit will work end-to-end.

## Testing
- `:composeApp:compileKotlinDesktop`, `:server:compileKotlin`, `:server:compileTestKotlin` pass.
- `:composeApp:verifyLocalizationKeys` passes.
- New `GitHubClientTest` builder tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)