### PR TITLE
Study back: localized prompt language + bilingual definition & cloze translation

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/study/StudySessionMapper.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/study/StudySessionMapper.kt
@@ -78,6 +78,7 @@ fun SessionCard.toStudyCardUiState(favoriteLemmas: Set<String>): StudyCardUiStat
                 back = StudyCardBackUiState(
                     headline = answer,
                     definition = definition,
+                    definitionTranslation = sense.senseDefinition.takeIf { it.isNotBlank() },
                     examples = sense.studyExamples(target),
                     synonyms = sense.toStudySynonyms(favoriteLemmas),
                     audioText = null,
@@ -125,7 +126,7 @@ fun SessionCard.toStudyCardUiState(favoriteLemmas: Set<String>): StudyCardUiStat
                 chipLabel = UiText.Plain("${target.studyCode()} -> ${sourceLanguage.studyCode()}"),
                 promptLabel = UiText.Resource(
                     Res.string.study_prompt_translate_to,
-                    listOf(sourceLanguage.englishName),
+                    listOf(sourceLanguage.selfName),
                 ),
                 promptText = cue,
                 firstLetterHint = lemma.firstLetterHint(),
@@ -143,11 +144,15 @@ fun SessionCard.toStudyCardUiState(favoriteLemmas: Set<String>): StudyCardUiStat
         CardKind.CLOZE_SOURCE -> {
             val target = targetLanguage ?: return null
             val cloze = example?.toClozeText() ?: return null
+            val clozeTranslation = sense.examples[example.exampleIndex.toInt()]
+                .targetLangTranslations[target]
+                ?.let { toTranslationHintCloze(it)?.copy(filled = true) }
             val activeBack = sourceClozeBack(
                 lemma = lemma,
                 sense = sense,
                 targetLanguage = target,
                 cloze = cloze.copy(filled = true),
+                clozeTranslation = clozeTranslation,
                 favoriteLemmas = favoriteLemmas,
             )
             val senses = studiedSenses.toSourceSenseUiStates(
@@ -266,6 +271,7 @@ private fun sourceBack(
         isLemmaHeadline = true,
         secondary = targetLanguage?.let { sense.translationWords(it) },
         definition = sense.senseDefinition,
+        definitionTranslation = targetLanguage?.let { sense.translationDef(it) },
         cloze = cloze,
         audioText = lemma,
         examples = sense.studyExamples(targetLanguage),
@@ -278,6 +284,7 @@ private fun sourceClozeBack(
     targetLanguage: Language?,
     favoriteLemmas: Set<String>,
     cloze: StudyClozeTextUiState? = null,
+    clozeTranslation: StudyClozeTextUiState? = null,
     examples: List<StudyExampleUiState> = emptyList(),
 ): StudyCardBackUiState =
     StudyCardBackUiState(
@@ -285,9 +292,11 @@ private fun sourceClozeBack(
         isLemmaHeadline = true,
         secondary = targetLanguage?.let { sense.translationWords(it) },
         definition = sense.senseDefinition,
+        definitionTranslation = targetLanguage?.let { sense.translationDef(it) },
         examples = examples,
         synonyms = sense.toStudySynonyms(favoriteLemmas),
         cloze = cloze,
+        clozeTranslation = clozeTranslation,
         audioText = lemma,
     )
 
@@ -321,6 +330,7 @@ private fun List<LanguageCardResponseSense>.toBilingualSenseUiStates(
             back = StudyCardBackUiState(
                 headline = answer,
                 definition = definition,
+                definitionTranslation = sense.senseDefinition.takeIf { it.isNotBlank() },
                 examples = sense.studyExamples(targetLanguage),
                 synonyms = sense.toStudySynonyms(favoriteLemmas),
                 audioText = null,

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/study/StudySessionModels.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/study/StudySessionModels.kt
@@ -118,9 +118,11 @@ data class StudyCardBackUiState(
     val isLemmaHeadline: Boolean = false,
     val secondary: String? = null,
     val definition: String? = null,
+    val definitionTranslation: String? = null,
     val examples: List<StudyExampleUiState> = emptyList(),
     val synonyms: List<StudySynonymUiState> = emptyList(),
     val cloze: StudyClozeTextUiState? = null,
+    val clozeTranslation: StudyClozeTextUiState? = null,
     val audioText: String? = headline,
 )
 

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/study/StudySessionScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/study/StudySessionScreen.kt
@@ -1511,13 +1511,17 @@ private fun StudyCardBackContent(
         verticalArrangement = Arrangement.spacedBy(AppSpacing.md),
     ) {
         back.cloze?.let { cloze ->
-            StudyClozeText(
-                cloze = cloze,
-                style = MaterialTheme.typography.headlineSmall.copy(
-                    fontFamily = MaterialTheme.serifFontFamily,
-                ),
-            )
-            Spacer(Modifier.height(AppSpacing.xs))
+            Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
+                StudyClozeText(
+                    cloze = cloze,
+                    style = MaterialTheme.typography.headlineSmall.copy(
+                        fontFamily = MaterialTheme.serifFontFamily,
+                    ),
+                )
+                back.clozeTranslation?.let { translation ->
+                    StudyClozeTranslationText(cloze = translation)
+                }
+            }
         }
 
         val headlineIsLemma = back.isLemmaHeadline
@@ -1564,13 +1568,22 @@ private fun StudyCardBackContent(
         }
 
         back.definition?.let { definition ->
-            StudyTaggedText(
-                text = definition,
-                style = MaterialTheme.typography.bodyLarge.copy(
-                    fontFamily = MaterialTheme.serifFontFamily,
-                ),
-                color = MaterialTheme.colorScheme.onSurface,
-            )
+            Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
+                StudyTaggedText(
+                    text = definition,
+                    style = MaterialTheme.typography.bodyLarge.copy(
+                        fontFamily = MaterialTheme.serifFontFamily,
+                    ),
+                    color = MaterialTheme.colorScheme.onSurface,
+                )
+                back.definitionTranslation?.let { translation ->
+                    StudyTaggedText(
+                        text = translation,
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            }
         }
 
         back.examples.forEach { example ->
@@ -1884,6 +1897,35 @@ internal fun StudyClozeTextUiState.toDisplayText(): StudyClozeDisplayText {
     return StudyClozeDisplayText(
         text = output.toString(),
         answerRanges = outputRanges,
+    )
+}
+
+@Composable
+private fun StudyClozeTranslationText(
+    cloze: StudyClozeTextUiState,
+    modifier: Modifier = Modifier,
+) {
+    val highlightColor = MaterialTheme.colorScheme.primary
+    val displayText = remember(cloze) { cloze.toDisplayText() }
+    val text = buildAnnotatedString {
+        var cursor = 0
+        displayText.answerRanges.forEach { range ->
+            append(displayText.text.substring(cursor, range.first))
+            pushStyle(SpanStyle(color = highlightColor, fontWeight = FontWeight.Medium))
+            append(displayText.text.substring(range.first, range.last + 1))
+            pop()
+            cursor = range.last + 1
+        }
+        append(displayText.text.substring(cursor))
+    }
+    Text(
+        text = text,
+        style = MaterialTheme.typography.bodyMedium.copy(
+            fontStyle = FontStyle.Italic,
+            lineHeight = MaterialTheme.typography.bodyMedium.lineHeight * 1.1f,
+        ),
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+        modifier = modifier,
     )
 }
 
@@ -2319,13 +2361,14 @@ private fun multiSenseRecognitionCard() = StudyCardUiState.Recognition(
 private fun productionCard() = StudyCardUiState.Production(
     id = "production",
     chipLabel = UiText.Plain("EN -> NL"),
-    promptLabel = UiText.Resource(Res.string.study_prompt_translate_to, listOf("Dutch")),
+    promptLabel = UiText.Resource(Res.string.study_prompt_translate_to, listOf("Nederlands")),
     promptText = "cosy, sociable",
     firstLetterHint = FirstLetterHint(letter = 'g', letterCount = 8, dotCount = 7),
     back = StudyCardBackUiState(
         headline = "gezellig",
         secondary = "cosy, sociable",
-        definition = "a uniquely Dutch flavour of warm conviviality",
+        definition = "een typisch Nederlandse vorm van warme gezelligheid",
+        definitionTranslation = "a uniquely Dutch flavour of warm conviviality",
         examples = listOf(
             StudyExampleUiState(
                 text = "Bij Marja is het altijd <w>gezellig</w>.",
@@ -2351,10 +2394,16 @@ private fun clozeCard() = StudyCardUiState.Cloze(
     back = StudyCardBackUiState(
         headline = "gezellig",
         secondary = "cosy, sociable",
-        definition = "a feeling of warmth and conviviality from being together",
+        definition = "een gevoel van warmte en gezelligheid van het samenzijn",
+        definitionTranslation = "a feeling of warmth and conviviality from being together",
         cloze = StudyClozeTextUiState(
             text = "Het was zo gezellig bij jullie thuis.",
             answerRanges = listOf(11..18),
+            filled = true,
+        ),
+        clozeTranslation = StudyClozeTextUiState(
+            text = "It was so lovely at your place.",
+            answerRanges = listOf(10..15),
             filled = true,
         ),
         synonyms = listOf(
@@ -2380,7 +2429,8 @@ private fun translationClozeCard() = StudyCardUiState.Cloze(
         headline = "gezellig",
         isLemmaHeadline = true,
         secondary = "cosy, sociable",
-        definition = "a feeling of warmth and conviviality from being together",
+        definition = "een gevoel van warmte en gezelligheid van het samenzijn",
+        definitionTranslation = "a feeling of warmth and conviviality from being together",
         examples = listOf(
             StudyExampleUiState(
                 text = "Het was zo gezellig bij jullie thuis.",

--- a/composeApp/src/commonTest/kotlin/com/slovy/slovymovyapp/ui/study/StudySessionMapperTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/slovy/slovymovyapp/ui/study/StudySessionMapperTest.kt
@@ -41,6 +41,7 @@ class StudySessionMapperTest {
         assertEquals(StudyRecognitionMode.BILINGUAL, mapped.mode)
         assertEquals("cosy, sociable", mapped.back.headline)
         assertEquals("a feeling of warmth", mapped.back.definition)
+        assertEquals("een gevoel van warmte", mapped.back.definitionTranslation)
         assertEquals("Het was zo <w>gezellig</w>.", mapped.back.examples.single().text)
         assertEquals("It was so cosy.", mapped.back.examples.single().translation)
     }
@@ -115,7 +116,7 @@ class StudySessionMapperTest {
         mapped.senses.forEach { senseUi ->
             assertEquals("gezellig", senseUi.back.headline)
         }
-        assertEquals("a feeling of warmth", mapped.senses.first().back.definition)
+        assertEquals("een gevoel van warmte", mapped.senses.first().back.definition)
         assertEquals("convivial gathering", mapped.senses.last().back.definition)
     }
 
@@ -130,7 +131,8 @@ class StudySessionMapperTest {
         assertEquals("gezellig", mapped.promptAudioText)
         assertEquals("gezellig", mapped.back.headline)
         assertEquals("cosy, sociable", mapped.back.secondary)
-        assertEquals("a feeling of warmth", mapped.back.definition)
+        assertEquals("een gevoel van warmte", mapped.back.definition)
+        assertEquals("a feeling of warmth", mapped.back.definitionTranslation)
         assertEquals("Het was zo <w>gezellig</w>.", mapped.back.examples.single().text)
         assertEquals("It was so cosy.", mapped.back.examples.single().translation)
     }
@@ -182,7 +184,7 @@ class StudySessionMapperTest {
         val activeSenseBack = mapped.senses.single { it.id == studiedSenseId }.back
         assertEquals("gezellig", activeSenseBack.headline)
         assertEquals("cosy, sociable", activeSenseBack.secondary)
-        assertEquals("a feeling of warmth", activeSenseBack.definition)
+        assertEquals("een gevoel van warmte", activeSenseBack.definition)
         val otherBack = mapped.senses.single { it.id == otherSenseId }.back
         assertEquals("gezellig", otherBack.headline)
         assertEquals("sociable evening", otherBack.secondary)
@@ -238,6 +240,11 @@ class StudySessionMapperTest {
         assertNull(mapped.translationHint)
         assertNotNull(mapped.back.cloze)
         assertEquals("gezellig", mapped.back.headline)
+        assertEquals("een gevoel van warmte", mapped.back.definition)
+        assertEquals("a feeling of warmth", mapped.back.definitionTranslation)
+        val clozeTranslation = assertNotNull(mapped.back.clozeTranslation)
+        assertEquals("It was so cosy.", clozeTranslation.text)
+        assertEquals(true, clozeTranslation.filled)
     }
 
     @Test
@@ -385,7 +392,7 @@ class StudySessionMapperTest {
                     senses = listOf(
                         LanguageCardResponseSense(
                             senseId = PrimarySenseId,
-                            senseDefinition = "a feeling of warmth",
+                            senseDefinition = "een gevoel van warmte",
                             learnerLevel = LearnerLevel.A2,
                             frequency = SenseFrequency.HIGH,
                             semanticGroupId = "warmth",


### PR DESCRIPTION
## Summary

Improvements to the study session card back, all in the study UI module.

- **Localization fix:** the `Translate to X` prompt now uses `Language.selfName` (native name) instead of `englishName`. The language name was previously rendered in English regardless of UI locale (e.g. *"Переведите на Dutch"*); it now reads *"Переведите на Nederlands"* / *"Translate to Nederlands"*.
- **Definition + translation on bilingual backs:** added `definitionTranslation`. The primary definition stays in the headline word's language; the translation renders muted beneath it. Wired through all four bilingual back builders, blank-guarded.
- **Cloze example translation on Fill-in backs:** added `clozeTranslation` + a `StudyClozeTranslationText` composable (italic/muted base, answer word in accent color). Populated from the source example's target-language translation, reusing the existing `<w>…</w>` cloze parsing.
- **Spacing fix:** definition/cloze and their translations are wrapped in tight `6.dp` columns so the outer `spacedBy(md)` arrangement doesn't double up the gap.

## Testing

- `:composeApp:compileKotlinDesktop` — clean.
- `:composeApp:desktopTest --tests StudySessionMapperTest` — passes (`--rerun-tasks`). Fixture now differentiates source vs. target definition (previously identical), with new assertions covering `definitionTranslation` (both directions) and `clozeTranslation`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)