### PR TITLE
Study cloze hints: per-card hint swap + de-italicized back translation

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/study/StudySessionMapper.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/study/StudySessionMapper.kt
@@ -162,11 +162,21 @@ fun SessionCard.toStudyCardUiState(favoriteLemmas: Set<String>): StudyCardUiStat
             ).map { senseUi ->
                 if (senseUi.id == sense.senseId) senseUi.copy(back = activeBack) else senseUi
             }
+            // Prefer the translation hint only when it actually highlights the answer word
+            // (the example translation is tagged). CLOZE_SOURCE can be eligible without a
+            // tagged/present example translation, so fall back to the first-letter hint to
+            // guarantee a usable hint.
+            val highlightedTranslation = clozeTranslation?.takeIf { it.answerRanges.isNotEmpty() }
             StudyCardUiState.Cloze(
                 id = card.id.toString(),
                 chipLabel = UiText.Resource(Res.string.study_chip_fill_in),
                 prompt = cloze,
-                firstLetterHint = cloze.firstAnswerText().firstLetterHint(),
+                translationHint = highlightedTranslation,
+                firstLetterHint = if (highlightedTranslation == null) {
+                    cloze.firstAnswerText().firstLetterHint()
+                } else {
+                    null
+                },
                 senses = senses,
                 activeSenseId = sense.senseId,
                 back = activeBack,
@@ -197,6 +207,7 @@ fun SessionCard.toStudyCardUiState(favoriteLemmas: Set<String>): StudyCardUiStat
             ).map { senseUi ->
                 if (senseUi.id == sense.senseId) senseUi.copy(back = activeBack) else senseUi
             }
+            val recallWord = toTranslationHintCloze(sourceExample.text)?.firstAnswerText()
             StudyCardUiState.Cloze(
                 id = card.id.toString(),
                 chipLabel = UiText.Resource(
@@ -204,7 +215,7 @@ fun SessionCard.toStudyCardUiState(favoriteLemmas: Set<String>): StudyCardUiStat
                     listOf(sourceLanguage.studyCode()),
                 ),
                 prompt = cloze.copy(filled = true),
-                translationHint = toTranslationHintCloze(sourceExample.text),
+                firstLetterHint = recallWord?.firstLetterHint(),
                 senses = senses,
                 activeSenseId = sense.senseId,
                 back = activeBack,

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/study/StudySessionMapper.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/study/StudySessionMapper.kt
@@ -207,7 +207,12 @@ fun SessionCard.toStudyCardUiState(favoriteLemmas: Set<String>): StudyCardUiStat
             ).map { senseUi ->
                 if (senseUi.id == sense.senseId) senseUi.copy(back = activeBack) else senseUi
             }
+            // Prefer the answer word from the source example; fall back to the lemma when the
+            // source example is untagged (CLOZE_TRANSLATION only requires a tagged translation),
+            // so the front always has a usable first-letter hint.
             val recallWord = toTranslationHintCloze(sourceExample.text)?.firstAnswerText()
+                ?.takeIf { it.isNotBlank() }
+                ?: lemma
             StudyCardUiState.Cloze(
                 id = card.id.toString(),
                 chipLabel = UiText.Resource(
@@ -215,7 +220,7 @@ fun SessionCard.toStudyCardUiState(favoriteLemmas: Set<String>): StudyCardUiStat
                     listOf(sourceLanguage.studyCode()),
                 ),
                 prompt = cloze.copy(filled = true),
-                firstLetterHint = recallWord?.firstLetterHint(),
+                firstLetterHint = recallWord.firstLetterHint(),
                 senses = senses,
                 activeSenseId = sense.senseId,
                 back = activeBack,

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/study/StudySessionScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/study/StudySessionScreen.kt
@@ -1921,7 +1921,7 @@ private fun StudyClozeTranslationText(
     Text(
         text = text,
         style = MaterialTheme.typography.bodyMedium.copy(
-            fontStyle = FontStyle.Italic,
+            fontStyle = FontStyle.Normal,
             lineHeight = MaterialTheme.typography.bodyMedium.lineHeight * 1.1f,
         ),
         color = MaterialTheme.colorScheme.onSurfaceVariant,
@@ -2050,7 +2050,6 @@ private fun HintRevealPill(
     val borderColor = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.28f)
     val dashWidth = 6.dp
     val dashGap = 4.dp
-    val description = contentDescription
     Box(
         modifier = modifier
             .height(48.dp)
@@ -2074,9 +2073,9 @@ private fun HintRevealPill(
             }
             .clip(CircleShape)
             .semantics(mergeDescendants = true) {
-                this.contentDescription = description
+                this.contentDescription = contentDescription
             }
-            .clickable(role = Role.Button, onClickLabel = description) { onReveal() }
+            .clickable(role = Role.Button, onClickLabel = contentDescription) { onReveal() }
             .padding(horizontal = 14.dp),
         contentAlignment = Alignment.Center,
     ) {
@@ -2390,7 +2389,11 @@ private fun clozeCard() = StudyCardUiState.Cloze(
         text = "Het was zo gezellig bij jullie thuis.",
         answerRanges = listOf(11..18),
     ),
-    firstLetterHint = FirstLetterHint(letter = 'g', letterCount = 8, dotCount = 7),
+    translationHint = StudyClozeTextUiState(
+        text = "It was so lovely at your place.",
+        answerRanges = listOf(10..15),
+        filled = true,
+    ),
     back = StudyCardBackUiState(
         headline = "gezellig",
         secondary = "cosy, sociable",
@@ -2421,10 +2424,7 @@ private fun translationClozeCard() = StudyCardUiState.Cloze(
         answerRanges = listOf(10..15),
         filled = true,
     ),
-    translationHint = StudyClozeTextUiState(
-        text = "Het was zo gezellig bij jullie thuis.",
-        answerRanges = listOf(11..18),
-    ),
+    firstLetterHint = FirstLetterHint(letter = 'g', letterCount = 8, dotCount = 7),
     back = StudyCardBackUiState(
         headline = "gezellig",
         isLemmaHeadline = true,
@@ -2684,7 +2684,7 @@ private fun StudySessionClozeFrontHintRevealedPreview(
     ThemedPreview(darkTheme = isDark) {
         StudySessionScreenContent(
             state = activeState(
-                clozeCard().copy(firstLetterHintRevealed = true),
+                clozeCard().copy(translationHintRevealed = true),
                 StudyCardSide.FRONT,
                 current = 6,
             ),
@@ -2730,7 +2730,7 @@ private fun StudySessionTranslationClozeFrontHintRevealedPreview(
     ThemedPreview(darkTheme = isDark) {
         StudySessionScreenContent(
             state = activeState(
-                translationClozeCard().copy(translationHintRevealed = true),
+                translationClozeCard().copy(firstLetterHintRevealed = true),
                 StudyCardSide.FRONT,
                 current = 6,
             ),

--- a/composeApp/src/commonTest/kotlin/com/slovy/slovymovyapp/ui/study/StudySessionMapperTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/slovy/slovymovyapp/ui/study/StudySessionMapperTest.kt
@@ -291,6 +291,28 @@ class StudySessionMapperTest {
     }
 
     @Test
+    fun translationClozeCardFallsBackToLemmaHintWhenSourceUntagged() {
+        val sessionCard = sessionCard(
+            variant = CardVariant(CardKind.CLOZE_TRANSLATION, targetLang = Language.ENGLISH.code),
+            example = ExamplePair(
+                exampleIndex = 0,
+                text = "It was so cosy.",
+                clozeRanges = listOf(10..13),
+            ),
+            // Source example without a tagged word: the hint must fall back to the lemma.
+            primaryExampleText = "Het was zo gezellig.",
+        )
+
+        val mapped = assertIs<StudyCardUiState.Cloze>(sessionCard.toStudyCardUiState(emptySet()))
+
+        assertNull(mapped.translationHint)
+        val hint = assertNotNull(mapped.firstLetterHint)
+        assertEquals('g', hint.letter)
+        assertEquals(8, hint.letterCount)
+        assertEquals(7, hint.dotCount)
+    }
+
+    @Test
     fun mapsSourceClozeCardWithMultipleTaggedRanges() {
         val sessionCard = sessionCard(
             variant = CardVariant(CardKind.CLOZE_SOURCE, targetLang = Language.ENGLISH.code),
@@ -374,6 +396,7 @@ class StudySessionMapperTest {
         studiedSenseIds: Set<String> = emptySet(),
         extraSenses: List<LanguageCardResponseSense> = emptyList(),
         synonyms: List<String> = emptyList(),
+        primaryExampleText: String = "Het was zo <w>gezellig</w>.",
         primaryExampleTranslation: String = "It was so cosy.",
     ): SessionCard {
         return SessionCard(
@@ -398,7 +421,9 @@ class StudySessionMapperTest {
                 ),
             ),
             variant = variant,
-            wordResult = WordResult(card = languageCard(extraSenses, synonyms, primaryExampleTranslation)),
+            wordResult = WordResult(
+                card = languageCard(extraSenses, synonyms, primaryExampleText, primaryExampleTranslation),
+            ),
             senseId = PrimarySenseId,
             example = example,
             studiedSenseIds = studiedSenseIds,
@@ -408,6 +433,7 @@ class StudySessionMapperTest {
     private fun languageCard(
         extraSenses: List<LanguageCardResponseSense>,
         synonyms: List<String>,
+        primaryExampleText: String,
         primaryExampleTranslation: String,
     ): LanguageCard =
         LanguageCard(
@@ -426,7 +452,7 @@ class StudySessionMapperTest {
                             semanticGroupId = "warmth",
                             examples = listOf(
                                 LanguageCardExample(
-                                    text = "Het was zo <w>gezellig</w>.",
+                                    text = primaryExampleText,
                                     targetLangTranslations = mapOf(Language.ENGLISH to primaryExampleTranslation),
                                 ),
                             ),

--- a/composeApp/src/commonTest/kotlin/com/slovy/slovymovyapp/ui/study/StudySessionMapperTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/slovy/slovymovyapp/ui/study/StudySessionMapperTest.kt
@@ -233,11 +233,12 @@ class StudySessionMapperTest {
 
         assertEquals("Het was zo gezellig.", mapped.prompt.text)
         assertEquals(listOf(11..18), mapped.prompt.answerRanges)
+        // Fixture translation is untagged, so the hint falls back to the first-letter hint.
+        assertNull(mapped.translationHint)
         val hint = assertNotNull(mapped.firstLetterHint)
         assertEquals('g', hint.letter)
         assertEquals(8, hint.letterCount)
         assertEquals(7, hint.dotCount)
-        assertNull(mapped.translationHint)
         assertNotNull(mapped.back.cloze)
         assertEquals("gezellig", mapped.back.headline)
         assertEquals("een gevoel van warmte", mapped.back.definition)
@@ -248,7 +249,29 @@ class StudySessionMapperTest {
     }
 
     @Test
-    fun translationClozeCardExposesSourceExampleAsClozeHint() {
+    fun sourceClozeCardHighlightsTranslationHintWhenTranslationTagged() {
+        val sessionCard = sessionCard(
+            variant = CardVariant(CardKind.CLOZE_SOURCE, targetLang = Language.ENGLISH.code),
+            example = ExamplePair(
+                exampleIndex = 0,
+                text = "Het was zo gezellig.",
+                clozeRanges = listOf(11..18),
+            ),
+            primaryExampleTranslation = "It was so <w>cosy</w>.",
+        )
+
+        val mapped = assertIs<StudyCardUiState.Cloze>(sessionCard.toStudyCardUiState(emptySet()))
+
+        // Tagged translation: highlight the answer word in the translation hint, no first-letter hint.
+        assertNull(mapped.firstLetterHint)
+        val hint = assertNotNull(mapped.translationHint)
+        assertEquals("It was so cosy.", hint.text)
+        assertEquals(listOf(10..13), hint.answerRanges)
+        assertEquals(true, hint.filled)
+    }
+
+    @Test
+    fun translationClozeCardExposesFirstLetterHintFromSourceWord() {
         val sessionCard = sessionCard(
             variant = CardVariant(CardKind.CLOZE_TRANSLATION, targetLang = Language.ENGLISH.code),
             example = ExamplePair(
@@ -260,9 +283,11 @@ class StudySessionMapperTest {
 
         val mapped = assertIs<StudyCardUiState.Cloze>(sessionCard.toStudyCardUiState(emptySet()))
 
-        val hint = assertNotNull(mapped.translationHint)
-        assertEquals("Het was zo gezellig.", hint.text)
-        assertEquals(listOf(11..18), hint.answerRanges)
+        assertNull(mapped.translationHint)
+        val hint = assertNotNull(mapped.firstLetterHint)
+        assertEquals('g', hint.letter)
+        assertEquals(8, hint.letterCount)
+        assertEquals(7, hint.dotCount)
     }
 
     @Test
@@ -280,6 +305,7 @@ class StudySessionMapperTest {
 
         assertEquals("Vergeet niet om je paspoort mee te nemen.", mapped.prompt.text)
         assertEquals(listOf(28..30, 35..39), mapped.prompt.answerRanges)
+        // Untagged fixture translation falls back to the first-letter hint of the first answer.
         val hint = assertNotNull(mapped.firstLetterHint)
         assertEquals('m', hint.letter)
         assertEquals(3, hint.letterCount)
@@ -348,6 +374,7 @@ class StudySessionMapperTest {
         studiedSenseIds: Set<String> = emptySet(),
         extraSenses: List<LanguageCardResponseSense> = emptyList(),
         synonyms: List<String> = emptyList(),
+        primaryExampleTranslation: String = "It was so cosy.",
     ): SessionCard {
         return SessionCard(
             card = Card(
@@ -371,7 +398,7 @@ class StudySessionMapperTest {
                 ),
             ),
             variant = variant,
-            wordResult = WordResult(card = languageCard(extraSenses, synonyms)),
+            wordResult = WordResult(card = languageCard(extraSenses, synonyms, primaryExampleTranslation)),
             senseId = PrimarySenseId,
             example = example,
             studiedSenseIds = studiedSenseIds,
@@ -381,6 +408,7 @@ class StudySessionMapperTest {
     private fun languageCard(
         extraSenses: List<LanguageCardResponseSense>,
         synonyms: List<String>,
+        primaryExampleTranslation: String,
     ): LanguageCard =
         LanguageCard(
             lemma = "gezellig",
@@ -399,7 +427,7 @@ class StudySessionMapperTest {
                             examples = listOf(
                                 LanguageCardExample(
                                     text = "Het was zo <w>gezellig</w>.",
-                                    targetLangTranslations = mapOf(Language.ENGLISH to "It was so cosy."),
+                                    targetLangTranslations = mapOf(Language.ENGLISH to primaryExampleTranslation),
                                 ),
                             ),
                             targetLangDefinitions = mapOf(Language.ENGLISH to "a feeling of warmth"),


### PR DESCRIPTION
## What

Reworks the front hint on the two study-session cloze cards so each shows the more useful aid, plus a small back-of-card styling fix.

### Visual changes
- **Source cloze** (front = clozed sentence in the language being studied): hint is now the **example translation with the answer word highlighted** instead of the first-letter pill.
- **Translation cloze** (front = sentence in the user's language): hint is now the **first-letter pill** (`g·······`) of the recalled studied-language word, instead of the clozed source sentence.
- **Cloze back**: the translation line is no longer rendered in italics (matches the front).

### Robustness
`CLOZE_SOURCE` can be eligible without a tagged/present example translation (`buildTaskVariants` only requires a tagged *source* example + any translation *cue*). To guarantee a usable hint, the translation hint is used only when it actually highlights the answer word (tagged translation → non-empty `answerRanges`); otherwise it **falls back to the first-letter hint**. This preserves the prior guarantee that a hint always exists.

## Tests
- Updated the two `CLOZE_SOURCE` mapper tests to assert the fallback (untagged fixture → first-letter hint).
- Added `sourceClozeCardHighlightsTranslationHintWhenTranslationTagged` for the tagged happy path (highlighted translation hint, no first-letter hint) — previously uncovered.
- Updated the `CLOZE_TRANSLATION` test to assert the first-letter hint.
- Previews updated to match the new per-card hints.

`:composeApp:compileKotlinDesktop` and `StudySessionMapperTest` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)