### PR TITLE
Source cloze first-letter hint: use the lemma

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/study/StudySessionMapper.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/study/StudySessionMapper.kt
@@ -173,7 +173,7 @@ fun SessionCard.toStudyCardUiState(favoriteLemmas: Set<String>): StudyCardUiStat
                 prompt = cloze,
                 translationHint = highlightedTranslation,
                 firstLetterHint = if (highlightedTranslation == null) {
-                    cloze.firstAnswerText().firstLetterHint()
+                    lemma.firstLetterHint()
                 } else {
                     null
                 },
@@ -403,13 +403,6 @@ private fun ExamplePair.toClozeText(): StudyClozeTextUiState? {
 private fun toTranslationHintCloze(text: String): StudyClozeTextUiState? {
     val parsed = parseClozeFromTaggedText(text) ?: return null
     return StudyClozeTextUiState(text = parsed.plainText, answerRanges = parsed.answerRanges)
-}
-
-private fun StudyClozeTextUiState.firstAnswerText(): String {
-    val range = answerRanges.firstOrNull() ?: return ""
-    val start = range.first.coerceIn(0, text.length)
-    val endExclusive = (range.last + 1).coerceIn(start, text.length)
-    return text.substring(start, endExclusive)
 }
 
 internal fun String.firstLetterHint(): FirstLetterHint? {

--- a/composeApp/src/commonTest/kotlin/com/slovy/slovymovyapp/ui/study/StudySessionMapperTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/slovy/slovymovyapp/ui/study/StudySessionMapperTest.kt
@@ -233,7 +233,7 @@ class StudySessionMapperTest {
 
         assertEquals("Het was zo gezellig.", mapped.prompt.text)
         assertEquals(listOf(11..18), mapped.prompt.answerRanges)
-        // Fixture translation is untagged, so the hint falls back to the first-letter hint.
+        // Fixture translation is untagged, so the hint falls back to the lemma's first-letter hint.
         assertNull(mapped.translationHint)
         val hint = assertNotNull(mapped.firstLetterHint)
         assertEquals('g', hint.letter)
@@ -308,11 +308,11 @@ class StudySessionMapperTest {
 
         assertEquals("Vergeet niet om je paspoort mee te nemen.", mapped.prompt.text)
         assertEquals(listOf(28..30, 35..39), mapped.prompt.answerRanges)
-        // Untagged fixture translation falls back to the first-letter hint of the first answer.
+        // Untagged fixture translation falls back to the lemma's first-letter hint.
         val hint = assertNotNull(mapped.firstLetterHint)
-        assertEquals('m', hint.letter)
-        assertEquals(3, hint.letterCount)
-        assertEquals(2, hint.dotCount)
+        assertEquals('g', hint.letter)
+        assertEquals(8, hint.letterCount)
+        assertEquals(7, hint.dotCount)
         assertNotNull(mapped.back.cloze)
         assertEquals(listOf(28..30, 35..39), mapped.back.cloze.answerRanges)
     }


### PR DESCRIPTION
## What

Follow-up to the study cloze hint work (#692). `CLOZE_SOURCE`'s first-letter **fallback** hint now derives from the **lemma**, consistent with every other first-letter hint in the mapper, instead of the answer word extracted from the example sentence.

After this, all four first-letter hints (`SOURCE_DEFINITION_TO_WORD`, `TRANSLATION_TO_WORD`, `CLOZE_TRANSLATION`, `CLOZE_SOURCE` fallback) use the lemma. The now-unused `firstAnswerText()` helper is removed.

## Tests

Updated the two `CLOZE_SOURCE` mapper tests to assert the lemma-derived hint (`gezellig` → `g`, 8, 7).

`:composeApp:compileKotlinDesktop` and `StudySessionMapperTest` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)