### PR TITLE
Fix long-word truncation on word details title

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/word/WordDetailsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/word/WordDetailsScreen.kt
@@ -8,7 +8,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.foundation.text.TextAutoSize
+import androidx.compose.ui.text.rememberTextMeasurer
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
@@ -1262,23 +1262,38 @@ private fun WordDetailContent(
 
 @Composable
 private fun LemmaHeadlineText(lemma: String, modifier: Modifier = Modifier) {
-    Text(
-        text = lemma,
-        style = MaterialTheme.typography.displaySmall.copy(
-            fontWeight = FontWeight.Medium,
-            lineHeight = 44.sp,
-            letterSpacing = (-0.3).sp
-        ),
-        color = MaterialTheme.colorScheme.onSurface,
-        maxLines = 1,
-        overflow = TextOverflow.Ellipsis,
-        autoSize = TextAutoSize.StepBased(
-            minFontSize = 22.sp,
-            maxFontSize = 42.sp,
-            stepSize = 1.sp,
-        ),
-        modifier = modifier,
+    val baseStyle = MaterialTheme.typography.displaySmall.copy(
+        fontWeight = FontWeight.Medium,
+        letterSpacing = (-0.3).sp,
     )
+    val textMeasurer = rememberTextMeasurer()
+    // autoSize on Text is unreliable on iOS, so measure-and-fit manually: shrink the
+    // font from maxFontSize down until the lemma fits the available width on one line.
+    BoxWithConstraints(modifier = modifier) {
+        val maxWidthPx = with(LocalDensity.current) { maxWidth.toPx() }
+        val maxFontSize = 42f
+        val minFontSize = 15f
+        val fontSize = remember(lemma, maxWidthPx, textMeasurer, baseStyle) {
+            var size = maxFontSize
+            while (size > minFontSize) {
+                val width = textMeasurer.measure(
+                    text = lemma,
+                    style = baseStyle.copy(fontSize = size.sp),
+                    maxLines = 1,
+                ).size.width
+                if (width <= maxWidthPx) break
+                size -= 1f
+            }
+            size
+        }
+        Text(
+            text = lemma,
+            style = baseStyle.copy(fontSize = fontSize.sp, lineHeight = (fontSize + 2f).sp),
+            color = MaterialTheme.colorScheme.onSurface,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+        )
+    }
 }
 
 @Composable


### PR DESCRIPTION
## Problem

On the word details screen, a long lemma title was truncated with an ellipsis (`…`) instead of shrinking to fit.

The hero title used `Text(autoSize = TextAutoSize.StepBased(...))`, but `autoSize` does **not** shrink text on iOS in Compose MP 1.11 — so lowering `minFontSize` had no visible effect on iPhone and long words stayed truncated.

## Fix

Replaced the flaky `autoSize` in `LemmaHeadlineText` with a deterministic measure-and-fit:

- `BoxWithConstraints` provides the actual available width (the space left by the play button in the row).
- `rememberTextMeasurer()` measures the lemma, shrinking the font from 42sp down to a 15sp floor until it fits on one line.
- Ellipsis only remains as a last-resort fallback below 15sp.

This behaves identically across iOS, Android, and desktop. Verified on iPhone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)