### PR TITLE
Keep spinners animating under iOS Reduce Motion

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/AppDataSection.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/AppDataSection.kt
@@ -10,6 +10,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.dp
+import com.slovy.slovymovyapp.ui.components.SpinningProgressIndicator
 import com.slovy.slovymovyapp.ui.theme.AppSpacing
 import org.jetbrains.compose.resources.stringResource
 import slovymovyapp.composeapp.generated.resources.*
@@ -52,7 +53,7 @@ fun AppDataSection(
                     horizontalArrangement = Arrangement.spacedBy(AppSpacing.sm)
                 ) {
                     if (isExporting) {
-                        CircularProgressIndicator(
+                        SpinningProgressIndicator(
                             modifier = Modifier.size(18.dp),
                             strokeWidth = 2.dp
                         )

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/DeveloperScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/DeveloperScreen.kt
@@ -26,7 +26,6 @@ import androidx.compose.material.icons.outlined.Warning
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CenterAlignedTopAppBar
-import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ElevatedCard
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FilledTonalButton
@@ -71,6 +70,7 @@ import com.slovy.slovymovyapp.logging.AppLogLevel
 import com.slovy.slovymovyapp.logging.AppLogSink
 import com.slovy.slovymovyapp.logging.AppLogger
 import com.slovy.slovymovyapp.logging.NoOpAppLogSink
+import com.slovy.slovymovyapp.ui.components.SpinningProgressIndicator
 import com.slovy.slovymovyapp.ui.study.StudySessionCompleteContent
 import com.slovy.slovymovyapp.ui.study.StudySessionCompletePreviewCase
 import com.slovy.slovymovyapp.ui.study.StudySessionCompletePreviewData
@@ -885,7 +885,7 @@ private fun DeveloperTerminalCard(
                     verticalAlignment = Alignment.CenterVertically,
                     horizontalArrangement = Arrangement.spacedBy(AppSpacing.sm),
                 ) {
-                    CircularProgressIndicator(modifier = Modifier.size(16.dp))
+                    SpinningProgressIndicator(modifier = Modifier.size(16.dp))
                     Text(
                         text = stringResource(
                             Res.string.developer_terminal_running,
@@ -1150,7 +1150,7 @@ private fun SchedulingStatsCard(
                     verticalAlignment = Alignment.CenterVertically,
                     horizontalArrangement = Arrangement.spacedBy(AppSpacing.sm),
                 ) {
-                    CircularProgressIndicator(modifier = Modifier.size(16.dp))
+                    SpinningProgressIndicator(modifier = Modifier.size(16.dp))
                     Text(
                         text = stringResource(Res.string.developer_stats_loading),
                         style = MaterialTheme.typography.bodySmall,
@@ -1457,7 +1457,7 @@ private fun LoadingStatusRow(text: String) {
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(AppSpacing.sm),
     ) {
-        CircularProgressIndicator(modifier = Modifier.size(16.dp))
+        SpinningProgressIndicator(modifier = Modifier.size(16.dp))
         Text(
             text = text,
             style = MaterialTheme.typography.bodySmall,

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/DownloadScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/DownloadScreen.kt
@@ -27,6 +27,7 @@ import androidx.lifecycle.viewModelScope
 import com.slovy.slovymovyapp.analytics.Analytics
 import com.slovy.slovymovyapp.analytics.AnalyticsEvent
 import com.slovy.slovymovyapp.data.remote.*
+import com.slovy.slovymovyapp.ui.components.SpinningProgressIndicator
 import com.slovy.slovymovyapp.ui.icons.DownloadScreenTransparent
 import com.slovy.slovymovyapp.ui.icons.SlovyIcons
 import com.slovy.slovymovyapp.ui.theme.AppSpacing
@@ -466,7 +467,7 @@ fun DownloadScreenContent(
             when (state) {
                 is DownloadUiState.Loading -> {
                     val loadingInfoContentDescription = stringResource(Res.string.download_content_desc_loading_info)
-                    CircularProgressIndicator(
+                    SpinningProgressIndicator(
                         modifier = Modifier.semantics {
                             contentDescription = loadingInfoContentDescription
                         }
@@ -533,7 +534,7 @@ fun DownloadScreenContent(
                 is DownloadUiState.Idle,
                 is DownloadUiState.Finalizing -> {
                     val preparingContentDescription = stringResource(Res.string.download_content_desc_preparing)
-                    CircularProgressIndicator(
+                    SpinningProgressIndicator(
                         modifier = Modifier.semantics {
                             contentDescription = preparingContentDescription
                         }

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/FeedbackDialog.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/FeedbackDialog.kt
@@ -13,6 +13,7 @@ import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.dp
+import com.slovy.slovymovyapp.ui.components.SpinningProgressIndicator
 import org.jetbrains.compose.resources.stringResource
 import slovymovyapp.composeapp.generated.resources.*
 
@@ -165,7 +166,7 @@ fun FeedbackDialog(
                     enabled = !isSending && commentValue.text.isNotBlank()
                 ) {
                     if (isSending) {
-                        CircularProgressIndicator(
+                        SpinningProgressIndicator(
                             modifier = Modifier.size(16.dp),
                             strokeWidth = 2.dp
                         )

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/LanguageSetupScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/LanguageSetupScreen.kt
@@ -31,6 +31,7 @@ import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.withLink
 import androidx.compose.ui.text.withStyle
+import com.slovy.slovymovyapp.ui.components.SpinningProgressIndicator
 import com.slovy.slovymovyapp.ui.theme.serifFontFamily
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextDecoration
@@ -311,7 +312,7 @@ fun LanguageSetupScreenContent(
                 Modifier.fillMaxSize().padding(innerPadding),
                 contentAlignment = Alignment.Center
             ) {
-                CircularProgressIndicator()
+                SpinningProgressIndicator()
             }
         } else if (state.errorMessage != null) {
             Column(

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/ListDetailScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/ListDetailScreen.kt
@@ -63,6 +63,7 @@ import com.slovy.slovymovyapp.speech.RowAudioController
 import com.slovy.slovymovyapp.speech.RowAudioUiState
 import com.slovy.slovymovyapp.speech.SpeechPlayer
 import com.slovy.slovymovyapp.speech.VoiceFilterHelper
+import com.slovy.slovymovyapp.ui.components.SpinningProgressIndicator
 import com.slovy.slovymovyapp.ui.theme.LocalIsDarkTheme
 import com.slovy.slovymovyapp.ui.theme.serifFontFamily
 import com.slovy.slovymovyapp.ui.word.ChapterRule
@@ -442,7 +443,7 @@ private fun ListDetailLoadingScreen(onBack: () -> Unit) {
         Box(
             modifier = Modifier.fillMaxSize().padding(innerPadding),
             contentAlignment = Alignment.Center,
-        ) { CircularProgressIndicator() }
+        ) { SpinningProgressIndicator() }
     }
 }
 
@@ -590,7 +591,7 @@ fun ListDetailContent(
                         modifier = Modifier.fillMaxWidth().padding(top = 32.dp),
                         contentAlignment = Alignment.Center
                     ) {
-                        CircularProgressIndicator()
+                        SpinningProgressIndicator()
                     }
                 }
             } else if (state.items.isEmpty()) {
@@ -769,7 +770,7 @@ private fun ListDetailHeader(
                     enabled = !bulkActionInProgress,
                 ) {
                     if (bulkActionInProgress) {
-                        CircularProgressIndicator(
+                        SpinningProgressIndicator(
                             modifier = Modifier.size(14.dp),
                             strokeWidth = 2.dp,
                         )

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/SearchScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/SearchScreen.kt
@@ -47,6 +47,7 @@ import androidx.compose.ui.tooling.preview.PreviewParameter
 import com.slovy.slovymovyapp.data.lists.ListsService
 import com.slovy.slovymovyapp.data.lists.WordList
 import com.slovy.slovymovyapp.data.lists.WordListSense
+import com.slovy.slovymovyapp.ui.components.SpinningProgressIndicator
 import com.slovy.slovymovyapp.ui.word.ClipboardVector
 import com.slovy.slovymovyapp.ui.word.DownloadVector
 import com.slovy.slovymovyapp.ui.word.FavoriteAccentColor
@@ -821,7 +822,7 @@ private fun EmptySearchState(
             modifier = Modifier.fillMaxSize(),
             contentAlignment = Alignment.Center
         ) {
-            CircularProgressIndicator()
+            SpinningProgressIndicator()
         }
         return
     }

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/SettingsComponents.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/SettingsComponents.kt
@@ -24,6 +24,7 @@ import androidx.compose.ui.semantics.stateDescription
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.slovy.slovymovyapp.ui.components.SpinningProgressIndicator
 import com.slovy.slovymovyapp.ui.theme.AppSpacing
 import org.jetbrains.compose.resources.stringResource
 import slovymovyapp.composeapp.generated.resources.*
@@ -85,7 +86,7 @@ fun CancellableProgressIndicator(
         contentAlignment = Alignment.Center
     ) {
         if (isIndeterminate) {
-            CircularProgressIndicator(
+            SpinningProgressIndicator(
                 modifier = Modifier.size(size),
                 strokeWidth = strokeWidth,
                 trackColor = MaterialTheme.colorScheme.surfaceVariant,
@@ -181,7 +182,7 @@ fun DeleteConfirmationDialog(
 @Composable
 fun LoadingIndicator(modifier: Modifier = Modifier) {
     Box(modifier = modifier, contentAlignment = Alignment.Center) {
-        CircularProgressIndicator()
+        SpinningProgressIndicator()
     }
 }
 

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/SettingsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/SettingsScreen.kt
@@ -28,6 +28,7 @@ import com.slovy.slovymovyapp.i18n.UiText
 import com.slovy.slovymovyapp.i18n.resolve
 import com.slovy.slovymovyapp.logging.AppLogger
 import com.slovy.slovymovyapp.speech.*
+import com.slovy.slovymovyapp.ui.components.SpinningProgressIndicator
 import com.slovy.slovymovyapp.ui.theme.AppSpacing
 import com.slovy.slovymovyapp.ui.theme.serifFontFamily
 import kotlinx.coroutines.CancellationException
@@ -1232,7 +1233,7 @@ fun SettingsScreenContent(
                                         modifier = Modifier.fillMaxWidth().padding(AppSpacing.xl),
                                         contentAlignment = Alignment.Center
                                     ) {
-                                        CircularProgressIndicator(modifier = Modifier.size(24.dp))
+                                        SpinningProgressIndicator(modifier = Modifier.size(24.dp))
                                     }
                                 }
                             } else {

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/VoiceSection.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/VoiceSection.kt
@@ -20,7 +20,6 @@ import androidx.compose.material.icons.filled.KeyboardArrowDown
 import androidx.compose.material.icons.filled.KeyboardArrowUp
 import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material3.CardDefaults
-import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ElevatedCard
 import androidx.compose.material3.FilledTonalButton
 import androidx.compose.material3.HorizontalDivider
@@ -43,6 +42,7 @@ import com.slovy.slovymovyapp.getPlatform
 import com.slovy.slovymovyapp.speech.Text2SpeechLanguage
 import com.slovy.slovymovyapp.speech.Text2SpeechVoice
 import com.slovy.slovymovyapp.speech.VoiceQuality
+import com.slovy.slovymovyapp.ui.components.SpinningProgressIndicator
 import com.slovy.slovymovyapp.ui.theme.AppSpacing
 import org.jetbrains.compose.resources.stringResource
 import slovymovyapp.composeapp.generated.resources.Res
@@ -175,7 +175,7 @@ fun VoiceSectionItem(
                             .padding(AppSpacing.lg),
                         contentAlignment = Alignment.Center
                     ) {
-                        CircularProgressIndicator(modifier = Modifier.size(24.dp))
+                        SpinningProgressIndicator(modifier = Modifier.size(24.dp))
                     }
                 } else if (languageState.voices.isEmpty()) {
                     Text(

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/WelcomeScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/WelcomeScreen.kt
@@ -20,6 +20,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.lifecycle.ViewModel
+import com.slovy.slovymovyapp.ui.components.SpinningProgressIndicator
 import com.slovy.slovymovyapp.ui.theme.AppSpacing
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
@@ -126,7 +127,7 @@ fun WelcomeScreenContent(
                 )
             ) {
                 if (state.isStarting) {
-                    CircularProgressIndicator(
+                    SpinningProgressIndicator(
                         modifier = Modifier.size(24.dp),
                         color = MaterialTheme.colorScheme.onPrimary,
                         strokeWidth = 2.dp

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/components/SpinningProgressIndicator.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/components/SpinningProgressIndicator.kt
@@ -1,0 +1,113 @@
+package com.slovy.slovymovyapp.ui.components
+
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.progressSemantics
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ProgressIndicatorDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.withFrameMillis
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewParameter
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import com.slovy.slovymovyapp.ui.ThemePreviewProvider
+import com.slovy.slovymovyapp.ui.ThemedPreview
+
+/**
+ * Indeterminate spinner used in place of the Material 3 [androidx.compose.material3.CircularProgressIndicator].
+ *
+ * The Material spinner is driven by `rememberInfiniteTransition`, which Compose collapses to a
+ * single static frame when the platform reports reduced motion (iOS Reduce Motion arrives as
+ * `MotionDurationScale == 0`), leaving a frozen arc. Progress feedback is functional rather than
+ * decorative — native iOS keeps `UIActivityIndicatorView` spinning under Reduce Motion — so this
+ * spinner derives its rotation directly from the frame clock, which the duration scale cannot
+ * collapse.
+ */
+@Composable
+fun SpinningProgressIndicator(
+    modifier: Modifier = Modifier,
+    color: Color = ProgressIndicatorDefaults.circularColor,
+    strokeWidth: Dp = ProgressIndicatorDefaults.CircularStrokeWidth,
+    trackColor: Color = ProgressIndicatorDefaults.circularIndeterminateTrackColor,
+) {
+    var rotation by remember { mutableFloatStateOf(0f) }
+    LaunchedEffect(Unit) {
+        val startMillis = withFrameMillis { it }
+        while (true) {
+            withFrameMillis { frameMillis ->
+                rotation = ((frameMillis - startMillis) % ROTATION_MILLIS) * 360f / ROTATION_MILLIS
+            }
+        }
+    }
+    Canvas(modifier.progressSemantics().size(SPINNER_DIAMETER)) {
+        val stroke = Stroke(width = strokeWidth.toPx(), cap = StrokeCap.Round)
+        val inset = stroke.width / 2
+        val arcSize = Size(size.width - stroke.width, size.height - stroke.width)
+        if (trackColor != Color.Transparent && trackColor != Color.Unspecified) {
+            drawArc(
+                color = trackColor,
+                startAngle = 0f,
+                sweepAngle = 360f,
+                useCenter = false,
+                topLeft = Offset(inset, inset),
+                size = arcSize,
+                style = stroke,
+            )
+        }
+        drawArc(
+            color = color,
+            startAngle = rotation - 90f,
+            sweepAngle = SWEEP_DEGREES,
+            useCenter = false,
+            topLeft = Offset(inset, inset),
+            size = arcSize,
+            style = stroke,
+        )
+    }
+}
+
+// Matches the Material 3 circular indicator's default 40dp diameter.
+private val SPINNER_DIAMETER = 40.dp
+private const val ROTATION_MILLIS = 1000
+private const val SWEEP_DEGREES = 270f
+
+@Preview
+@Composable
+private fun SpinningProgressIndicatorPreview(
+    @PreviewParameter(ThemePreviewProvider::class) isDark: Boolean,
+) {
+    ThemedPreview(darkTheme = isDark) {
+        Row(
+            modifier = Modifier.padding(16.dp),
+            horizontalArrangement = Arrangement.spacedBy(16.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            SpinningProgressIndicator()
+            SpinningProgressIndicator(
+                modifier = Modifier.size(20.dp),
+                strokeWidth = 2.dp,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            SpinningProgressIndicator(
+                modifier = Modifier.size(24.dp),
+                trackColor = MaterialTheme.colorScheme.surfaceVariant,
+            )
+        }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/reader/TextReaderScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/reader/TextReaderScreen.kt
@@ -42,6 +42,7 @@ import com.slovy.slovymovyapp.data.remote.DictionaryRepository
 import com.slovy.slovymovyapp.data.remote.SenseFrequency
 import com.slovy.slovymovyapp.ui.ThemePreviewProvider
 import com.slovy.slovymovyapp.ui.ThemedPreview
+import com.slovy.slovymovyapp.ui.components.SpinningProgressIndicator
 import com.slovy.slovymovyapp.ui.theme.serifFontFamily
 import com.slovy.slovymovyapp.ui.word.ClipboardVector
 import com.slovy.slovymovyapp.ui.word.FavoriteAccentColor
@@ -288,7 +289,7 @@ private fun InputView(
         ) {
             if (isAnalyzing) {
                 val analyzingLabel = stringResource(Res.string.reader_analyzing)
-                CircularProgressIndicator(
+                SpinningProgressIndicator(
                     modifier = Modifier.semantics { contentDescription = analyzingLabel }
                 )
             } else {

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/study/StudySessionScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/study/StudySessionScreen.kt
@@ -47,7 +47,6 @@ import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material.icons.filled.StopCircle
 import androidx.compose.material.icons.filled.VpnKey
 import androidx.compose.material3.AlertDialog
-import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Icon
@@ -110,6 +109,7 @@ import com.slovy.slovymovyapp.i18n.resolve
 import com.slovy.slovymovyapp.ui.SpeakerOffVector
 import com.slovy.slovymovyapp.ui.ThemePreviewProvider
 import com.slovy.slovymovyapp.ui.ThemedPreview
+import com.slovy.slovymovyapp.ui.components.SpinningProgressIndicator
 import com.slovy.slovymovyapp.ui.components.appendWithCenteredBullets
 import com.slovy.slovymovyapp.ui.components.centeredBulletInlineContent
 import com.slovy.slovymovyapp.ui.theme.AppSpacing
@@ -386,7 +386,7 @@ private fun StudyLoadingIndicator() {
     Column(
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {
-        CircularProgressIndicator(modifier = Modifier.size(32.dp))
+        SpinningProgressIndicator(modifier = Modifier.size(32.dp))
         Spacer(Modifier.height(AppSpacing.lg))
         Text(
             text = stringResource(Res.string.study_loading),
@@ -1390,7 +1390,7 @@ private fun ListeningFront(
             ) {
                 Box(contentAlignment = Alignment.Center) {
                     when {
-                        isPreparingAudio -> CircularProgressIndicator(
+                        isPreparingAudio -> SpinningProgressIndicator(
                             modifier = Modifier.size(48.dp),
                             strokeWidth = 3.dp,
                             color = MaterialTheme.colorScheme.primary,
@@ -1753,7 +1753,7 @@ private fun StudySpeakerButton(
     ) {
         Box(contentAlignment = Alignment.Center) {
             when {
-                isPreparingAudio -> CircularProgressIndicator(
+                isPreparingAudio -> SpinningProgressIndicator(
                     modifier = Modifier.size(20.dp),
                     strokeWidth = 2.dp,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/word/SenseCard.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/word/SenseCard.kt
@@ -41,6 +41,7 @@ import com.slovy.slovymovyapp.data.remote.*
 import com.slovy.slovymovyapp.speech.LemmaAudioControl
 import com.slovy.slovymovyapp.speech.RowAudioPhase
 import com.slovy.slovymovyapp.ui.SpeakerVector
+import com.slovy.slovymovyapp.ui.components.SpinningProgressIndicator
 import com.slovy.slovymovyapp.ui.components.appendWithCenteredBullets
 import com.slovy.slovymovyapp.ui.components.appendWithMutedCenteredBullets
 import com.slovy.slovymovyapp.ui.components.centeredBulletInlineContent
@@ -408,7 +409,7 @@ private fun LemmaWithSpeaker(
                     contentAlignment = Alignment.Center,
                 ) {
                     when {
-                        control.phase == RowAudioPhase.PREPARING -> CircularProgressIndicator(
+                        control.phase == RowAudioPhase.PREPARING -> SpinningProgressIndicator(
                             modifier = Modifier.size(16.dp),
                             strokeWidth = 2.dp,
                             color = speakerTint,

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/word/WordDetailsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/word/WordDetailsScreen.kt
@@ -52,6 +52,7 @@ import com.slovy.slovymovyapp.speech.*
 import com.slovy.slovymovyapp.ui.AppNavigationBar
 import com.slovy.slovymovyapp.ui.SpeakerVector
 import com.slovy.slovymovyapp.ui.VoiceSetupBottomSheet
+import com.slovy.slovymovyapp.ui.components.SpinningProgressIndicator
 import com.slovy.slovymovyapp.ui.theme.serifFontFamily
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.delay
@@ -928,7 +929,7 @@ fun WordDetailScreenContent(
                                     modifier = Modifier.size(36.dp)
                                 ) {
                                     when {
-                                        isPreparing -> CircularProgressIndicator(
+                                        isPreparing -> SpinningProgressIndicator(
                                             modifier = Modifier.size(20.dp),
                                             strokeWidth = 2.dp,
                                             color = MaterialTheme.colorScheme.onSurfaceVariant
@@ -1129,7 +1130,7 @@ private fun WordDetailContent(
                         .size(36.dp)
                 ) {
                     when {
-                        isPreparing -> CircularProgressIndicator(
+                        isPreparing -> SpinningProgressIndicator(
                             modifier = Modifier.size(20.dp),
                             strokeWidth = 2.dp,
                             color = MaterialTheme.colorScheme.onSurfaceVariant


### PR DESCRIPTION
## Problem

On iOS devices with **Reduce Motion** enabled, every indeterminate spinner in the app renders frozen (seen on the text reader, downloads, study session, etc.). Compose Multiplatform maps Reduce Motion to `MotionDurationScale = 0`, and Material 3's indeterminate `CircularProgressIndicator` is driven by `rememberInfiniteTransition`, which under that scale snaps to its end frame and stays still. The expressive `LoadingIndicator` (word enrichment) kept animating because its `Animatable` loop advances every frame regardless — which is why only the spinners appeared broken.

## Fix

New `SpinningProgressIndicator` component: a 270° arc whose rotation is computed directly from the frame clock (`withFrameMillis`), which the duration scale cannot collapse. This matches native iOS behavior — `UIActivityIndicatorView` keeps spinning under Reduce Motion because progress feedback is functional, not decorative. Decorative animations (e.g. the reward-screen entrance) still respect Reduce Motion.

- Matches M3 defaults (40dp, theme colors, round caps, optional track color) and keeps indeterminate `progressSemantics()`
- Rotation state is read only in the draw phase — per-frame redraw, no recomposition
- All 24 indeterminate call sites across 15 screens swapped; determinate indicators untouched
- Themed light/dark previews included

## Testing

- `:composeApp:desktopTest` and `:composeApp:testAndroidHostTest` pass (except 5 pre-existing `DictionaryClientTest` failures from a missing local GitHub token)
- `:composeApp:compileKotlinIosSimulatorArm64` compiles
- Verified on iOS: spinners now animate with Reduce Motion enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)