### PR TITLE
Add words-learned milestone hero to study session-complete screen

### DIFF
--- a/composeApp/src/commonMain/composeResources/values-cs/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-cs/strings.xml
@@ -672,6 +672,8 @@
     <string name="study_complete_milestone_subtitle_50">Padesát dní bez přerušení. Odhodlání a pravidelnost.</string>
     <string name="study_complete_milestone_subtitle_100">Sto dní bez přerušení. Neuvěřitelný milník.</string>
     <string name="study_complete_milestone_subtitle_generic">%1$d dní bez přerušení. Jen tak dál.</string>
+    <string name="study_complete_words_milestone_title">%1$d plně naučených slov!</string>
+    <string name="study_complete_words_milestone_subtitle">Slova, která opravdu použiješ.</string>
     <string name="study_action_done_for_now">Pro teď hotovo</string>
     <string name="study_progress_count">%1$d z %2$d</string>
     <string name="study_tap_to_flip">Klepni pro otočení</string>

--- a/composeApp/src/commonMain/composeResources/values-cs/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-cs/strings.xml
@@ -672,7 +672,12 @@
     <string name="study_complete_milestone_subtitle_50">Padesát dní bez přerušení. Odhodlání a pravidelnost.</string>
     <string name="study_complete_milestone_subtitle_100">Sto dní bez přerušení. Neuvěřitelný milník.</string>
     <string name="study_complete_milestone_subtitle_generic">%1$d dní bez přerušení. Jen tak dál.</string>
-    <string name="study_complete_words_milestone_title">%1$d plně naučených slov!</string>
+    <plurals name="study_complete_words_milestone_title">
+        <item quantity="one">%1$d plně naučené slovo!</item>
+        <item quantity="few">%1$d plně naučená slova!</item>
+        <item quantity="many">%1$d plně naučených slov!</item>
+        <item quantity="other">%1$d plně naučených slov!</item>
+    </plurals>
     <string name="study_complete_words_milestone_subtitle">Slova, která opravdu použiješ.</string>
     <string name="study_action_done_for_now">Pro teď hotovo</string>
     <string name="study_progress_count">%1$d z %2$d</string>

--- a/composeApp/src/commonMain/composeResources/values-de/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-de/strings.xml
@@ -672,7 +672,12 @@
     <string name="study_complete_milestone_subtitle_50">Fünfzig Tage ohne Unterbrechung. Engagiert und beständig.</string>
     <string name="study_complete_milestone_subtitle_100">Einhundert Tage ohne Unterbrechung. Ein unglaublicher Meilenstein.</string>
     <string name="study_complete_milestone_subtitle_generic">%1$d Tage ohne Unterbrechung. Halte die Serie am Laufen.</string>
-    <string name="study_complete_words_milestone_title">%1$d Wörter vollständig gelernt!</string>
+    <plurals name="study_complete_words_milestone_title">
+        <item quantity="one">%1$d Wort vollständig gelernt!</item>
+        <item quantity="few">%1$d Wörter vollständig gelernt!</item>
+        <item quantity="many">%1$d Wörter vollständig gelernt!</item>
+        <item quantity="other">%1$d Wörter vollständig gelernt!</item>
+    </plurals>
     <string name="study_complete_words_milestone_subtitle">Wörter, die du wirklich benutzen wirst.</string>
     <string name="study_action_done_for_now">Für jetzt genug</string>
     <string name="study_progress_count">%1$d von %2$d</string>

--- a/composeApp/src/commonMain/composeResources/values-de/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-de/strings.xml
@@ -672,6 +672,8 @@
     <string name="study_complete_milestone_subtitle_50">Fünfzig Tage ohne Unterbrechung. Engagiert und beständig.</string>
     <string name="study_complete_milestone_subtitle_100">Einhundert Tage ohne Unterbrechung. Ein unglaublicher Meilenstein.</string>
     <string name="study_complete_milestone_subtitle_generic">%1$d Tage ohne Unterbrechung. Halte die Serie am Laufen.</string>
+    <string name="study_complete_words_milestone_title">%1$d Wörter vollständig gelernt!</string>
+    <string name="study_complete_words_milestone_subtitle">Wörter, die du wirklich benutzen wirst.</string>
     <string name="study_action_done_for_now">Für jetzt genug</string>
     <string name="study_progress_count">%1$d von %2$d</string>
     <string name="study_tap_to_flip">Zum Umdrehen tippen</string>

--- a/composeApp/src/commonMain/composeResources/values-es/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-es/strings.xml
@@ -672,6 +672,8 @@
     <string name="study_complete_milestone_subtitle_50">Cincuenta días sin fallar. Dedicación y constancia.</string>
     <string name="study_complete_milestone_subtitle_100">Cien días sin fallar. Un hito increíble.</string>
     <string name="study_complete_milestone_subtitle_generic">%1$d días sin fallar. Mantén la racha.</string>
+    <string name="study_complete_words_milestone_title">¡%1$d palabras aprendidas por completo!</string>
+    <string name="study_complete_words_milestone_subtitle">Palabras que de verdad usarás.</string>
     <string name="study_action_done_for_now">Por ahora basta</string>
     <string name="study_progress_count">%1$d de %2$d</string>
     <string name="study_tap_to_flip">Toca para girar</string>

--- a/composeApp/src/commonMain/composeResources/values-es/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-es/strings.xml
@@ -672,7 +672,12 @@
     <string name="study_complete_milestone_subtitle_50">Cincuenta días sin fallar. Dedicación y constancia.</string>
     <string name="study_complete_milestone_subtitle_100">Cien días sin fallar. Un hito increíble.</string>
     <string name="study_complete_milestone_subtitle_generic">%1$d días sin fallar. Mantén la racha.</string>
-    <string name="study_complete_words_milestone_title">¡%1$d palabras aprendidas por completo!</string>
+    <plurals name="study_complete_words_milestone_title">
+        <item quantity="one">¡%1$d palabra aprendida por completo!</item>
+        <item quantity="few">¡%1$d palabras aprendidas por completo!</item>
+        <item quantity="many">¡%1$d palabras aprendidas por completo!</item>
+        <item quantity="other">¡%1$d palabras aprendidas por completo!</item>
+    </plurals>
     <string name="study_complete_words_milestone_subtitle">Palabras que de verdad usarás.</string>
     <string name="study_action_done_for_now">Por ahora basta</string>
     <string name="study_progress_count">%1$d de %2$d</string>

--- a/composeApp/src/commonMain/composeResources/values-fr/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-fr/strings.xml
@@ -672,7 +672,12 @@
     <string name="study_complete_milestone_subtitle_50">Cinquante jours sans interruption. Assidu et régulier.</string>
     <string name="study_complete_milestone_subtitle_100">Cent jours sans interruption. Un cap incroyable.</string>
     <string name="study_complete_milestone_subtitle_generic">%1$d jours sans interruption. Continue sur ta lancée.</string>
-    <string name="study_complete_words_milestone_title">%1$d mots entièrement appris !</string>
+    <plurals name="study_complete_words_milestone_title">
+        <item quantity="one">%1$d mot entièrement appris !</item>
+        <item quantity="few">%1$d mots entièrement appris !</item>
+        <item quantity="many">%1$d mots entièrement appris !</item>
+        <item quantity="other">%1$d mots entièrement appris !</item>
+    </plurals>
     <string name="study_complete_words_milestone_subtitle">Des mots que tu utiliseras vraiment.</string>
     <string name="study_action_done_for_now">Terminé pour l'instant</string>
     <string name="study_progress_count">%1$d sur %2$d</string>

--- a/composeApp/src/commonMain/composeResources/values-fr/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-fr/strings.xml
@@ -672,6 +672,8 @@
     <string name="study_complete_milestone_subtitle_50">Cinquante jours sans interruption. Assidu et régulier.</string>
     <string name="study_complete_milestone_subtitle_100">Cent jours sans interruption. Un cap incroyable.</string>
     <string name="study_complete_milestone_subtitle_generic">%1$d jours sans interruption. Continue sur ta lancée.</string>
+    <string name="study_complete_words_milestone_title">%1$d mots entièrement appris !</string>
+    <string name="study_complete_words_milestone_subtitle">Des mots que tu utiliseras vraiment.</string>
     <string name="study_action_done_for_now">Terminé pour l'instant</string>
     <string name="study_progress_count">%1$d sur %2$d</string>
     <string name="study_tap_to_flip">Touche pour retourner</string>

--- a/composeApp/src/commonMain/composeResources/values-it/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-it/strings.xml
@@ -672,7 +672,12 @@
     <string name="study_complete_milestone_subtitle_50">Cinquanta giorni senza interruzioni. Dedizione e costanza.</string>
     <string name="study_complete_milestone_subtitle_100">Cento giorni senza interruzioni. Un traguardo incredibile.</string>
     <string name="study_complete_milestone_subtitle_generic">%1$d giorni senza interruzioni. Continua la serie.</string>
-    <string name="study_complete_words_milestone_title">%1$d parole imparate a fondo!</string>
+    <plurals name="study_complete_words_milestone_title">
+        <item quantity="one">%1$d parola imparata a fondo!</item>
+        <item quantity="few">%1$d parole imparate a fondo!</item>
+        <item quantity="many">%1$d parole imparate a fondo!</item>
+        <item quantity="other">%1$d parole imparate a fondo!</item>
+    </plurals>
     <string name="study_complete_words_milestone_subtitle">Parole che userai davvero.</string>
     <string name="study_action_done_for_now">Per ora basta</string>
     <string name="study_progress_count">%1$d di %2$d</string>

--- a/composeApp/src/commonMain/composeResources/values-it/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-it/strings.xml
@@ -672,6 +672,8 @@
     <string name="study_complete_milestone_subtitle_50">Cinquanta giorni senza interruzioni. Dedizione e costanza.</string>
     <string name="study_complete_milestone_subtitle_100">Cento giorni senza interruzioni. Un traguardo incredibile.</string>
     <string name="study_complete_milestone_subtitle_generic">%1$d giorni senza interruzioni. Continua la serie.</string>
+    <string name="study_complete_words_milestone_title">%1$d parole imparate a fondo!</string>
+    <string name="study_complete_words_milestone_subtitle">Parole che userai davvero.</string>
     <string name="study_action_done_for_now">Per ora basta</string>
     <string name="study_progress_count">%1$d di %2$d</string>
     <string name="study_tap_to_flip">Tocca per girare</string>

--- a/composeApp/src/commonMain/composeResources/values-nl/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-nl/strings.xml
@@ -673,6 +673,8 @@
     <string name="study_complete_milestone_subtitle_50">Vijftig dagen zonder pauze. Pure toewijding en discipline.</string>
     <string name="study_complete_milestone_subtitle_100">Honderd dagen onafgebroken. Een ongelooflijke mijlpaal.</string>
     <string name="study_complete_milestone_subtitle_generic">%1$d dagen zonder te missen. Houd deze streak vast.</string>
+    <string name="study_complete_words_milestone_title">%1$d woorden volledig geleerd!</string>
+    <string name="study_complete_words_milestone_subtitle">Woorden die je echt gaat gebruiken.</string>
     <string name="study_action_done_for_now">Klaar voor nu</string>
     <string name="study_progress_count">%1$d van %2$d</string>
     <string name="study_tap_to_flip">Tik om te draaien</string>

--- a/composeApp/src/commonMain/composeResources/values-nl/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-nl/strings.xml
@@ -673,7 +673,12 @@
     <string name="study_complete_milestone_subtitle_50">Vijftig dagen zonder pauze. Pure toewijding en discipline.</string>
     <string name="study_complete_milestone_subtitle_100">Honderd dagen onafgebroken. Een ongelooflijke mijlpaal.</string>
     <string name="study_complete_milestone_subtitle_generic">%1$d dagen zonder te missen. Houd deze streak vast.</string>
-    <string name="study_complete_words_milestone_title">%1$d woorden volledig geleerd!</string>
+    <plurals name="study_complete_words_milestone_title">
+        <item quantity="one">%1$d woord volledig geleerd!</item>
+        <item quantity="few">%1$d woorden volledig geleerd!</item>
+        <item quantity="many">%1$d woorden volledig geleerd!</item>
+        <item quantity="other">%1$d woorden volledig geleerd!</item>
+    </plurals>
     <string name="study_complete_words_milestone_subtitle">Woorden die je echt gaat gebruiken.</string>
     <string name="study_action_done_for_now">Klaar voor nu</string>
     <string name="study_progress_count">%1$d van %2$d</string>

--- a/composeApp/src/commonMain/composeResources/values-pl/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-pl/strings.xml
@@ -674,7 +674,12 @@
     <string name="study_complete_milestone_subtitle_50">Pięćdziesiąt dni bez żadnej przerwy. Wyjątkowa dyscyplina.</string>
     <string name="study_complete_milestone_subtitle_100">Sto dni bez przerwy. Niesamowite osiągnięcie.</string>
     <string name="study_complete_milestone_subtitle_generic">%1$d dni bez przerwy. Utrzymaj tę serię.</string>
-    <string name="study_complete_words_milestone_title">%1$d słów w pełni opanowanych!</string>
+    <plurals name="study_complete_words_milestone_title">
+        <item quantity="one">%1$d słowo w pełni opanowane!</item>
+        <item quantity="few">%1$d słowa w pełni opanowane!</item>
+        <item quantity="many">%1$d słów w pełni opanowanych!</item>
+        <item quantity="other">%1$d słowa w pełni opanowane!</item>
+    </plurals>
     <string name="study_complete_words_milestone_subtitle">Słowa, których naprawdę użyjesz.</string>
     <string name="study_action_done_for_now">Na dziś wystarczy</string>
     <string name="study_progress_count">%1$d z %2$d</string>

--- a/composeApp/src/commonMain/composeResources/values-pl/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-pl/strings.xml
@@ -674,6 +674,8 @@
     <string name="study_complete_milestone_subtitle_50">Pięćdziesiąt dni bez żadnej przerwy. Wyjątkowa dyscyplina.</string>
     <string name="study_complete_milestone_subtitle_100">Sto dni bez przerwy. Niesamowite osiągnięcie.</string>
     <string name="study_complete_milestone_subtitle_generic">%1$d dni bez przerwy. Utrzymaj tę serię.</string>
+    <string name="study_complete_words_milestone_title">%1$d słów w pełni opanowanych!</string>
+    <string name="study_complete_words_milestone_subtitle">Słowa, których naprawdę użyjesz.</string>
     <string name="study_action_done_for_now">Na dziś wystarczy</string>
     <string name="study_progress_count">%1$d z %2$d</string>
     <string name="study_tap_to_flip">Dotknij, aby odwrócić</string>

--- a/composeApp/src/commonMain/composeResources/values-ru/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-ru/strings.xml
@@ -672,7 +672,12 @@
     <string name="study_complete_milestone_subtitle_50">Пятьдесят дней без единого пропуска. Отличная дисциплина.</string>
     <string name="study_complete_milestone_subtitle_100">Сто дней без перерыва. Невероятное достижение.</string>
     <string name="study_complete_milestone_subtitle_generic">%1$d дней без пропусков. Продолжайте в том же духе.</string>
-    <string name="study_complete_words_milestone_title">%1$d слов выучено полностью!</string>
+    <plurals name="study_complete_words_milestone_title">
+        <item quantity="one">%1$d слово выучено полностью!</item>
+        <item quantity="few">%1$d слова выучены полностью!</item>
+        <item quantity="many">%1$d слов выучено полностью!</item>
+        <item quantity="other">%1$d слова выучены полностью!</item>
+    </plurals>
     <string name="study_complete_words_milestone_subtitle">Слова, которые теперь в вашем активном запасе.</string>
     <string name="study_action_done_for_now">На сегодня хватит</string>
     <string name="study_progress_count">%1$d из %2$d</string>

--- a/composeApp/src/commonMain/composeResources/values-ru/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-ru/strings.xml
@@ -672,6 +672,8 @@
     <string name="study_complete_milestone_subtitle_50">Пятьдесят дней без единого пропуска. Отличная дисциплина.</string>
     <string name="study_complete_milestone_subtitle_100">Сто дней без перерыва. Невероятное достижение.</string>
     <string name="study_complete_milestone_subtitle_generic">%1$d дней без пропусков. Продолжайте в том же духе.</string>
+    <string name="study_complete_words_milestone_title">%1$d слов выучено полностью!</string>
+    <string name="study_complete_words_milestone_subtitle">Слова, которые теперь в вашем активном запасе.</string>
     <string name="study_action_done_for_now">На сегодня хватит</string>
     <string name="study_progress_count">%1$d из %2$d</string>
     <string name="study_tap_to_flip">Нажмите, чтобы перевернуть</string>

--- a/composeApp/src/commonMain/composeResources/values-tr/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-tr/strings.xml
@@ -672,7 +672,12 @@
     <string name="study_complete_milestone_subtitle_50">Aralıksız elli gün. Kararlı ve istikrarlı.</string>
     <string name="study_complete_milestone_subtitle_100">Aralıksız yüz gün. İnanılmaz bir dönüm noktası.</string>
     <string name="study_complete_milestone_subtitle_generic">Aralıksız %1$d gün. Seriyi sürdür.</string>
-    <string name="study_complete_words_milestone_title">%1$d kelime tamamen öğrenildi!</string>
+    <plurals name="study_complete_words_milestone_title">
+        <item quantity="one">%1$d kelime tamamen öğrenildi!</item>
+        <item quantity="few">%1$d kelime tamamen öğrenildi!</item>
+        <item quantity="many">%1$d kelime tamamen öğrenildi!</item>
+        <item quantity="other">%1$d kelime tamamen öğrenildi!</item>
+    </plurals>
     <string name="study_complete_words_milestone_subtitle">Gerçekten kullanacağın kelimeler.</string>
     <string name="study_action_done_for_now">Şimdilik bu kadar</string>
     <string name="study_progress_count">%1$d / %2$d</string>

--- a/composeApp/src/commonMain/composeResources/values-tr/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-tr/strings.xml
@@ -672,6 +672,8 @@
     <string name="study_complete_milestone_subtitle_50">Aralıksız elli gün. Kararlı ve istikrarlı.</string>
     <string name="study_complete_milestone_subtitle_100">Aralıksız yüz gün. İnanılmaz bir dönüm noktası.</string>
     <string name="study_complete_milestone_subtitle_generic">Aralıksız %1$d gün. Seriyi sürdür.</string>
+    <string name="study_complete_words_milestone_title">%1$d kelime tamamen öğrenildi!</string>
+    <string name="study_complete_words_milestone_subtitle">Gerçekten kullanacağın kelimeler.</string>
     <string name="study_action_done_for_now">Şimdilik bu kadar</string>
     <string name="study_progress_count">%1$d / %2$d</string>
     <string name="study_tap_to_flip">Çevirmek için dokun</string>

--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -672,7 +672,12 @@
     <string name="study_complete_milestone_subtitle_50">Fifty days unbroken. Dedicated and consistent.</string>
     <string name="study_complete_milestone_subtitle_100">One hundred days unbroken. An incredible milestone.</string>
     <string name="study_complete_milestone_subtitle_generic">%1$d days unbroken. Keep the streak going.</string>
-    <string name="study_complete_words_milestone_title">%1$d words fully learned!</string>
+    <plurals name="study_complete_words_milestone_title">
+        <item quantity="one">%1$d word fully learned!</item>
+        <item quantity="few">%1$d words fully learned!</item>
+        <item quantity="many">%1$d words fully learned!</item>
+        <item quantity="other">%1$d words fully learned!</item>
+    </plurals>
     <string name="study_complete_words_milestone_subtitle">Words you'll actually use.</string>
     <string name="study_action_done_for_now">Done for now</string>
     <string name="study_progress_count">%1$d of %2$d</string>

--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -672,6 +672,8 @@
     <string name="study_complete_milestone_subtitle_50">Fifty days unbroken. Dedicated and consistent.</string>
     <string name="study_complete_milestone_subtitle_100">One hundred days unbroken. An incredible milestone.</string>
     <string name="study_complete_milestone_subtitle_generic">%1$d days unbroken. Keep the streak going.</string>
+    <string name="study_complete_words_milestone_title">%1$d words fully learned!</string>
+    <string name="study_complete_words_milestone_subtitle">Words you'll actually use.</string>
     <string name="study_action_done_for_now">Done for now</string>
     <string name="study_progress_count">%1$d of %2$d</string>
     <string name="study_tap_to_flip">Tap to flip</string>

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/study/MilestoneCompleteHero.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/study/MilestoneCompleteHero.kt
@@ -1,40 +1,12 @@
 package com.slovy.slovymovyapp.ui.study
 
-import androidx.compose.foundation.BorderStroke
-import androidx.compose.foundation.Canvas
-import androidx.compose.foundation.background
-import androidx.compose.foundation.border
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.widthIn
-import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.remember
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
-import androidx.compose.ui.geometry.Offset
-import androidx.compose.ui.geometry.Size
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.drawscope.rotate
-import androidx.compose.ui.text.font.FontStyle
-import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
-import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import com.slovy.slovymovyapp.ui.ThemePreviewProvider
 import com.slovy.slovymovyapp.ui.ThemedPreview
-import com.slovy.slovymovyapp.ui.theme.AppSpacing
-import com.slovy.slovymovyapp.ui.theme.serifFontFamily
 import org.jetbrains.compose.resources.stringResource
 import slovymovyapp.composeapp.generated.resources.*
 
@@ -43,81 +15,19 @@ internal fun MilestoneCompleteHero(
     streakDays: Int,
     modifier: Modifier = Modifier,
 ) {
-    val primary = MaterialTheme.colorScheme.primary
-    val tertiary = MaterialTheme.colorScheme.tertiary
-
-    Box(
-        modifier = modifier
-            .border(BorderStroke(0.5.dp, MaterialTheme.colorScheme.primary.copy(alpha = 0.3f)), RoundedCornerShape(22.dp))
-            .clip(RoundedCornerShape(22.dp))
-            .background(MaterialTheme.colorScheme.primaryContainer),
-        contentAlignment = Alignment.Center,
-    ) {
-        MilestoneConfetti(
-            primary = primary,
-            tertiary = tertiary,
-            modifier = Modifier.matchParentSize(),
-        )
-        Column(
-            horizontalAlignment = Alignment.CenterHorizontally,
-            verticalArrangement = Arrangement.spacedBy(AppSpacing.md),
-            modifier = Modifier
-                .align(Alignment.Center)
-                .padding(start = 22.dp, top = 22.dp, end = 22.dp, bottom = 24.dp),
-        ) {
-            val medallionCount by rememberCountUp(
-                target = streakDays,
-                delayMillis = MedallionCountUpDelayMillis,
-                durationMillis = MedallionCountUpDurationMillis,
-                label = "medallionCount",
-            )
-            Box(
-                modifier = Modifier
-                    .rewardEntrance(RewardElement.MEDALLION)
-                    .size(76.dp)
-                    .clip(CircleShape)
-                    .background(MaterialTheme.colorScheme.primary),
-                contentAlignment = Alignment.Center,
-            ) {
-                Text(
-                    text = medallionCount.toString(),
-                    style = MaterialTheme.typography.displaySmall.copy(
-                        fontFamily = MaterialTheme.serifFontFamily,
-                        fontWeight = FontWeight.SemiBold,
-                        fontSize = 34.sp,
-                        lineHeight = 34.sp,
-                        letterSpacing = (-1.2).sp,
-                    ),
-                    color = MaterialTheme.colorScheme.onPrimary,
-                    textAlign = TextAlign.Center,
-                )
-            }
-            Text(
-                text = milestoneTitle(streakDays),
-                style = MaterialTheme.typography.headlineSmall.copy(
-                    fontFamily = MaterialTheme.serifFontFamily,
-                    fontWeight = FontWeight.SemiBold,
-                    fontSize = 22.sp,
-                    lineHeight = 24.sp,
-                    letterSpacing = (-0.3).sp,
-                ),
-                color = MaterialTheme.colorScheme.onPrimaryContainer,
-                textAlign = TextAlign.Center,
-            )
-            Text(
-                text = milestoneSubtitle(streakDays),
-                style = MaterialTheme.typography.bodyMedium.copy(
-                    fontFamily = MaterialTheme.serifFontFamily,
-                    fontStyle = FontStyle.Italic,
-                    fontSize = 14.sp,
-                    lineHeight = 20.sp,
-                ),
-                color = MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.78f),
-                textAlign = TextAlign.Center,
-                modifier = Modifier.widthIn(max = 250.dp),
-            )
-        }
-    }
+    MilestoneHeroCard(
+        medallionTarget = streakDays,
+        title = milestoneTitle(streakDays),
+        subtitle = milestoneSubtitle(streakDays),
+        colors = MilestoneHeroColors(
+            container = MaterialTheme.colorScheme.primaryContainer,
+            onContainer = MaterialTheme.colorScheme.onPrimaryContainer,
+            accent = MaterialTheme.colorScheme.primary,
+            onAccent = MaterialTheme.colorScheme.onPrimary,
+            confettiSecondary = MaterialTheme.colorScheme.tertiary,
+        ),
+        modifier = modifier,
+    )
 }
 
 @Composable
@@ -138,91 +48,6 @@ private fun milestoneSubtitle(days: Int): String = when (days) {
     50 -> stringResource(Res.string.study_complete_milestone_subtitle_50)
     100 -> stringResource(Res.string.study_complete_milestone_subtitle_100)
     else -> stringResource(Res.string.study_complete_milestone_subtitle_generic, days)
-}
-
-@Composable
-private fun MilestoneConfetti(
-    primary: Color,
-    tertiary: Color,
-    modifier: Modifier = Modifier,
-) {
-    val pieces = remember(primary, tertiary) {
-        listOf(
-            ConfettiPiece(0.12f, 0.18f, ConfettiShape.DOT, primary, 5f, 0f),
-            ConfettiPiece(0.88f, 0.24f, ConfettiShape.TICK, tertiary, 8f, 28f),
-            ConfettiPiece(0.22f, 0.44f, ConfettiShape.TICK, Color(0xFFE9C049), 9f, -18f),
-            ConfettiPiece(0.78f, 0.50f, ConfettiShape.DOT, primary, 4f, 0f),
-            ConfettiPiece(0.36f, 0.08f, ConfettiShape.TICK, Color(0xFFC46060), 7f, 12f),
-            ConfettiPiece(0.68f, 0.12f, ConfettiShape.DOT, tertiary, 4f, 0f),
-            ConfettiPiece(0.08f, 0.70f, ConfettiShape.TICK, primary, 8f, -36f),
-            ConfettiPiece(0.92f, 0.76f, ConfettiShape.TICK, Color(0xFFE9C049), 9f, 22f),
-            ConfettiPiece(0.52f, 0.04f, ConfettiShape.DOT, Color(0xFFC46060), 5f, 0f),
-            ConfettiPiece(0.16f, 0.88f, ConfettiShape.DOT, Color(0xFFE9C049), 6f, 0f),
-            ConfettiPiece(0.84f, 0.92f, ConfettiShape.TICK, tertiary, 7f, 8f),
-            ConfettiPiece(0.46f, 0.96f, ConfettiShape.TICK, primary, 6f, -12f),
-        )
-    }
-
-    // One-shot fall per piece (§8b rwFall), staggered by 55ms. Never loops; finished state = 1f.
-    val fall = pieces.mapIndexed { index, _ ->
-        rememberRewardEntranceFloat(
-            hiddenValue = 0f,
-            playedValue = 1f,
-            delayMillis = ConfettiBaseDelayMillis + index * ConfettiPieceStaggerMillis,
-            durationMillis = ConfettiDurationMillis,
-            easing = ConfettiEase,
-            label = "confetti[$index]",
-        )
-    }
-
-    Canvas(modifier = modifier) {
-        pieces.forEachIndexed { index, piece ->
-            val t = fall[index].value
-            // rwFall: drops from -42px, fades in over the first 30% of travel, lands upright.
-            val fallAlpha = (t / 0.3f).coerceIn(0f, 1f)
-            val alpha = 0.55f * fallAlpha
-            if (alpha <= 0f) return@forEachIndexed
-            val center = Offset(
-                x = piece.x * size.width,
-                y = piece.y * size.height + (1f - t) * (-42.dp.toPx()),
-            )
-            rotate(degrees = piece.rotation + (1f - t) * -40f, pivot = center) {
-                if (piece.shape == ConfettiShape.DOT) {
-                    drawCircle(
-                        color = piece.color.copy(alpha = alpha),
-                        radius = piece.size.dp.toPx() / 2f,
-                        center = center,
-                    )
-                } else {
-                    drawRoundRect(
-                        color = piece.color.copy(alpha = alpha),
-                        topLeft = Offset(
-                            x = center.x - piece.size.dp.toPx() * 1.1f,
-                            y = center.y - piece.size.dp.toPx() * 0.25f,
-                        ),
-                        size = Size(
-                            width = piece.size.dp.toPx() * 2.2f,
-                            height = piece.size.dp.toPx() * 0.5f,
-                        ),
-                    )
-                }
-            }
-        }
-    }
-}
-
-private data class ConfettiPiece(
-    val x: Float,
-    val y: Float,
-    val shape: ConfettiShape,
-    val color: Color,
-    val size: Float,
-    val rotation: Float,
-)
-
-private enum class ConfettiShape {
-    DOT,
-    TICK,
 }
 
 // Run this preview in interactive mode and tap the hero to (re)play the entrance choreography.

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/study/MilestoneHeroCard.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/study/MilestoneHeroCard.kt
@@ -1,0 +1,213 @@
+package com.slovy.slovymovyapp.ui.study
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.drawscope.rotate
+import androidx.compose.ui.text.font.FontStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.TextUnit
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.slovy.slovymovyapp.ui.theme.AppSpacing
+import com.slovy.slovymovyapp.ui.theme.serifFontFamily
+
+internal data class MilestoneHeroColors(
+    val container: Color,
+    val onContainer: Color,
+    val accent: Color,
+    val onAccent: Color,
+    val confettiSecondary: Color,
+)
+
+// The shared medallion-card skeleton for milestone heroes (streak and words-learned).
+// The two are choreography siblings by design: identical pop/count-up/confetti timing,
+// differing only in palette, copy, and medallion digit size.
+@Composable
+internal fun MilestoneHeroCard(
+    medallionTarget: Int,
+    title: String,
+    subtitle: String,
+    colors: MilestoneHeroColors,
+    modifier: Modifier = Modifier,
+    medallionFontSize: TextUnit = 34.sp,
+) {
+    Box(
+        modifier = modifier
+            .border(BorderStroke(0.5.dp, colors.accent.copy(alpha = 0.3f)), RoundedCornerShape(22.dp))
+            .clip(RoundedCornerShape(22.dp))
+            .background(colors.container),
+        contentAlignment = Alignment.Center,
+    ) {
+        MilestoneConfetti(
+            accent = colors.accent,
+            secondary = colors.confettiSecondary,
+            modifier = Modifier.matchParentSize(),
+        )
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(AppSpacing.md),
+            modifier = Modifier
+                .align(Alignment.Center)
+                .padding(start = 22.dp, top = 22.dp, end = 22.dp, bottom = 24.dp),
+        ) {
+            val medallionCount by rememberCountUp(
+                target = medallionTarget,
+                delayMillis = MedallionCountUpDelayMillis,
+                durationMillis = MedallionCountUpDurationMillis,
+                label = "medallionCount",
+            )
+            Box(
+                modifier = Modifier
+                    .rewardEntrance(RewardElement.MEDALLION)
+                    .size(76.dp)
+                    .clip(CircleShape)
+                    .background(colors.accent),
+                contentAlignment = Alignment.Center,
+            ) {
+                Text(
+                    text = medallionCount.toString(),
+                    style = MaterialTheme.typography.displaySmall.copy(
+                        fontFamily = MaterialTheme.serifFontFamily,
+                        fontWeight = FontWeight.SemiBold,
+                        fontSize = medallionFontSize,
+                        lineHeight = medallionFontSize,
+                        letterSpacing = (-1.2).sp,
+                    ),
+                    color = colors.onAccent,
+                    textAlign = TextAlign.Center,
+                )
+            }
+            Text(
+                text = title,
+                style = MaterialTheme.typography.headlineSmall.copy(
+                    fontFamily = MaterialTheme.serifFontFamily,
+                    fontWeight = FontWeight.SemiBold,
+                    fontSize = 22.sp,
+                    lineHeight = 24.sp,
+                    letterSpacing = (-0.3).sp,
+                ),
+                color = colors.onContainer,
+                textAlign = TextAlign.Center,
+            )
+            Text(
+                text = subtitle,
+                style = MaterialTheme.typography.bodyMedium.copy(
+                    fontFamily = MaterialTheme.serifFontFamily,
+                    fontStyle = FontStyle.Italic,
+                    fontSize = 14.sp,
+                    lineHeight = 20.sp,
+                ),
+                color = colors.onContainer.copy(alpha = 0.78f),
+                textAlign = TextAlign.Center,
+                modifier = Modifier.widthIn(max = 250.dp),
+            )
+        }
+    }
+}
+
+@Composable
+private fun MilestoneConfetti(
+    accent: Color,
+    secondary: Color,
+    modifier: Modifier = Modifier,
+) {
+    val pieces = remember(accent, secondary) {
+        listOf(
+            ConfettiPiece(0.12f, 0.18f, ConfettiShape.DOT, accent, 5f, 0f),
+            ConfettiPiece(0.88f, 0.24f, ConfettiShape.TICK, secondary, 8f, 28f),
+            ConfettiPiece(0.22f, 0.44f, ConfettiShape.TICK, Color(0xFFE9C049), 9f, -18f),
+            ConfettiPiece(0.78f, 0.50f, ConfettiShape.DOT, accent, 4f, 0f),
+            ConfettiPiece(0.36f, 0.08f, ConfettiShape.TICK, Color(0xFFC46060), 7f, 12f),
+            ConfettiPiece(0.68f, 0.12f, ConfettiShape.DOT, secondary, 4f, 0f),
+            ConfettiPiece(0.08f, 0.70f, ConfettiShape.TICK, accent, 8f, -36f),
+            ConfettiPiece(0.92f, 0.76f, ConfettiShape.TICK, Color(0xFFE9C049), 9f, 22f),
+            ConfettiPiece(0.52f, 0.04f, ConfettiShape.DOT, Color(0xFFC46060), 5f, 0f),
+            ConfettiPiece(0.16f, 0.88f, ConfettiShape.DOT, Color(0xFFE9C049), 6f, 0f),
+            ConfettiPiece(0.84f, 0.92f, ConfettiShape.TICK, secondary, 7f, 8f),
+            ConfettiPiece(0.46f, 0.96f, ConfettiShape.TICK, accent, 6f, -12f),
+        )
+    }
+
+    // One-shot fall per piece (§8b rwFall), staggered by 55ms. Never loops; finished state = 1f.
+    val fall = pieces.mapIndexed { index, _ ->
+        rememberRewardEntranceFloat(
+            hiddenValue = 0f,
+            playedValue = 1f,
+            delayMillis = ConfettiBaseDelayMillis + index * ConfettiPieceStaggerMillis,
+            durationMillis = ConfettiDurationMillis,
+            easing = ConfettiEase,
+            label = "confetti[$index]",
+        )
+    }
+
+    Canvas(modifier = modifier) {
+        pieces.forEachIndexed { index, piece ->
+            val t = fall[index].value
+            // rwFall: drops from -42px, fades in over the first 30% of travel, lands upright.
+            val fallAlpha = (t / 0.3f).coerceIn(0f, 1f)
+            val alpha = 0.55f * fallAlpha
+            if (alpha <= 0f) return@forEachIndexed
+            val center = Offset(
+                x = piece.x * size.width,
+                y = piece.y * size.height + (1f - t) * (-42.dp.toPx()),
+            )
+            rotate(degrees = piece.rotation + (1f - t) * -40f, pivot = center) {
+                if (piece.shape == ConfettiShape.DOT) {
+                    drawCircle(
+                        color = piece.color.copy(alpha = alpha),
+                        radius = piece.size.dp.toPx() / 2f,
+                        center = center,
+                    )
+                } else {
+                    drawRoundRect(
+                        color = piece.color.copy(alpha = alpha),
+                        topLeft = Offset(
+                            x = center.x - piece.size.dp.toPx() * 1.1f,
+                            y = center.y - piece.size.dp.toPx() * 0.25f,
+                        ),
+                        size = Size(
+                            width = piece.size.dp.toPx() * 2.2f,
+                            height = piece.size.dp.toPx() * 0.5f,
+                        ),
+                    )
+                }
+            }
+        }
+    }
+}
+
+private data class ConfettiPiece(
+    val x: Float,
+    val y: Float,
+    val shape: ConfettiShape,
+    val color: Color,
+    val size: Float,
+    val rotation: Float,
+)
+
+private enum class ConfettiShape {
+    DOT,
+    TICK,
+}

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/study/StudySessionCompleteModels.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/study/StudySessionCompleteModels.kt
@@ -17,6 +17,10 @@ sealed interface StudySessionCompleteHero {
         val streakDays: Int,
     ) : StudySessionCompleteHero
 
+    data class WordsMilestone(
+        val learnedTotal: Int,
+    ) : StudySessionCompleteHero
+
     data class PipelineShift(
         val stages: List<PipelineShiftStageUiState>,
     ) : StudySessionCompleteHero

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/study/StudySessionCompletePreviewData.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/study/StudySessionCompletePreviewData.kt
@@ -42,6 +42,17 @@ object StudySessionCompletePreviewData {
             reward = milestone(days = 100, cardsReviewed = 21, minutes = 10),
         ),
         StudySessionCompletePreviewCase(
+            label = "Words milestone",
+            description = "Lifetime words-learned mark crossed this session.",
+            reward = StudySessionCompleteUiState(
+                cardsReviewed = 16,
+                minutes = 7,
+                streakDays = 5,
+                message = "Nicely done!",
+                hero = StudySessionCompleteHero.WordsMilestone(learnedTotal = 51),
+            ),
+        ),
+        StudySessionCompletePreviewCase(
             label = "Pipeline shift",
             description = "Multiple stages move forward.",
             reward = StudySessionCompleteUiState(

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/study/StudySessionCompleteResolver.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/study/StudySessionCompleteResolver.kt
@@ -17,6 +17,24 @@ fun resolveStudySessionCompleteHero(
     pipelineBefore: List<StatsPipelineStage>,
     pipelineAfter: List<StatsPipelineStage>,
 ): StudySessionCompleteHero {
+    // Words milestone outranks everything: a lifetime vocabulary landmark is the rarest,
+    // biggest moment. Detection is intentionally session-window only (no persisted
+    // high-water mark), so a word slipping below the LEARNED threshold and recovering
+    // later may re-celebrate the same mark — accepted product decision.
+    // The empty-before guard keeps a missing session-start snapshot from reading as a
+    // giant crossing.
+    if (pipelineBefore.isNotEmpty()) {
+        val learnedAfter = learnedCount(pipelineAfter)
+        val mark = wordsMilestoneMark(
+            learnedBefore = learnedCount(pipelineBefore),
+            learnedAfter = learnedAfter,
+        )
+        if (mark != null) {
+            // The ladder mark only gates the celebration; the hero shows the real total.
+            return StudySessionCompleteHero.WordsMilestone(learnedTotal = learnedAfter)
+        }
+    }
+
     if (streakDays in MilestoneDays) {
         return StudySessionCompleteHero.Milestone(streakDays)
     }
@@ -27,6 +45,22 @@ fun resolveStudySessionCompleteHero(
     } else {
         StudySessionCompleteHero.None
     }
+}
+
+private fun learnedCount(pipeline: List<StatsPipelineStage>): Int =
+    pipeline.firstOrNull { it.id == StatsPipelineStageId.LEARNED }?.count ?: 0
+
+// Ladder: 5, then every 10 up to 100, then every 50 (unbounded). Returns the highest
+// mark crossed this session (before < mark <= after), or null when none was crossed.
+private fun wordsMilestoneMark(learnedBefore: Int, learnedAfter: Int): Int? {
+    val highestMarkAtOrBelowAfter = when {
+        learnedAfter >= 150 -> (learnedAfter / 50) * 50
+        learnedAfter >= 100 -> 100
+        learnedAfter >= 10 -> (learnedAfter / 10) * 10
+        learnedAfter >= 5 -> 5
+        else -> return null
+    }
+    return highestMarkAtOrBelowAfter.takeIf { it > learnedBefore }
 }
 
 private val PipelineShiftStageUiState.isHighSignalMove: Boolean

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/study/StudySessionCompleteScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/study/StudySessionCompleteScreen.kt
@@ -180,6 +180,7 @@ private fun StudySessionCompleteScaffold(
 private fun SlovyIcons.completeIllustration(hero: StudySessionCompleteHero): ImageVector =
     when (hero) {
         is StudySessionCompleteHero.Milestone -> OtterDaysStreakC
+        is StudySessionCompleteHero.WordsMilestone -> ImageOtterSessionComplete
         is StudySessionCompleteHero.PipelineShift -> OtterPipelineStreakC
         StudySessionCompleteHero.None -> ImageOtterSessionComplete
     }
@@ -236,6 +237,11 @@ private fun CompletionHero(
             modifier = modifier.fillMaxWidth(),
         )
 
+        is StudySessionCompleteHero.WordsMilestone -> WordsMilestoneCompleteHero(
+            learnedTotal = hero.learnedTotal,
+            modifier = modifier.fillMaxWidth(),
+        )
+
         is StudySessionCompleteHero.PipelineShift -> PipelineShiftCompleteHero(
             stages = hero.stages,
             modifier = modifier.fillMaxWidth(),
@@ -258,6 +264,28 @@ private fun StudySessionCompleteMilestonePreview(
                 streakDays = 7,
                 message = "Goed gedaan!",
                 hero = StudySessionCompleteHero.Milestone(streakDays = 7),
+            ),
+            scrollState = ScrollState(0),
+            onClose = {},
+            snackbarHostState = SnackbarHostState(),
+            animate = false,
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun StudySessionCompleteWordsMilestonePreview(
+    @PreviewParameter(ThemePreviewProvider::class) isDark: Boolean,
+) {
+    ThemedPreview(darkTheme = isDark) {
+        StudySessionCompleteContent(
+            reward = StudySessionCompleteUiState(
+                cardsReviewed = 15,
+                minutes = 7,
+                streakDays = 5,
+                message = "Goed gedaan!",
+                hero = StudySessionCompleteHero.WordsMilestone(learnedTotal = 11),
             ),
             scrollState = ScrollState(0),
             onClose = {},

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/study/WordsMilestoneCompleteHero.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/study/WordsMilestoneCompleteHero.kt
@@ -1,0 +1,69 @@
+package com.slovy.slovymovyapp.ui.study
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewParameter
+import androidx.compose.ui.unit.sp
+import com.slovy.slovymovyapp.ui.ThemePreviewProvider
+import com.slovy.slovymovyapp.ui.ThemedPreview
+import com.slovy.slovymovyapp.ui.theme.LocalIsDarkTheme
+import org.jetbrains.compose.resources.stringResource
+import slovymovyapp.composeapp.generated.resources.*
+
+// The pipeline-Learned green family, intentionally hardcoded like the pipeline swatches
+// (deeper than the 0xFF7CB078 bar swatch so white medallion digits stay legible).
+// Copper/primary stays reserved for the streak milestone so the two never look alike.
+private val WordsAccent = Color(0xFF4F8A4C)
+
+@Composable
+internal fun WordsMilestoneCompleteHero(
+    learnedTotal: Int,
+    modifier: Modifier = Modifier,
+) {
+    val dark = LocalIsDarkTheme.current
+    MilestoneHeroCard(
+        medallionTarget = learnedTotal,
+        title = stringResource(Res.string.study_complete_words_milestone_title, learnedTotal),
+        subtitle = stringResource(Res.string.study_complete_words_milestone_subtitle),
+        colors = MilestoneHeroColors(
+            container = if (dark) Color(0xFF26341F) else Color(0xFFE5F0E0),
+            onContainer = if (dark) Color(0xFFCFE3C6) else Color(0xFF254A22),
+            accent = WordsAccent,
+            onAccent = Color.White,
+            confettiSecondary = Color(0xFF7CB078),
+        ),
+        // Unlike the streak medallion (max 3 digits at a flat 34sp), the words count can
+        // reach 4 digits — shrink so the digits keep fitting the 76dp disc.
+        medallionFontSize = when {
+            learnedTotal >= 1000 -> 25.sp
+            learnedTotal >= 100 -> 30.sp
+            else -> 34.sp
+        },
+        modifier = modifier,
+    )
+}
+
+// Run this preview in interactive mode and tap the hero to (re)play the entrance choreography.
+@Preview
+@Composable
+private fun WordsMilestoneCompleteHeroEntrancePreview(
+    @PreviewParameter(ThemePreviewProvider::class) isDark: Boolean,
+) {
+    ThemedPreview(darkTheme = isDark) {
+        RewardEntrancePreviewPlayer {
+            WordsMilestoneCompleteHero(learnedTotal = 11)
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun WordsMilestoneCompleteHeroThreeDigitPreview(
+    @PreviewParameter(ThemePreviewProvider::class) isDark: Boolean,
+) {
+    ThemedPreview(darkTheme = isDark) {
+        WordsMilestoneCompleteHero(learnedTotal = 154)
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/study/WordsMilestoneCompleteHero.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/study/WordsMilestoneCompleteHero.kt
@@ -9,6 +9,7 @@ import androidx.compose.ui.unit.sp
 import com.slovy.slovymovyapp.ui.ThemePreviewProvider
 import com.slovy.slovymovyapp.ui.ThemedPreview
 import com.slovy.slovymovyapp.ui.theme.LocalIsDarkTheme
+import org.jetbrains.compose.resources.pluralStringResource
 import org.jetbrains.compose.resources.stringResource
 import slovymovyapp.composeapp.generated.resources.*
 
@@ -25,7 +26,7 @@ internal fun WordsMilestoneCompleteHero(
     val dark = LocalIsDarkTheme.current
     MilestoneHeroCard(
         medallionTarget = learnedTotal,
-        title = stringResource(Res.string.study_complete_words_milestone_title, learnedTotal),
+        title = pluralStringResource(Res.plurals.study_complete_words_milestone_title, learnedTotal, learnedTotal),
         subtitle = stringResource(Res.string.study_complete_words_milestone_subtitle),
         colors = MilestoneHeroColors(
             container = if (dark) Color(0xFF26341F) else Color(0xFFE5F0E0),

--- a/composeApp/src/commonTest/kotlin/com/slovy/slovymovyapp/ui/study/StudySessionCompleteResolverTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/slovy/slovymovyapp/ui/study/StudySessionCompleteResolverTest.kt
@@ -74,6 +74,164 @@ class StudySessionCompleteResolverTest {
         assertTrue(hero is StudySessionCompleteHero.PipelineShift)
     }
 
+    @Test
+    fun words_milestone_fires_on_first_mark() {
+        val hero = resolveStudySessionCompleteHero(
+            streakDays = 4,
+            pipelineBefore = pipeline(new = 10, fresh = 4, middle = 2, strong = 1, learned = 4),
+            pipelineAfter = pipeline(new = 10, fresh = 4, middle = 2, strong = 1, learned = 5),
+        )
+
+        assertEquals(StudySessionCompleteHero.WordsMilestone(learnedTotal = 5), hero)
+    }
+
+    @Test
+    fun words_milestone_shows_real_total_when_vaulting_several_marks() {
+        val hero = resolveStudySessionCompleteHero(
+            streakDays = 4,
+            pipelineBefore = pipeline(new = 10, fresh = 4, middle = 2, strong = 1, learned = 3),
+            pipelineAfter = pipeline(new = 10, fresh = 4, middle = 2, strong = 1, learned = 27),
+        )
+
+        assertEquals(StudySessionCompleteHero.WordsMilestone(learnedTotal = 27), hero)
+    }
+
+    @Test
+    fun words_milestone_beats_streak_milestone() {
+        val hero = resolveStudySessionCompleteHero(
+            streakDays = 7,
+            pipelineBefore = pipeline(new = 10, fresh = 4, middle = 2, strong = 1, learned = 9),
+            pipelineAfter = pipeline(new = 10, fresh = 4, middle = 2, strong = 1, learned = 10),
+        )
+
+        assertEquals(StudySessionCompleteHero.WordsMilestone(learnedTotal = 10), hero)
+    }
+
+    @Test
+    fun words_milestone_beats_pipeline_shift() {
+        val hero = resolveStudySessionCompleteHero(
+            streakDays = 4,
+            pipelineBefore = pipeline(new = 10, fresh = 4, middle = 2, strong = 1, learned = 4),
+            pipelineAfter = pipeline(new = 8, fresh = 4, middle = 2, strong = 3, learned = 6),
+        )
+
+        assertEquals(StudySessionCompleteHero.WordsMilestone(learnedTotal = 6), hero)
+    }
+
+    @Test
+    fun no_words_milestone_when_mark_was_already_reached_before_session() {
+        val hero = resolveStudySessionCompleteHero(
+            streakDays = 4,
+            pipelineBefore = pipeline(new = 10, fresh = 4, middle = 2, strong = 1, learned = 5),
+            pipelineAfter = pipeline(new = 10, fresh = 4, middle = 2, strong = 1, learned = 7),
+        )
+
+        assertTrue(
+            hero is StudySessionCompleteHero.PipelineShift,
+            "Learned growth without a mark crossing must fall through to the shift hero, got $hero",
+        )
+    }
+
+    @Test
+    fun no_words_milestone_when_learned_count_is_unchanged() {
+        val hero = resolveStudySessionCompleteHero(
+            streakDays = 7,
+            pipelineBefore = pipeline(new = 10, fresh = 4, middle = 2, strong = 1, learned = 10),
+            pipelineAfter = pipeline(new = 10, fresh = 4, middle = 2, strong = 1, learned = 10),
+        )
+
+        assertEquals(StudySessionCompleteHero.Milestone(streakDays = 7), hero)
+    }
+
+    @Test
+    fun no_words_milestone_below_first_mark() {
+        val hero = resolveStudySessionCompleteHero(
+            streakDays = 4,
+            pipelineBefore = pipeline(new = 10, fresh = 4, middle = 2, strong = 1, learned = 0),
+            pipelineAfter = pipeline(new = 10, fresh = 4, middle = 2, strong = 1, learned = 4),
+        )
+
+        assertTrue(
+            hero !is StudySessionCompleteHero.WordsMilestone,
+            "Learned counts below the first ladder mark must not celebrate, got $hero",
+        )
+    }
+
+    @Test
+    fun no_words_milestone_on_learned_regression() {
+        val hero = resolveStudySessionCompleteHero(
+            streakDays = 4,
+            pipelineBefore = pipeline(new = 10, fresh = 4, middle = 2, strong = 1, learned = 12),
+            pipelineAfter = pipeline(new = 10, fresh = 4, middle = 2, strong = 1, learned = 8),
+        )
+
+        assertTrue(
+            hero !is StudySessionCompleteHero.WordsMilestone,
+            "A shrinking learned count must not celebrate, got $hero",
+        )
+    }
+
+    @Test
+    fun words_milestone_ladder_hits_hundred() {
+        val hero = resolveStudySessionCompleteHero(
+            streakDays = 4,
+            pipelineBefore = pipeline(new = 10, fresh = 4, middle = 2, strong = 1, learned = 99),
+            pipelineAfter = pipeline(new = 10, fresh = 4, middle = 2, strong = 1, learned = 100),
+        )
+
+        assertEquals(StudySessionCompleteHero.WordsMilestone(learnedTotal = 100), hero)
+    }
+
+    @Test
+    fun words_milestone_ladder_has_no_marks_between_hundred_and_hundred_fifty() {
+        val hero = resolveStudySessionCompleteHero(
+            streakDays = 4,
+            pipelineBefore = pipeline(new = 10, fresh = 4, middle = 2, strong = 1, learned = 100),
+            pipelineAfter = pipeline(new = 10, fresh = 4, middle = 2, strong = 1, learned = 149),
+        )
+
+        assertTrue(
+            hero !is StudySessionCompleteHero.WordsMilestone,
+            "The ladder has no marks in 101..149, got $hero",
+        )
+    }
+
+    @Test
+    fun words_milestone_ladder_hits_hundred_fifty() {
+        val hero = resolveStudySessionCompleteHero(
+            streakDays = 4,
+            pipelineBefore = pipeline(new = 10, fresh = 4, middle = 2, strong = 1, learned = 149),
+            pipelineAfter = pipeline(new = 10, fresh = 4, middle = 2, strong = 1, learned = 150),
+        )
+
+        assertEquals(StudySessionCompleteHero.WordsMilestone(learnedTotal = 150), hero)
+    }
+
+    @Test
+    fun words_milestone_ladder_uses_fifty_steps_above_hundred_fifty() {
+        val hero = resolveStudySessionCompleteHero(
+            streakDays = 4,
+            pipelineBefore = pipeline(new = 10, fresh = 4, middle = 2, strong = 1, learned = 240),
+            pipelineAfter = pipeline(new = 10, fresh = 4, middle = 2, strong = 1, learned = 260),
+        )
+
+        assertEquals(StudySessionCompleteHero.WordsMilestone(learnedTotal = 260), hero)
+    }
+
+    @Test
+    fun no_words_milestone_with_empty_before_snapshot() {
+        val hero = resolveStudySessionCompleteHero(
+            streakDays = 4,
+            pipelineBefore = emptyList(),
+            pipelineAfter = pipeline(new = 10, fresh = 4, middle = 2, strong = 1, learned = 60),
+        )
+
+        assertTrue(
+            hero !is StudySessionCompleteHero.WordsMilestone,
+            "A missing session-start snapshot must not read as a crossing, got $hero",
+        )
+    }
+
     private fun pipeline(
         new: Int,
         fresh: Int,


### PR DESCRIPTION
## What

Adds a new conditional hero to the session-complete reward screen: a **lifetime words-learned milestone**. When the all-time Learned count (senses with min stability ≥ 90 days — the Stats screen number) crosses a ladder mark during the session, a green medallion card celebrates with the **real total**, e.g. going 8 → 11 shows "11 words fully learned!".

- **Ladder**: 5, then 10..100 every 10, then 150+ every 50 (unbounded). Crossing test `before < mark ≤ after`; vaulting several marks fires once.
- **Precedence**: words milestone > streak milestone > pipeline shift > none.
- **Detection is session-window only** (start vs end pipeline snapshot). No persisted high-water mark: a slip-and-recover can re-celebrate a mark — accepted product decision, documented in the resolver.
- **Visuals**: sibling of the copper streak medallion — same pop/count-up/confetti choreography — but in the pipeline-Learned green family (accent `#4F8A4C`, light/dark container fields) so the two milestones read as distinct wins. Copper stays reserved for streaks. Adaptive medallion digits (34/30/25 sp at 1–2/3/4 digits).
- Uses the basic session-complete otter; headline message unchanged.

## How

- `StudySessionCompleteResolver`: crossing detection + ladder (pure policy, unit-tested).
- `MilestoneHeroCard.kt` (new): the medallion-card skeleton extracted verbatim from `MilestoneCompleteHero`, parameterized by `MilestoneHeroColors`, title/subtitle, and medallion font size — keeps the two heroes' motion in lockstep.
- `WordsMilestoneCompleteHero.kt` (new): green variant + previews (entrance replay, 3-digit).
- Developer mode: new "Words milestone" case in the completion-states gallery.
- Localization: 2 new keys in base + all 9 locales (`%1$d words fully learned!` / `Words you'll actually use.`); translations are drafts for localization review.

## Testing

- 13 new resolver tests: first mark, vaulting shows real total, precedence over streak/shift, no-crossing/regression/below-first-mark cases, ladder edges (100, the 101–149 gap, 150, 250), empty-snapshot guard.
- `:composeApp:desktopTest` and `:composeApp:testAndroidHostTest`: 440/445 pass; the 5 failures are pre-existing `DictionaryClientTest` cases requiring a GitHub token for the local test server, unrelated to this branch.
- `:composeApp:verifyLocalizationKeys` and desktop compile pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)