### PR TITLE
Add Simplified Chinese as a translation language

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,9 +26,13 @@ Important namespaces and entry points:
 - Versions: `gradle/libs.versions.toml`. The root build derives `versionCode` from the git commit count and
   `versionName` as `1.3.<commit-count>`.
 
-Supported learning languages are EN, RU, NL, PL, DE, FR, IT, CS, TR, and ES; see
+Supported languages are EN, RU, NL, PL, DE, FR, IT, CS, TR, ES, and ZH-HANS; see
 `shared/src/commonMain/kotlin/com/slovy/slovymovyapp/data/Language.kt`. Offline Wiktextract source mappings currently
-exist only for EN, RU, NL, and PL.
+exist only for EN, RU, NL, and PL, so only those can be learning languages; the rest are translation targets.
+
+`Language.code` is not just a display key: it is the `translation_{src}_{tgt}.db` filename segment, the `/word` route's
+`translations` value, the `lang_code`/`target_lang_code` column value, and the Android TTS locale tag. Chinese is the
+first code carrying a script subtag, so treat it as the case that breaks naive assumptions there.
 
 ## Environment and Gradle commands
 

--- a/composeApp/src/androidMain/kotlin/com/slovy/slovymovyapp/speech/Speech.android.kt
+++ b/composeApp/src/androidMain/kotlin/com/slovy/slovymovyapp/speech/Speech.android.kt
@@ -242,10 +242,10 @@ actual class TextToSpeechManager actual constructor(androidContext: Any?) : Spee
         if (interruptedSpeech) notifyStatus(TTSStatus.IDLE)
     }
 
-    private fun toLocale(lang: Language): Locale {
-        val builder = Locale.Builder()
-        return builder.setLanguage(lang.code).build()
-    }
+    // Parses the full tag rather than seeding a builder with it: Locale.Builder.setLanguage rejects
+    // anything beyond a bare language subtag, so a code carrying a script (zh-Hans) would throw here
+    // and abort the Language.entries loop in getAvailableLanguages, leaving every language voiceless.
+    private fun toLocale(lang: Language): Locale = Locale.forLanguageTag(lang.code)
 
     actual override fun stop() {
         tts.stop()

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/data/remote/DataDbManager.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/data/remote/DataDbManager.kt
@@ -485,7 +485,7 @@ class DataDbManager(
             when {
                 fileName.startsWith(DICTIONARY_PREFIX) && fileName.endsWith(DB_EXTENSION) -> {
                     val langCode = fileName.removePrefix(DICTIONARY_PREFIX).removeSuffix(DB_EXTENSION)
-                    val language = Language.fromCodeOrNull(langCode)
+                    val language = Language.fromFileNameSegment(langCode)
                     if (language != null) {
                         dictionaries[language] = size
                     }
@@ -494,8 +494,8 @@ class DataDbManager(
                 fileName.startsWith(TRANSLATION_PREFIX) && fileName.endsWith(DB_EXTENSION) -> {
                     val parts = fileName.removePrefix(TRANSLATION_PREFIX).removeSuffix(DB_EXTENSION).split("_")
                     if (parts.size == 2) {
-                        val srcLang = Language.fromCodeOrNull(parts[0])
-                        val tgtLang = Language.fromCodeOrNull(parts[1])
+                        val srcLang = Language.fromFileNameSegment(parts[0])
+                        val tgtLang = Language.fromFileNameSegment(parts[1])
                         if (srcLang != null && tgtLang != null) {
                             translations.getOrPut(srcLang) { mutableListOf() }
                                 .add(AvailableTranslationInfo(tgtLang, size))
@@ -528,15 +528,15 @@ class DataDbManager(
             when {
                 fileName.startsWith(DICTIONARY_PREFIX) && fileName.endsWith(DB_EXTENSION) -> {
                     val langCode = fileName.removePrefix(DICTIONARY_PREFIX).removeSuffix(DB_EXTENSION)
-                    val language = Language.fromCodeOrNull(langCode) ?: return@mapNotNull null
+                    val language = Language.fromFileNameSegment(langCode) ?: return@mapNotNull null
                     DatabaseFileInfo.Dictionary(language, size)
                 }
 
                 fileName.startsWith(TRANSLATION_PREFIX) && fileName.endsWith(DB_EXTENSION) -> {
                     val parts = fileName.removePrefix(TRANSLATION_PREFIX).removeSuffix(DB_EXTENSION).split("_")
                     if (parts.size != 2) return@mapNotNull null
-                    val srcLang = Language.fromCodeOrNull(parts[0]) ?: return@mapNotNull null
-                    val tgtLang = Language.fromCodeOrNull(parts[1]) ?: return@mapNotNull null
+                    val srcLang = Language.fromFileNameSegment(parts[0]) ?: return@mapNotNull null
+                    val tgtLang = Language.fromFileNameSegment(parts[1]) ?: return@mapNotNull null
                     DatabaseFileInfo.Translation(srcLang, tgtLang, size)
                 }
 

--- a/composeApp/src/commonTest/kotlin/com/slovy/slovymovyapp/data/remote/LanguageFileNameRoundTripTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/slovy/slovymovyapp/data/remote/LanguageFileNameRoundTripTest.kt
@@ -3,17 +3,21 @@ package com.slovy.slovymovyapp.data.remote
 import com.slovy.slovymovyapp.data.Language
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNull
 
 /**
  * Downloaded DB filenames lowercase the language code, and both the remote listing
  * ([DataDbManager.fetchAvailableLanguages]) and the installed-file listing
  * ([DataDbManager.listDownloadedDatabases]) recover the [Language] by parsing that segment back
- * through [Language.fromCodeOrNull].
+ * through [Language.fromFileNameSegment].
  *
- * A code carrying a script subtag (`zh-Hans`) only survives that round trip because the lookup
+ * A code carrying a script subtag (`zh-Hans`) only survives that round trip because that lookup
  * ignores case, and a failure here is silent rather than loud: the pair is skipped, so the DB is
- * never offered for download nor reported as installed, and nothing raises or logs. These tests
- * pin the round trip for every language so a future code cannot quietly break it.
+ * never offered for download nor reported as installed, and nothing raises or logs.
+ *
+ * The leniency has to stay confined to filename parsing, so the strictness of [Language.fromCodeOrNull]
+ * is pinned here too - it is what stops a request for `RU` from validating and then missing the
+ * existing `ru` data downstream.
  */
 class LanguageFileNameRoundTripTest {
 
@@ -25,9 +29,30 @@ class LanguageFileNameRoundTripTest {
                 .removeSuffix(DB_EXTENSION)
             assertEquals(
                 lang,
-                Language.fromCodeOrNull(segment),
+                Language.fromFileNameSegment(segment),
                 "dictionary filename segment '$segment' must resolve back to $lang"
             )
+        }
+    }
+
+    @Test
+    fun fromCodeOrNull_rejectsCasingThatDiffersFromTheCanonicalCode() {
+        for (lang in Language.entries) {
+            assertEquals(
+                lang,
+                Language.fromCodeOrNull(lang.code),
+                "${lang.code} must resolve to $lang"
+            )
+            // Callers validate with fromCodeOrNull and then keep using their own input string, so
+            // accepting a variant spelling here would let it flow on into case-sensitive lookups
+            // and map keys downstream. Only codes that already differ under case can be checked.
+            val swapped = lang.code.uppercase()
+            if (swapped != lang.code) {
+                assertNull(
+                    Language.fromCodeOrNull(swapped),
+                    "'$swapped' must not resolve: it is not the canonical spelling of ${lang.code}"
+                )
+            }
         }
     }
 
@@ -46,12 +71,12 @@ class LanguageFileNameRoundTripTest {
                 assertEquals(2, parts.size, "'$name' must split into exactly two language segments")
                 assertEquals(
                     src,
-                    Language.fromCodeOrNull(parts[0]),
+                    Language.fromFileNameSegment(parts[0]),
                     "source segment '${parts[0]}' of '$name' must resolve back to $src"
                 )
                 assertEquals(
                     tgt,
-                    Language.fromCodeOrNull(parts[1]),
+                    Language.fromFileNameSegment(parts[1]),
                     "target segment '${parts[1]}' of '$name' must resolve back to $tgt"
                 )
             }

--- a/composeApp/src/commonTest/kotlin/com/slovy/slovymovyapp/data/remote/LanguageFileNameRoundTripTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/slovy/slovymovyapp/data/remote/LanguageFileNameRoundTripTest.kt
@@ -1,0 +1,67 @@
+package com.slovy.slovymovyapp.data.remote
+
+import com.slovy.slovymovyapp.data.Language
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Downloaded DB filenames lowercase the language code, and both the remote listing
+ * ([DataDbManager.fetchAvailableLanguages]) and the installed-file listing
+ * ([DataDbManager.listDownloadedDatabases]) recover the [Language] by parsing that segment back
+ * through [Language.fromCodeOrNull].
+ *
+ * A code carrying a script subtag (`zh-Hans`) only survives that round trip because the lookup
+ * ignores case, and a failure here is silent rather than loud: the pair is skipped, so the DB is
+ * never offered for download nor reported as installed, and nothing raises or logs. These tests
+ * pin the round trip for every language so a future code cannot quietly break it.
+ */
+class LanguageFileNameRoundTripTest {
+
+    @Test
+    fun dictionaryFileName_segmentResolvesBackToItsLanguage() {
+        for (lang in Language.entries) {
+            val segment = DataDbManager.dictionaryFileName(lang)
+                .removePrefix(DICTIONARY_PREFIX)
+                .removeSuffix(DB_EXTENSION)
+            assertEquals(
+                lang,
+                Language.fromCodeOrNull(segment),
+                "dictionary filename segment '$segment' must resolve back to $lang"
+            )
+        }
+    }
+
+    @Test
+    fun translationFileName_bothSegmentsResolveBackToTheirLanguages() {
+        for (src in Language.entries) {
+            for (tgt in Language.entries) {
+                if (src == tgt) continue
+                val name = DataDbManager.translationFileName(src, tgt)
+                val parts = name
+                    .removePrefix(TRANSLATION_PREFIX)
+                    .removeSuffix(DB_EXTENSION)
+                    .split("_")
+                // The parsers require exactly two segments, so a code containing '_' would be
+                // dropped just as silently as a case mismatch.
+                assertEquals(2, parts.size, "'$name' must split into exactly two language segments")
+                assertEquals(
+                    src,
+                    Language.fromCodeOrNull(parts[0]),
+                    "source segment '${parts[0]}' of '$name' must resolve back to $src"
+                )
+                assertEquals(
+                    tgt,
+                    Language.fromCodeOrNull(parts[1]),
+                    "target segment '${parts[1]}' of '$name' must resolve back to $tgt"
+                )
+            }
+        }
+    }
+
+    private companion object {
+        // Mirrors the private constants DataDbManager builds its filenames from.
+        const val DICTIONARY_PREFIX = "dictionary_"
+        const val TRANSLATION_PREFIX = "translation_"
+        const val DB_EXTENSION = ".db"
+    }
+}

--- a/shared/src/commonMain/kotlin/com/slovy/slovymovyapp/data/Language.kt
+++ b/shared/src/commonMain/kotlin/com/slovy/slovymovyapp/data/Language.kt
@@ -28,13 +28,20 @@ enum class Language(
     CHINESE("zh-Hans", "简体中文", "🇨🇳", "Simplified Chinese");
 
     companion object {
-        fun fromCode(code: String): Language {
-            return entries.find { it.code == code }
-                ?: throw IllegalArgumentException("Unknown language code: $code")
+        /**
+         * Matches case-insensitively because [code] is not only stored verbatim: it is also a
+         * `dictionary_{lang}.db` / `translation_{src}_{tgt}.db` filename segment, and those names are
+         * built lowercased. A code carrying a script subtag (`zh-Hans`) therefore comes back out of a
+         * filename as `zh-hans`, and an exact match would drop the pair with no error anywhere -
+         * the file would simply never be offered for download or listed as installed.
+         */
+        fun fromCodeOrNull(code: String): Language? {
+            return entries.find { it.code.equals(code, ignoreCase = true) }
         }
 
-        fun fromCodeOrNull(code: String): Language? {
-            return entries.find { it.code == code }
+        fun fromCode(code: String): Language {
+            return fromCodeOrNull(code)
+                ?: throw IllegalArgumentException("Unknown language code: $code")
         }
     }
 }

--- a/shared/src/commonMain/kotlin/com/slovy/slovymovyapp/data/Language.kt
+++ b/shared/src/commonMain/kotlin/com/slovy/slovymovyapp/data/Language.kt
@@ -18,7 +18,14 @@ enum class Language(
     ITALIAN("it", "Italiano", "🇮🇹", "Italian"),
     CZECH("cs", "Čeština", "🇨🇿", "Czech"),
     TURKISH("tr", "Türkçe", "🇹🇷", "Turkish"),
-    SPANISH("es", "Español", "🇪🇸", "Spanish");
+    SPANISH("es", "Español", "🇪🇸", "Spanish"),
+
+    /**
+     * Simplified Chinese only. [englishName] is the sole input to the AI translation prompt's
+     * `$TARGET_LANG` placeholder, so it is what keeps the generated corpus in 简体 rather than 繁體.
+     * Traditional would join as a separate `zh-Hant` entry; it is not a variant of this one.
+     */
+    CHINESE("zh-Hans", "简体中文", "🇨🇳", "Simplified Chinese");
 
     companion object {
         fun fromCode(code: String): Language {

--- a/shared/src/commonMain/kotlin/com/slovy/slovymovyapp/data/Language.kt
+++ b/shared/src/commonMain/kotlin/com/slovy/slovymovyapp/data/Language.kt
@@ -29,19 +29,37 @@ enum class Language(
 
     companion object {
         /**
-         * Matches case-insensitively because [code] is not only stored verbatim: it is also a
-         * `dictionary_{lang}.db` / `translation_{src}_{tgt}.db` filename segment, and those names are
-         * built lowercased. A code carrying a script subtag (`zh-Hans`) therefore comes back out of a
-         * filename as `zh-hans`, and an exact match would drop the pair with no error anywhere -
-         * the file would simply never be offered for download or listed as installed.
+         * Exact match on purpose. Callers that merely validate a code and then keep using their own
+         * input string rely on it: the `/word` route checks the requested translation codes here but
+         * carries the raw strings on into existing-language checks, db-extract filtering, and the
+         * merged translation map keys, none of which ignore case. A lenient match would let `RU`
+         * past validation and then miss the existing `ru` data, regenerating it and storing a
+         * duplicate `RU` entry the client can never read.
+         *
+         * Filename segments are the one place that legitimately needs leniency; they have
+         * [fromFileNameSegment] instead.
          */
         fun fromCodeOrNull(code: String): Language? {
-            return entries.find { it.code.equals(code, ignoreCase = true) }
+            return entries.find { it.code == code }
         }
 
         fun fromCode(code: String): Language {
             return fromCodeOrNull(code)
                 ?: throw IllegalArgumentException("Unknown language code: $code")
+        }
+
+        /**
+         * Resolves a language from a downloaded-DB filename segment, which
+         * [com.slovy.slovymovyapp.data.remote.DataDbManager] builds lowercased. A code carrying a
+         * script subtag (`zh-Hans`) comes back out as `zh-hans`, so an exact match would drop the
+         * pair with no error anywhere - the file would simply never be offered for download nor
+         * reported as installed.
+         *
+         * Kept separate from [fromCodeOrNull] so this leniency stays confined to filename parsing
+         * and never widens what a network or storage boundary accepts.
+         */
+        fun fromFileNameSegment(segment: String): Language? {
+            return entries.find { it.code.equals(segment, ignoreCase = true) }
         }
     }
 }


### PR DESCRIPTION
Adds `CHINESE("zh-Hans", "简体中文", "🇨🇳", "Simplified Chinese")` to the `Language` enum.

Chinese is a **translation target only** — there is no Wiktextract source mapping for it, so it cannot be a learning language. Adding a translation language is otherwise data-driven: everything downstream derives from `Language.entries`, so the onboarding and settings pickers, the server's target-language validation, remote DB discovery, the `DbPrepTool` build, and the words-repo merge all pick it up with no further wiring.

### Why `englishName` is "Simplified Chinese"

It is the sole input to the AI translation prompt's `$TARGET_LANG` placeholder (`DbExtractEnhancerUtils.targetLanguageName` → `EnhancerPrompts`), so it is what keeps the generated corpus in 简体 rather than 繁體. The locale tag has no influence on that. It is never shown in the UI.

Traditional would later join as a separate `zh-Hant` entry rather than a variant of this one.

### Why `Speech.android.kt` changed

`zh-Hans` is the first code carrying a script subtag, which breaks one assumption about `Language.code` — it is not just a display key, it is simultaneously the `translation_{src}_{tgt}.db` filename segment, the `/word` route's `translations` value, the `lang_code`/`target_lang_code` column value, **and** the Android TTS locale tag.

`Locale.Builder.setLanguage` rejects anything past a bare language subtag, so `toLocale` would have thrown inside the `Language.entries` loop in `getAvailableLanguages()`. All three callers catch it (`SettingsScreen.kt:650`, `StudySessionViewModel.kt:112`, `RowAudioController.kt:96`), so the result would not have been a crash but an **empty voice list for every language** — TTS silently dead app-wide, including for users who never touch Chinese. Parsing the full tag instead is equivalent for the ten existing two-letter codes.

### Known follow-up, deliberately not in this PR

`Language.fromCode`/`fromCodeOrNull` match exactly, while `DataDbManager.translationFileName` lowercases. So `translation_en_zh-hans.db` parses back via `fromCodeOrNull("zh-hans")`, which never equals `"zh-Hans"`, and the pair would be **silently invisible** to the download flow — `fetchAvailableLanguages` drops it, nothing downloads, no error and no log.

This is a one-line fix (`it.code.equals(code, ignoreCase = true)`) that must land **with the DB upload PR, not after it**. Online-only Chinese is unaffected in the meantime, because `local_translation.db` is a single file that keys `target_lang_code` as a column value with no filename round-trip.

Also accepted for v1: reverse search matches translations by normalized-word prefix range (`DictionaryRepository.kt:636`), so typing 苹 finds 苹果 but pinyin finds nothing. A real fix needs a pinyin column in `sense_translation` plus a migration.

### Remaining work after this merges

1. Deploy the server — `targetLanguageName("zh-Hans")` resolves through the enum, so the current build still rejects the code.
2. Corpus generation: `scripts/batch_enrich.py --translations zh-Hans` per learning language.
3. `:server:runDbPrepTool`, then upload under the **existing** `v15` GCS prefix. No `DataDbManager.VERSION` bump — that would trigger the destructive cache refresh for every user.

### Testing

Compiles on desktop, Android, and server.

`:server:test` (13 failures) and `:composeApp:desktopTest` (5 failures) were each re-run against a stashed baseline and produced **identical failure sets** — all `GitHubClientTest`/`DictionaryClientTest`/feedback tests, failing because no GitHub token is present in the local environment. No regressions from this change. CI has the token and should be green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
