### PR TITLE
Stop the Chinese prompt tagging measure words and bare names

### DIFF
--- a/shared/src/commonMain/kotlin/com/slovy/slovymovyapp/data/Language.kt
+++ b/shared/src/commonMain/kotlin/com/slovy/slovymovyapp/data/Language.kt
@@ -79,8 +79,12 @@ enum class Language(
               了, 的, word order - write the natural sentence and leave it untagged. An untagged
               example translation is a correct answer, and takes precedence over the later
               instruction to tag the word in every example; a filler inserted only so that something
-              can be tagged is not (锻炼对你的健康<w>为</w>（有益）, 住了<w>持续</w>十年). Do not fall
-              back to tagging the duration itself, since 十年 is the span rather than the preposition.
+              can be tagged is not (锻炼对你的健康<w>为</w>（有益）, 住了<w>持续</w>十年). Nor is the
+              quantity a substitute for the word: 十年, 百分之二十 and 几秒钟 are the amount being
+              measured rather than the preposition, so leave those sentences untagged too.
+            - That licence is narrow. It applies only where no word in the sentence carries the
+              sense. Where a declared translation is already sitting in the sentence you wrote, tag
+              it; a name always supplies one (<w>斯普林</w>先生, 德克萨斯州的<w>斯普林</w>).
             - At least one example per sense must still come out with a tagged translation. When the
               rule above would leave every example of a sense untagged, shape one of them so that a
               real word carries the meaning.
@@ -90,6 +94,13 @@ enum class Language(
             - Tag the declared translation exactly. Do not pull an added verb inside the tag
               (<w>去健身房</w> where the word is 健身房), and do not leave part of it outside
               (<w>体育</w>课 where the word is 体育课).
+            - Chinese counts nouns with a measure word, and which of the two carries the tag is
+              decided by the sense's own declared translations. Where those are measure words
+              (块, 条, 件), the English word is the counter, so tag the measure word: 一<w>块</w>派,
+              一<w>条</w>有用的建议. Where they are nouns (曲子, 文章, 枪), tag the noun and leave the
+              measure word outside it: 两首优美的<w>曲子</w>, 一篇关于医学研究的<w>文章</w>,
+              带着<w>枪</w>. Never tag the noun when the declared translations are measure words -
+              blanking 建议 asks the learner for "advice" rather than for the word being taught.
             - Do not repeat a morpheme the surrounding words already supply: 正则表达式, 生理盐水 and
               母乳 each already contain the head, so choose wording that fits what is around it.
             - Keep parenthetical glosses out of the example sentences; that belongs in the sense


### PR DESCRIPTION
Follow-up to #813. I regenerated a 15-word probe set against the merged rules, then tested candidate fixes in the kaikki-parser prompt sandbox before writing them here.

## #813 is working

133 senses, 264 example translations, measured the same way as the batch that motivated it:

| Failure | Before #813 (126 senses) | After (133 senses) |
|---|---|---|
| Filler word for function words | ~15 in `for` alone | **0** |
| `……` pattern pasted whole | 3 × `<w>对你来说</w>` | **0** |
| Morpheme doubling | 4 | **0** |
| Gloss in example | 1 | 0 |
| Malformed tag | 1 | 0 |
| Traditional / lect / Cyrillic | 0 | 0 |

`by` is the clearest evidence: 15 senses, 15 different coverbs each in the slot Chinese grammar gives it — 乘 用 旁 前 被 由 经过 按 按照 凭 — none mirroring the English word's position. `cell` hit every morpheme-doubling trap (手机, 细胞膜, 蜂房, 风暴单体) and doubled none. Transliteration held throughout: 史密斯, 史密斯学院, 埃文人, 埃文语, 阿德迈尔.

Both remaining problems are rules from #813 that were written too broadly.

## The untagged licence leaked onto names

Both name senses of `spring` produced 斯普林先生正在大厅等候 and 他们搬到了德克萨斯州的斯普林 — the declared translation sitting in the sentence, tagged nothing. Both senses therefore have zero tagged examples and lose `CLOZE_TRANSLATION`, which is precisely what the one-tag-per-sense floor was added to prevent.

The old wording only ever said when you *may* omit the tag, never when you may not. `smith` and `admire` tagged their name senses correctly, so it was inconsistent rather than systematic — which is what an under-specified rule looks like.

Fixed by narrowing the licence to "only where no word in the sentence carries the sense", plus the two 斯普林 sentences as worked examples.

While here: the duration carve-out is generalised. `by` produced 利润增长了`<w>`百分之二十`</w>` and 仅差了`<w>`几秒钟`</w>` — the same shape as the 十年 trap the rule already named, but the rule said "duration" so it never generalised to a measured amount.

## Permission to tag a particle leaked onto classifiers

`piece`, 8 of 11 senses: 两`<w>`首`</w>`曲子 · 一`<w>`件`</w>`…艺术品 · 一`<w>`篇`</w>`…文章 · 一`<w>`枚`</w>`…银币 · 一`<w>`把`</w>`枪.

In each, the declared translation (曲子, 艺术品, 文章, 硬币, 枪) is sitting right there untagged while the cloze blanks a measure word. A learner asked to produce 首 learns nothing about "piece".

My first attempt at this rule said "where the sense corresponds to a noun, tag the noun". The sandbox showed it overcorrecting: 一条有用的`<w>`建议`</w>`, where "a piece of advice" is a true partitive and 条 really is what "piece" means — blanking 建议 asks for *advice*. Every one of these senses is nominal, so that phrasing gave the model nothing to discriminate on.

The version here lets the sense's own declared translations decide, since they already record whether the sense is a counter (件, 项) or a noun (文章, 枪). Checked against all seven senses in the sandbox output: the six it already got right stay right, and the advice case flips to correct.

## Testing

Sandbox runs of `piece`, `spring` and `by` (kaikki-parser `/api/translate`, prompt pasted in, so nothing was written anywhere).

- `spring` — both name examples now tagged; 16 examples, 1 unrelated defect (山`<w>`泉`</w>`里的清泉水, a morpheme doubling that R5 already covers).
- `by` — 14 examples, 0 issues, 8 distinct coverbs, none of the old filler shapes. This was the real risk: the name fix pushes back toward tagging, and it did not undo the coverb behaviour.
- `piece` — 20 examples, 0 mechanical issues, 6 of 7 classifier cases fixed; the seventh drove the sharpened wording above.

**Not tested:** the quantity clause. Neither sandbox card carried the "amount of difference" sense of `by`, so that clause goes in on the strength of the generated-corpus evidence alone. It is low-risk in that it only ever removes a tag.

`:shared:compileKotlinJvm` and `PromptNotesTest` pass. `Language.kt` only; no other language is affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)