### PR TITLE
Declare Chinese measure words without the numeral

### DIFF
--- a/shared/src/commonMain/kotlin/com/slovy/slovymovyapp/data/Language.kt
+++ b/shared/src/commonMain/kotlin/com/slovy/slovymovyapp/data/Language.kt
@@ -101,6 +101,10 @@ enum class Language(
               measure word outside it: 两首优美的<w>曲子</w>, 一篇关于医学研究的<w>文章</w>,
               带着<w>枪</w>. Never tag the noun when the declared translations are measure words -
               blanking 建议 asks the learner for "advice" rather than for the word being taught.
+            - Declare a measure word on its own - 串, 滴, 杯, 群 - and tag it on its own. 一 is the
+              numeral "one", not part of the word, so 一串 as a declared translation makes the tag
+              either swallow the numeral (一<w>杯</w>糖 is right, <w>一杯</w>糖 is not) or fall
+              outside what was declared. The numeral belongs in the sentence, never in the entry.
             - Do not repeat a morpheme the surrounding words already supply: 正则表达式, 生理盐水 and
               母乳 each already contain the head, so choose wording that fits what is around it.
             - Keep parenthetical glosses out of the example sentences; that belongs in the sense


### PR DESCRIPTION
Follow-up to #815. One bullet, from the only pattern that survived three batches.

## The problem

Declared translations for counter senses keep arriving with the numeral fused on — 一串, 一滴, 一杯, 一群 — and that leaves the tag with no correct option:

- include the numeral, and the cloze blanks *one cup* when the word being taught is *cup*: `<w>`一杯`</w>`糖
- exclude it, and the tag no longer matches anything in `translations`: 一`<w>`杯`</w>`糖 against a declared 一杯

Both shapes are in the corpus, sometimes for the same sense. `bunch` declares 一群/一伙 and then writes 他和一`<w>`群`</w>`朋友 in one example and 他们是`<w>`一群人`</w>` in the next.

## Why now

Three independent occurrences across three batches:

| Batch | Word | Declared | Written |
|---|---|---|---|
| classifier probe | `bunch` | 一束 / 一串 / 一捆, 一群 / 一伙 | 一`<w>`串`</w>`香蕉, 一`<w>`群`</w>`朋友 |
| 50-word batch | `drop` | 一滴 / 一点 | 连一`<w>`滴`</w>`水都没剩下 |
| 50-word batch | `cup` | 杯 | `<w>`一杯`</w>`糖 ×2 |

I held this back after the first two sightings on the grounds that one or two occurrences is noise. The third crossed the line I'd set for acting.

## The fix

States that the numeral belongs in the sentence and never in the entry, with the contrast spelled out — 一`<w>`杯`</w>`糖 right, `<w>`一杯`</w>`糖 wrong.

It composes with the classifier rule from #815 rather than replacing it: #815 decides *which* of measure word and noun carries the tag, this decides *where the tag starts* once the measure word is the answer.

## Testing

Corpus state with a corrected checker (see below): **83 en words, 540 senses, 1092 examples, zero hard defects**, plus 15 ru/nl/pl words with zero. The 5 remaining soft findings are exactly this `一X` pattern, which is what this bullet addresses.

`:shared:compileKotlinJvm` and `PromptNotesTest` pass. `Language.kt` only.

## Note on an earlier claim

While validating this I found my quality checker had been keying on `<w>` alone. The app's `HtmlTagParser` deliberately supports a second syntax — a bare `<content>` tag, per its own KDoc and `isHighlightTag` — and treats it as tagged. Anything using the simple form was being reported as untagged.

That invalidated a claim I made earlier in this work about a large "corruption" in the ru/pl corpus. There is no such corruption; it is the supported alternate syntax. The checker is now a faithful port of `parseTextSegments` with a self-test covering both forms, so the numbers above are measured correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)