### PR TITLE
Revert "Declare Chinese measure words without the numeral"

### DIFF
--- a/shared/src/commonMain/kotlin/com/slovy/slovymovyapp/data/Language.kt
+++ b/shared/src/commonMain/kotlin/com/slovy/slovymovyapp/data/Language.kt
@@ -101,10 +101,6 @@ enum class Language(
               measure word outside it: 两首优美的<w>曲子</w>, 一篇关于医学研究的<w>文章</w>,
               带着<w>枪</w>. Never tag the noun when the declared translations are measure words -
               blanking 建议 asks the learner for "advice" rather than for the word being taught.
-            - Declare a measure word on its own - 串, 滴, 杯, 群 - and tag it on its own. 一 is the
-              numeral "one", not part of the word, so 一串 as a declared translation makes the tag
-              either swallow the numeral (一<w>杯</w>糖 is right, <w>一杯</w>糖 is not) or fall
-              outside what was declared. The numeral belongs in the sentence, never in the entry.
             - Do not repeat a morpheme the surrounding words already supply: 正则表达式, 生理盐水 and
               母乳 each already contain the head, so choose wording that fits what is around it.
             - Keep parenthetical glosses out of the example sentences; that belongs in the sense


### PR DESCRIPTION
Reverts #816. The rule asks for the wrong Chinese, and it was written from too little evidence.

## Why it is wrong

It told the model to declare and tag the bare measure word, reasoning that 一 is the numeral rather than part of the word. That holds for the four examples it cites — 串, 滴, 杯, 群 are all nouns in their own right — and breaks for measure words that are not.

把 alone means "handle", "to grasp", or the classifier for knives and chairs. It does not mean "handful". 一把 is the lexical unit, so following the rule would have produced a worse entry.

A sandbox run of `handful` against the merged prompt returned 一把 anyway, in both the declaration and the tag. That is the model declining a bad instruction, not ignoring a good one.

## The defect was mischaracterised

What actually went wrong in `bunch` was the declared form and the tagged form **disagreeing** — not the numeral being present. `cup` shows both directions in one file: one sense declares 一杯 and tags 一杯 (fine), another declares 杯 and tags 一杯 (broken).

A rule about stripping numerals cannot express that, and picks the wrong side half the time.

## The evidence was too thin

Measured with a corrected checker across 89 words, 578 senses, 1168 examples:

| Class | Count | Rate |
|---|---|---|
| Hard defects | 0 | 0% |
| NOT-DECLARED | 57 | 4.9% |
| Measure-form disagreement | 4 | 0.3% |

Four occurrences in 1168 examples, from a corpus of ~70k words. #816 was written from three sightings across three small batches, which is indistinguishable from noise at this sample size. The existing "Tag the declared translation exactly" bullet already covers the disagreement in principle.

## What stays

#815 is untouched — its classifier rule (which of the measure word and the noun carries the tag) is validated on `sheet` and `bunch` in both directions, and does the real work here. This revert removes one bullet and nothing else.

`:shared:compileKotlinJvm` and `PromptNotesTest` pass.

## Method note

Two of my checker's findings in this area turned out to be artefacts of the checker rather than the data — first counting only `<w>` tags and so missing the app's second supported syntax, then counting "numeral appears in tag" instead of "declaration and tag disagree". Both have been corrected and the checker now carries a self-test.

The sequence that produced #816 — read ten words, spot a pattern, write a rule, generate ten more to check it — fits the prompt to whichever words happened to be sampled. Remaining work should measure at scale first and only write a rule for a class whose frequency and mechanism are both established.

🤖 Generated with [Claude Code](https://claude.com/claude-code)