### PR TITLE
Fall back to OpenAI when a model drops example translations

### DIFF
--- a/composeApp/src/commonMain/composeResources/values-zh/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-zh/strings.xml
@@ -184,7 +184,11 @@
     <string name="language_setup_request_language_link">告诉我们</string>
     <string name="language_setup_request_language_after">，我们会把它加进来。</string>
     <string name="language_setup_request_language_title">建议添加语言</string>
-    <string name="language_setup_request_language_placeholder">你希望我们添加哪种语言？</string>
+    <string name="language_setup_request_language_roadmap">在%1$s上查看我们接下来会添加哪些语言。</string>
+    <string name="language_setup_request_language_roadmap_link">路线图</string>
+    <string name="language_setup_request_language_learn_label">想学的语言</string>
+    <string name="language_setup_request_language_translate_label">想翻译成的语言</string>
+    <string name="language_setup_request_language_required">请至少填写一种语言</string>
     <string name="language_setup_request_language_sent_title">建议已发送</string>
     <string name="language_setup_request_language_sent_message">谢谢！我们已经收到你的语言建议。你可以在 GitHub 上关注进展。</string>
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -21,7 +21,6 @@ googleCloudLoggingLogback = "0.143.0-alpha"
 googleCloudCore = "2.73.0"
 googleCloudTasks = "2.95.0"
 googleGenai = "1.65.0"
-janino = "3.1.12"
 jtokkit = "1.1.0"
 junit = "4.13.2"
 kotlin = "2.4.10"
@@ -52,7 +51,6 @@ google-cloud-logging-logback = { module = "com.google.cloud:google-cloud-logging
 google-cloud-tasks = { module = "com.google.cloud:google-cloud-tasks", version.ref = "googleCloudTasks" }
 google-cloud-core = { module = "com.google.cloud:google-cloud-core", version.ref = "googleCloudCore" }
 google-genai = { module = "com.google.genai:google-genai", version.ref = "googleGenai" }
-janino = { module = "org.codehaus.janino:janino", version.ref = "janino" }
 jtokkit = { module = "com.knuddels:jtokkit", version.ref = "jtokkit" }
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
 openai-java = { module = "com.openai:openai-java", version.ref = "openaiJava" }

--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -17,7 +17,6 @@ application {
 dependencies {
     api(projects.shared)
     implementation(libs.logback)
-    implementation(libs.janino)
     implementation(libs.ktor.serverCore)
     implementation(libs.ktor.serverNetty)
     implementation(libs.ktor.serverCallLogging)

--- a/server/src/main/kotlin/com/slovy/slovymovyapp/Application.kt
+++ b/server/src/main/kotlin/com/slovy/slovymovyapp/Application.kt
@@ -534,11 +534,11 @@ fun Application.module() {
                     call.application.environment.log.warn("Conflict detected for $lang/$word, will retry")
                     call.respond(HttpStatusCode.Conflict, "Concurrent modification detected, please retry")
                 } else {
-                    call.application.environment.log.error("GitHub API error for $lang/$word: ${e.message}")
+                    call.application.environment.log.error("GitHub API error for $lang/$word: ${e.message}", e)
                     call.respond(HttpStatusCode.InternalServerError, "GitHub API error: ${e.message}")
                 }
             } catch (e: Exception) {
-                call.application.environment.log.error("Failed to update $lang/$word: ${e.message}")
+                call.application.environment.log.error("Failed to update $lang/$word: ${e.message}", e)
                 call.respond(HttpStatusCode.InternalServerError, "Failed to update: ${e.message}")
             }
         }
@@ -780,9 +780,12 @@ private suspend fun addMissingTranslations(
     val missingLangCodes = targetLangCodes.filter { it !in existingLanguages }
     if (missingLangCodes.isEmpty()) return TranslationResult(response, updated = false)
 
+    // The two bail-outs below look exactly like a successful "nothing to translate" from the
+    // client's side - base chunk, no translated chunk - so each has to say why it gave up.
     val geminiProvider = GeminiProvider()
     val openAIProvider = OpenAIProvider()
     if (!geminiProvider.isAvailable() && !openAIProvider.isAvailable()) {
+        logger.error("No AI provider configured; cannot translate $lang/$word into $missingLangCodes")
         return TranslationResult(response, updated = false)
     }
 
@@ -790,6 +793,7 @@ private suspend fun addMissingTranslations(
         val content = GitHubClient.loadDbExtractContent(lang, "$word.json")
         json.decodeFromString(ExtractedWordData.serializer(), content)
     } catch (_: GHFileNotFoundException) {
+        logger.warn("No db-extract for $lang/$word; cannot translate it into $missingLangCodes")
         return TranslationResult(response, updated = false)
     }
 

--- a/server/src/main/kotlin/com/slovy/slovymovyapp/Application.kt
+++ b/server/src/main/kotlin/com/slovy/slovymovyapp/Application.kt
@@ -224,53 +224,67 @@ fun Application.module() {
                 val baseResult = loadBaseWordData(lang, word, json, logger = call.application.environment.log)
 
                 // Step 2: Stream results as NDJSON (base, then translated if available)
+                //
+                // respondTextWriter swallows whatever this block throws: the writer runs outside the
+                // handler's try/catch, so the client just sees the stream stop at whatever chunk was
+                // already flushed and nothing reaches the logs. Everything in here has to report its
+                // own failures, or a broken translation stage is invisible in production.
                 call.respondTextWriter(contentType = ContentType.parse("application/x-ndjson")) {
-                    // Parse requested language codes for filtering.
-                    // If no translations parameter provided, return empty list (no translations in response).
-                    val requestedLangCodes = parseTranslationCodes(translationsParam)
+                    val streamLogger = call.application.environment.log
+                    try {
+                        // Parse requested language codes for filtering.
+                        // If no translations parameter provided, return empty list (no translations in response).
+                        val requestedLangCodes = parseTranslationCodes(translationsParam)
 
-                    // Send filtered base response to client (always filter based on requested codes)
-                    val baseResponseToClient = filterTranslations(baseResult.response, requestedLangCodes)
-                    val baseChunk = WordStreamChunk(WordStreamStage.BASE, baseResponseToClient)
-                    write(json.encodeToString(WordStreamChunk.serializer(), baseChunk))
-                    write("\n")
-                    flush()
+                        // Send filtered base response to client (always filter based on requested codes)
+                        val baseResponseToClient = filterTranslations(baseResult.response, requestedLangCodes)
+                        val baseChunk = WordStreamChunk(WordStreamStage.BASE, baseResponseToClient)
+                        write(json.encodeToString(WordStreamChunk.serializer(), baseChunk))
+                        write("\n")
+                        flush()
 
-                    // Track full response for repo updates (unfiltered)
-                    var fullResponse = baseResult.response
-                    var wasProcessed = baseResult.wasProcessed
+                        // Track full response for repo updates (unfiltered)
+                        var fullResponse = baseResult.response
+                        var wasProcessed = baseResult.wasProcessed
 
-                    if (requestedLangCodes.isNotEmpty()) {
-                        val translationResult = addMissingTranslations(
-                            response = fullResponse,
-                            lang = lang,
-                            word = word,
-                            requestedLangCodes = requestedLangCodes,
-                            json = json,
-                            logger = call.application.environment.log
-                        )
+                        if (requestedLangCodes.isNotEmpty()) {
+                            val translationResult = addMissingTranslations(
+                                response = fullResponse,
+                                lang = lang,
+                                word = word,
+                                requestedLangCodes = requestedLangCodes,
+                                json = json,
+                                logger = streamLogger
+                            )
 
-                        if (translationResult.updated) {
-                            fullResponse = translationResult.response
-                            wasProcessed = true
-                            // Send filtered translated response to client
-                            val translatedResponseToClient = filterTranslations(fullResponse, requestedLangCodes)
-                            val translatedChunk =
-                                WordStreamChunk(WordStreamStage.TRANSLATED, translatedResponseToClient)
-                            write(json.encodeToString(WordStreamChunk.serializer(), translatedChunk))
-                            write("\n")
-                            flush()
+                            if (translationResult.updated) {
+                                fullResponse = translationResult.response
+                                wasProcessed = true
+                                // Send filtered translated response to client
+                                val translatedResponseToClient = filterTranslations(fullResponse, requestedLangCodes)
+                                val translatedChunk =
+                                    WordStreamChunk(WordStreamStage.TRANSLATED, translatedResponseToClient)
+                                write(json.encodeToString(WordStreamChunk.serializer(), translatedChunk))
+                                write("\n")
+                                flush()
+                            }
                         }
-                    }
 
-                    // Step 3: Queue Cloud Tasks update if requested (only if something was processed)
-                    // IMPORTANT: Use fullResponse (unfiltered) to ensure nothing is lost in repo
-                    if (!push.isNullOrBlank() && wasProcessed) {
-                        val responseJson = json.encodeToString(
-                            LanguageCardResponse.serializer(),
-                            fullResponse
-                        )
-                        RepoUpdateTaskClient.queueRepoUpdate(lang, word, responseJson)
+                        // Step 3: Queue Cloud Tasks update if requested (only if something was processed)
+                        // IMPORTANT: Use fullResponse (unfiltered) to ensure nothing is lost in repo
+                        if (!push.isNullOrBlank() && wasProcessed) {
+                            val responseJson = json.encodeToString(
+                                LanguageCardResponse.serializer(),
+                                fullResponse
+                            )
+                            RepoUpdateTaskClient.queueRepoUpdate(lang, word, responseJson)
+                        }
+                    } catch (e: CancellationException) {
+                        throw e
+                    } catch (e: Throwable) {
+                        // The status line is already sent, so this cannot become an error response;
+                        // logging it here is the only record that the stream ended early.
+                        streamLogger.error("Failed to stream $lang/$word: ${e.message}", e)
                     }
                 }
             } catch (e: GHFileNotFoundException) {
@@ -691,6 +705,16 @@ private data class TranslationResult(
     val updated: Boolean
 )
 
+/**
+ * [response] with [mergedLangCodes] merged into it. A requested language is absent from
+ * [mergedLangCodes] when every provider failed to translate it, which leaves [response] carrying
+ * whatever the other languages produced.
+ */
+private data class EnhancedTranslations(
+    val response: LanguageCardResponse,
+    val mergedLangCodes: List<String>
+)
+
 private suspend fun loadBaseWordData(lang: String, word: String, json: Json, logger: Logger): WordProcessResult {
     var wasProcessed = false
     val response = try {
@@ -769,7 +793,7 @@ private suspend fun addMissingTranslations(
         return TranslationResult(response, updated = false)
     }
 
-    val updatedResponse = enhanceWithTranslations(
+    val enhanced = enhanceWithTranslations(
         response = response,
         extractedData = extractedData,
         word = word,
@@ -779,7 +803,9 @@ private suspend fun addMissingTranslations(
         openAIProvider = openAIProvider,
         logger = logger
     )
-    return TranslationResult(updatedResponse, updated = true)
+    // A language that produced nothing must not be reported as an update: that would stream a
+    // translated chunk identical to the base one and queue a repo update with no new content.
+    return TranslationResult(enhanced.response, updated = enhanced.mergedLangCodes.isNotEmpty())
 }
 
 private suspend fun enhanceWithTranslations(
@@ -791,70 +817,105 @@ private suspend fun enhanceWithTranslations(
     geminiProvider: GeminiProvider,
     openAIProvider: OpenAIProvider,
     logger: Logger
-): LanguageCardResponse {
+): EnhancedTranslations {
     val translationEnhancer = TranslationEnhancer()
     var updatedResponse = response
 
-    val translationResults: List<Pair<String, TranslationResponse>> = coroutineScope {
+    // supervisorScope, and a catch per language, so one target language that both providers fail
+    // to translate is logged and dropped instead of cancelling its siblings.
+    val translationResults: List<Pair<String, TranslationResponse>> = supervisorScope {
         targetLangCodes.map { targetLangCode ->
             async {
-                val targetTranslations = extractedData.sourceFileToEntries.values
-                    .flatten()
-                    .flatMap { it.translations }
-                    .filter { it.targetLangCode == targetLangCode }
-
-                val translationRequest = TranslationRequest(
-                    word = word,
-                    langCode = lang,
-                    targetLangCode = targetLangCode,
-                    languageCardData = updatedResponse,
-                    translations = targetTranslations
-                )
-
-                val targetLangName = targetLanguageName(targetLangCode)
-                val targetLangNotes = DbExtractEnhancerUtils.targetLanguageNotes(targetLangCode)
-
-                raceWithFallback(
-                    primaryAvailable = geminiProvider.isAvailable(),
-                    fallbackAvailable = openAIProvider.isAvailable(),
-                    primary = {
-                        translationEnhancer.enhanceWithTranslations(
-                            request = translationRequest,
-                            provider = geminiProvider,
-                            targetLanguageName = targetLangName,
-                            targetLanguageNotes = targetLangNotes,
-                            model = GEMINI_3_1_FLASH_LITE,
-                            reasoningBudget = 1
-                        )
-                    },
-                    fallback = {
-                        translationEnhancer.enhanceWithTranslations(
-                            request = translationRequest,
-                            provider = openAIProvider,
-                            targetLanguageName = targetLangName,
-                            targetLanguageNotes = targetLangNotes,
-                            model = ChatModel.GPT_5_4.asString(),
-                            reasoningBudget = 900
-                        )
-                    },
-                    onPrimaryError = { e ->
-                        logger.error("Gemini translation failed for $lang/$word -> $targetLangCode: ${e.message}", e)
-                    },
-                    onPrimaryTimeout = {
-                        logger.warn("Gemini translation timed out for $lang/$word -> $targetLangCode after ${AI_FALLBACK_TIMEOUT_MS}ms")
-                    }
-                ).let { targetLangCode to it }
+                try {
+                    translateInto(
+                        targetLangCode = targetLangCode,
+                        extractedData = extractedData,
+                        card = updatedResponse,
+                        word = word,
+                        lang = lang,
+                        translationEnhancer = translationEnhancer,
+                        geminiProvider = geminiProvider,
+                        openAIProvider = openAIProvider,
+                        logger = logger
+                    ).let { targetLangCode to it }
+                } catch (e: CancellationException) {
+                    throw e
+                } catch (e: Throwable) {
+                    logger.error("Translation of $lang/$word -> $targetLangCode failed: ${e.message}", e)
+                    null
+                }
             }
-        }.awaitAll()
+        }.awaitAll().filterNotNull()
     }
 
+    val mergedLangCodes = mutableListOf<String>()
     for ((targetLangCode, translationResponse) in translationResults) {
         updatedResponse = translationEnhancer.mergeTranslationData(
             originalCard = updatedResponse,
             translationResponse = translationResponse,
             targetLangCode = targetLangCode
         )
+        mergedLangCodes += targetLangCode
     }
 
-    return updatedResponse
+    return EnhancedTranslations(response = updatedResponse, mergedLangCodes = mergedLangCodes)
+}
+
+private suspend fun translateInto(
+    targetLangCode: String,
+    extractedData: ExtractedWordData,
+    card: LanguageCardResponse,
+    word: String,
+    lang: String,
+    translationEnhancer: TranslationEnhancer,
+    geminiProvider: GeminiProvider,
+    openAIProvider: OpenAIProvider,
+    logger: Logger
+): TranslationResponse {
+    val targetTranslations = extractedData.sourceFileToEntries.values
+        .flatten()
+        .flatMap { it.translations }
+        .filter { it.targetLangCode == targetLangCode }
+
+    val translationRequest = TranslationRequest(
+        word = word,
+        langCode = lang,
+        targetLangCode = targetLangCode,
+        languageCardData = card,
+        translations = targetTranslations
+    )
+
+    val targetLangName = targetLanguageName(targetLangCode)
+    val targetLangNotes = DbExtractEnhancerUtils.targetLanguageNotes(targetLangCode)
+
+    return raceWithFallback(
+        primaryAvailable = geminiProvider.isAvailable(),
+        fallbackAvailable = openAIProvider.isAvailable(),
+        primary = {
+            translationEnhancer.enhanceWithTranslations(
+                request = translationRequest,
+                provider = geminiProvider,
+                targetLanguageName = targetLangName,
+                targetLanguageNotes = targetLangNotes,
+                model = GEMINI_3_1_FLASH_LITE,
+                reasoningBudget = 1
+            )
+        },
+        fallback = {
+            translationEnhancer.enhanceWithTranslations(
+                request = translationRequest,
+                provider = openAIProvider,
+                targetLanguageName = targetLangName,
+                targetLanguageNotes = targetLangNotes,
+                model = ChatModel.GPT_5_4.asString(),
+                reasoningBudget = 900
+            )
+        },
+        onPrimaryError = { e ->
+            logger.error("Gemini translation failed for $lang/$word -> $targetLangCode: ${e.message}", e)
+        },
+        onPrimaryTimeout = {
+            logger.warn("Gemini translation timed out for $lang/$word -> $targetLangCode after ${AI_FALLBACK_TIMEOUT_MS}ms")
+        }
+    )
 }

--- a/server/src/main/kotlin/com/slovy/slovymovyapp/server/ai/enhancer/TranslationEnhancer.kt
+++ b/server/src/main/kotlin/com/slovy/slovymovyapp/server/ai/enhancer/TranslationEnhancer.kt
@@ -2,6 +2,7 @@ package com.slovy.slovymovyapp.server.ai.enhancer
 
 import com.slovy.slovymovyapp.ingestion.LanguageCardResponse
 import com.slovy.slovymovyapp.server.ai.*
+import io.ktor.util.logging.*
 import kotlinx.serialization.json.Json
 
 /**
@@ -10,6 +11,8 @@ import kotlinx.serialization.json.Json
  * For creating requests from extracted data, see the main project's TranslationEnhancer.
  */
 class TranslationEnhancer {
+
+    private val logger = KtorSimpleLogger("TranslationEnhancer")
 
     /**
      * Enhances a language card with translation data using AIProvider abstraction.
@@ -85,6 +88,7 @@ class TranslationEnhancer {
         )
         val decodedResponse = Json.decodeFromString<TranslationResponse>(response)
         validateSenseIds(request, decodedResponse)
+        validateExampleCoverage(request, decodedResponse)
         return decodedResponse
     }
 
@@ -182,9 +186,20 @@ class TranslationEnhancer {
                 val updatedExamples = sense.examples.map { example ->
                     // Normalize example text for lookup
                     val normalizedExampleText = normalizeTextForMatching(example.text)
-                    val exampleTranslation = exampleTranslationsMap[normalizedExampleText]
-                        ?: findBestMatchingTranslation(normalizedExampleText, translationResponse.exampleTranslations)
-                        ?: throw IllegalArgumentException("Missing translation for example: ${example.text} (normalized: '$normalizedExampleText')")
+                    val exampleTranslation = resolveExampleTranslation(
+                        normalizedExampleText = normalizedExampleText,
+                        exampleTranslationsMap = exampleTranslationsMap,
+                        exampleTranslations = translationResponse.exampleTranslations
+                    )
+                    if (exampleTranslation == null) {
+                        // enhanceWithTranslations rejects a response with unresolvable examples, so
+                        // reaching this means the caller merged a response it never validated. Keep
+                        // the sense-level translations rather than discarding the whole language.
+                        logger.warn(
+                            "No $targetLangCode translation for example '${example.text}'; leaving it untranslated"
+                        )
+                        return@map example
+                    }
                     val updatedTranslations =
                         example.targetLangTranslations + (targetLangCode to exampleTranslation.targetLangTranslation)
                     example.copy(targetLangTranslations = updatedTranslations)
@@ -214,6 +229,56 @@ class TranslationEnhancer {
         }
 
         return originalCard.copy(entries = updatedPos)
+    }
+
+    /**
+     * Resolves the translation for one example, exactly as [mergeTranslationData] does: an exact
+     * match on the normalized text first, then the fuzzy fallback.
+     *
+     * [validateExampleCoverage] resolves through this same function so a response it accepts can
+     * never fail to merge.
+     */
+    private fun resolveExampleTranslation(
+        normalizedExampleText: String,
+        exampleTranslationsMap: Map<String, ExampleTranslationData>,
+        exampleTranslations: List<ExampleTranslationData>
+    ): ExampleTranslationData? {
+        return exampleTranslationsMap[normalizedExampleText]
+            ?: findBestMatchingTranslation(normalizedExampleText, exampleTranslations)
+    }
+
+    /**
+     * Rejects a response that leaves any example of the source card untranslated.
+     *
+     * Models do drop examples: `gemini-3.1-flash-lite` returns 24 of the 26 examples of `en/star`
+     * for Simplified Chinese, deterministically. Failing here rather than at merge time makes that
+     * a provider failure, which is what lets the caller's provider fallback produce the complete
+     * response instead of losing the whole target language.
+     */
+    private fun validateExampleCoverage(
+        request: TranslationRequest,
+        response: TranslationResponse
+    ) {
+        val exampleTranslationsMap = response.exampleTranslations.associateBy {
+            normalizeTextForMatching(it.originalText)
+        }
+        val untranslated = request.languageCardData.entries
+            .flatMap { it.senses }
+            .flatMap { it.examples }
+            .filter { example ->
+                resolveExampleTranslation(
+                    normalizedExampleText = normalizeTextForMatching(example.text),
+                    exampleTranslationsMap = exampleTranslationsMap,
+                    exampleTranslations = response.exampleTranslations
+                ) == null
+            }
+            .map { it.text }
+        if (untranslated.isNotEmpty()) {
+            throw IllegalArgumentException(
+                "LLM left ${untranslated.size} example(s) untranslated in translation enhancement " +
+                        "to ${request.targetLangCode}: $untranslated"
+            )
+        }
     }
 
     private fun validateSenseIds(

--- a/server/src/main/kotlin/com/slovy/slovymovyapp/server/cloudrun/CloudTasksAuthVerifier.kt
+++ b/server/src/main/kotlin/com/slovy/slovymovyapp/server/cloudrun/CloudTasksAuthVerifier.kt
@@ -24,7 +24,8 @@ object CloudTasksAuthVerifier {
     fun verify(authorizationHeader: String?): Boolean {
         if (authorizationHeader == null) return false
         if (!authorizationHeader.startsWith("Bearer ", ignoreCase = true)) {
-            logger.warn("Authorization header does not start with Bearer: $authorizationHeader")
+            // Never log the header itself: whatever scheme it carries, the value is a credential.
+            logger.warn("Authorization header does not start with Bearer")
             return false
         }
 

--- a/server/src/main/kotlin/com/slovy/slovymovyapp/server/tasks/CloudTasksClient.kt
+++ b/server/src/main/kotlin/com/slovy/slovymovyapp/server/tasks/CloudTasksClient.kt
@@ -61,7 +61,7 @@ object RepoUpdateTaskClient {
         try {
             client.createTask(queuePath, task)
         } catch (e: Exception) {
-            logger.error("Failed to queue task: ${e.message}")
+            logger.error("Failed to queue repo update task for $lang/$word: ${e.message}", e)
         }
     }
 

--- a/server/src/main/resources/logback-profile-local.xml
+++ b/server/src/main/resources/logback-profile-local.xml
@@ -1,0 +1,12 @@
+<included>
+    <!-- Selected by logback.xml when GCLOUD is unset: local runs, tests, and the desktop shell. -->
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="CONSOLE"/>
+    </root>
+</included>

--- a/server/src/main/resources/logback-profile-true.xml
+++ b/server/src/main/resources/logback-profile-true.xml
@@ -1,0 +1,17 @@
+<included>
+    <!--
+      Selected by logback.xml when GCLOUD=true, which is set on the Cloud Run service. The appender
+      writes structured JSON to stdout instead of calling the Logging API, and Cloud Run ingests
+      that into Cloud Logging with the per-entry severity this format carries.
+    -->
+    <appender name="CLOUD" class="com.google.cloud.logging.logback.LoggingAppender">
+        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+            <level>INFO</level>
+        </filter>
+        <redirectToStdout>true</redirectToStdout>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="CLOUD"/>
+    </root>
+</included>

--- a/server/src/main/resources/logback.xml
+++ b/server/src/main/resources/logback.xml
@@ -1,27 +1,13 @@
 <configuration>
-    <if condition='System.getenv("GCLOUD") != null'>
-        <then>
-            <appender name="CLOUD" class="com.google.cloud.logging.logback.LoggingAppender">
-                <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
-                    <level>INFO</level>
-                </filter>
-                <redirectToStdout>true</redirectToStdout>
-            </appender>
+    <!--
+      Appender selection goes through an <include> rather than <if condition="...">: logback 1.6.1
+      treats that attribute as deprecated and then processes neither <then> nor <else>, so the
+      conditional config it replaces attached no appender at all and the server logged nothing -
+      locally and in Cloud Logging alike. Property substitution in the include's resource name has
+      no such problem, and it keeps the unselected appender from being instantiated at all.
 
-            <root level="info">
-                <appender-ref ref="CLOUD"/>
-            </root>
-        </then>
-        <else>
-            <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
-                <encoder>
-                    <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
-                </encoder>
-            </appender>
-
-            <root level="INFO">
-                <appender-ref ref="CONSOLE"/>
-            </root>
-        </else>
-    </if>
+      GCLOUD is "true" on Cloud Run and unset everywhere else, so the profile is the value itself.
+    -->
+    <property name="LOG_PROFILE" value="${GCLOUD:-local}"/>
+    <include resource="logback-profile-${LOG_PROFILE}.xml"/>
 </configuration>

--- a/server/src/test/kotlin/com/slovy/slovymovyapp/server/ai/enhancer/EnhancerSenseIdValidationTest.kt
+++ b/server/src/test/kotlin/com/slovy/slovymovyapp/server/ai/enhancer/EnhancerSenseIdValidationTest.kt
@@ -1,5 +1,6 @@
 package com.slovy.slovymovyapp.server.ai.enhancer
 
+import com.slovy.slovymovyapp.ingestion.LanguageCardExample
 import com.slovy.slovymovyapp.ingestion.LanguageCardPosEntry
 import com.slovy.slovymovyapp.ingestion.LanguageCardResponse
 import com.slovy.slovymovyapp.ingestion.LanguageCardResponseSense
@@ -8,7 +9,10 @@ import com.slovy.slovymovyapp.server.ai.AIProvider
 import com.slovy.slovymovyapp.server.ai.ModelInfo
 import kotlinx.serialization.json.Json
 import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 
 class EnhancerSenseIdValidationTest {
 
@@ -105,6 +109,144 @@ class EnhancerSenseIdValidationTest {
                 model = "test-model"
             )
         }
+    }
+
+    @Test
+    fun translationEnhancerRejectsResponseThatSkipsAnExample() {
+        val request = translationRequestWithExamples("She saw a bright <w>star</w>.", "Call me later, <w>star</w>.")
+
+        val response = TranslationResponse(
+            senseTranslations = listOf(
+                SenseTranslationData(
+                    senseId = "sense-1",
+                    targetLangDefinition = "夜空中的亮点",
+                    translations = emptyList()
+                )
+            ),
+            exampleTranslations = listOf(
+                ExampleTranslationData(
+                    originalText = "She saw a bright <w>star</w>.",
+                    targetLangTranslation = "她看到一颗明亮的<w>星星</w>。"
+                )
+            )
+        )
+
+        val provider = StubProvider(Json.encodeToString(TranslationResponse.serializer(), response))
+
+        // Rejecting here is what turns a model that drops examples into a provider failure, so the
+        // caller's fallback provider can produce the complete response.
+        val error = assertFailsWith<IllegalArgumentException> {
+            TranslationEnhancer().enhanceWithTranslations(
+                request = request,
+                provider = provider,
+                targetLanguageName = "Simplified Chinese",
+                model = "test-model"
+            )
+        }
+        assertTrue(
+            error.message?.contains("Call me later") == true,
+            "Error should name the untranslated example, was: ${error.message}"
+        )
+    }
+
+    @Test
+    fun translationEnhancerAcceptsExampleTranslationsThatOnlyFuzzyMatch() {
+        val request = translationRequestWithExamples("She saw a bright <w>star</w>.")
+
+        // The model echoes the example back with the tags stripped and spacing changed; merging
+        // resolves that through the fuzzy fallback, so validation has to accept it too.
+        val response = TranslationResponse(
+            senseTranslations = listOf(
+                SenseTranslationData(
+                    senseId = "sense-1",
+                    targetLangDefinition = "夜空中的亮点",
+                    translations = emptyList()
+                )
+            ),
+            exampleTranslations = listOf(
+                ExampleTranslationData(
+                    originalText = "She saw a  bright star!",
+                    targetLangTranslation = "她看到一颗明亮的<w>星星</w>。"
+                )
+            )
+        )
+
+        val provider = StubProvider(Json.encodeToString(TranslationResponse.serializer(), response))
+
+        val enhanced = TranslationEnhancer().enhanceWithTranslations(
+            request = request,
+            provider = provider,
+            targetLanguageName = "Simplified Chinese",
+            model = "test-model"
+        )
+        assertEquals(1, enhanced.exampleTranslations.size)
+    }
+
+    @Test
+    fun mergeKeepsSenseTranslationsWhenAnExampleHasNoMatch() {
+        val request = translationRequestWithExamples("She saw a bright <w>star</w>.", "Call me later, <w>star</w>.")
+
+        val response = TranslationResponse(
+            senseTranslations = listOf(
+                SenseTranslationData(
+                    senseId = "sense-1",
+                    targetLangDefinition = "夜空中的亮点",
+                    translations = emptyList()
+                )
+            ),
+            exampleTranslations = listOf(
+                ExampleTranslationData(
+                    originalText = "She saw a bright <w>star</w>.",
+                    targetLangTranslation = "她看到一颗明亮的<w>星星</w>。"
+                )
+            )
+        )
+
+        val merged = TranslationEnhancer().mergeTranslationData(
+            originalCard = request.languageCardData,
+            translationResponse = response,
+            targetLangCode = "zh"
+        )
+
+        val sense = merged.entries.single().senses.single()
+        assertTrue(sense.targetLangDefinitions.containsKey("zh"), "Sense definition should still be merged")
+        assertTrue(
+            sense.examples[0].targetLangTranslations.containsKey("zh"),
+            "Matched example should carry the translation"
+        )
+        assertFalse(
+            sense.examples[1].targetLangTranslations.containsKey("zh"),
+            "Unmatched example should be left untranslated rather than failing the whole language"
+        )
+    }
+
+    private fun translationRequestWithExamples(vararg exampleTexts: String): TranslationRequest {
+        val languageCard = LanguageCardResponse(
+            wordFamily = emptyList(),
+            entries = listOf(
+                LanguageCardPosEntry(
+                    pos = "noun",
+                    senses = listOf(
+                        LanguageCardResponseSense(
+                            senseId = "sense-1",
+                            senseDefinition = "definition",
+                            learnerLevel = "A1",
+                            frequency = "High",
+                            semanticGroupId = "group-1",
+                            nameType = "no",
+                            examples = exampleTexts.map { LanguageCardExample(text = it) }
+                        )
+                    )
+                )
+            )
+        )
+        return TranslationRequest(
+            word = "star",
+            langCode = "en",
+            targetLangCode = "zh",
+            languageCardData = languageCard,
+            translations = emptyList()
+        )
     }
 
     private class StubProvider(


### PR DESCRIPTION
## Contributor terms

- [x] I have read and agree to the contributor terms in `CONTRIBUTING.md`.
- [x] I have the right to submit these changes under those terms.

## Summary

`GET /word/en/star?translations=zh` stubbornly returned only a base chunk and no translations, with nothing in the logs to say why. Reproducing it locally turned up three separate defects.

**1. An incomplete model response discarded the whole target language.** `gemini-3.1-flash-lite` returns 24 of the 26 example translations for that card, deterministically — it skips both examples of one sense. `mergeTranslationData` threw on the first example it could not resolve, throwing away the entire language including its 13 perfectly good sense translations. Crucially that throw happened *after* `raceWithFallback` had returned, so an incomplete response was never counted as a provider failure and OpenAI never got a chance.

Example coverage is now validated inside `enhanceWithTranslations`, alongside the existing sense-id validation, so an incomplete response fails as a provider error and the fallback produces the complete one. Validation resolves examples through the same helper the merge uses (exact match on normalized text, then the fuzzy fallback), so a response validation accepts cannot subsequently fail to merge. The merge itself now warns and leaves a single unresolvable example untranslated rather than throwing — a last resort, no longer the failure path.

Measured against the real card: OpenAI returns 26/26 for `zh`, and Gemini returns 26/26 for `de`, so this is specific to that model on that language rather than a general shortfall.

**2. Per-language failures were not isolated.** `awaitAll` meant one target language failing cancelled its siblings, so `translations=zh,de` lost `de` because `zh` failed. Each language now fails independently and is logged. A language that produced nothing also no longer counts as an update — previously that would stream a translated chunk identical to the base one and queue a repo update carrying no new content.

**3. None of it was visible in the logs**, locally or in Cloud Logging. Two independent causes:

- `respondTextWriter` invokes its writer block outside the handler's `try`/`catch`. Confirmed with a probe: the block throws, `respondTextWriter` returns normally, the client gets a 200 with the stream stopping after the base chunk, and the route's `logger.error` never runs. The writer block now reports its own failures.
- logback 1.6.1 treats the `condition` attribute of `<if>` as deprecated and then processes **neither** `<then>` nor `<else>`. Janino is present and loadable (checked), and `isDefined("GCLOUD")` behaves identically, so it is the attribute form itself. The result was no appender, no root logger, and zero output in every environment. Appender selection now goes through an `<include>` whose resource name is built from `GCLOUD` (`"true"` on Cloud Run, unset elsewhere) — no Janino needed, and the unselected appender is never instantiated. The GCP appender and its severity mapping are preserved. `janino` is dropped as now unused.

## Testing

- `./gradlew :server:test` — green (run after each config change, and again after the dependency removal).
- Three regression tests added to `EnhancerSenseIdValidationTest`: a response that skips an example is rejected; one that only fuzzy-matches is accepted; and the merge keeps sense translations when an example has no match.
- End-to-end against a locally built distribution, before/after:

  ```
  before   stage=base        sensesWithZh=0/13   examplesWithZh=0/26     (no translated chunk)
  after    stage=translated  sensesWithZh=13/13  examplesWithZh=26/26
  ```

- Both logback profiles verified by running the built distribution. Local emits plain console lines; `GCLOUD=true` emits the structured form, needing no GCP credentials since `redirectToStdout` avoids the Logging API:

  ```json
  {"severity":"ERROR","logging.googleapis.com/labels":{"loggerName":"io.ktor.server.Application","levelName":"ERROR"},"@type":"type.googleapis.com/google.devtools.clouderrorreporting.v1beta1.ReportedErrorEvent","message":"Gemini translation failed for en/star -> zh: LLM left 2 example(s) untranslated..."}
  ```

  The `ReportedErrorEvent` type means these now also reach Cloud Error Reporting.

- Confirmed `janino` and its transitive `commons-compiler` are gone from the distribution, and that both profiles still start clean without them (logback now reports no status warnings at all).

## Notes for the reviewer

- `Application.kt` shows a large diff mostly from re-indentation: the writer block is now wrapped in a `try`, and the per-language body was extracted into `translateInto`. `git diff -w` reduces it to the substantive changes.
- `en/star` still has no `zh` in the words repo — everything here was verified without `push` to avoid writing to it. The first `push=true` request after deploy will persist it.
- Pre-existing and untouched, but adjacent enough to flag: `getExistingTranslationLanguages` treats a language as present if *any* sense carries it, so a partially translated word is never repaired by a later request.
