### PR TITLE
Make the Chinese translation notes source-language neutral

### DIFF
--- a/shared/src/commonMain/kotlin/com/slovy/slovymovyapp/data/Language.kt
+++ b/shared/src/commonMain/kotlin/com/slovy/slovymovyapp/data/Language.kt
@@ -69,10 +69,11 @@ enum class Language(
             from non-Han scripts unless the sense has no usable Mandarin entry at all. This applies
             equally to the definitions and example translations you write yourself.
 
-            Mandarin has no lexical counterpart for many English function words, and what you write
-            has to be natural Chinese rather than a word-for-word mirror of the English:
+            Mandarin has no lexical counterpart for many of the function words the source language
+            uses, and what you write has to be natural Chinese rather than a word-for-word mirror of
+            the source sentence:
             - Prefer wording in which a real Mandarin word carries the sense, and tag that word in
-              the slot Chinese grammar gives it rather than the slot the English word held. Usually
+              the slot Chinese grammar gives it rather than the slot the source word held. Usually
               this is a coverb: 我<w>给</w>妈妈买了礼物, 锻炼<w>对</w>你的健康很有益, 他用苹果<w>换</w>了
               一根香蕉.
             - Where the sense is carried by structure alone - a bare duration complement (住了十年),
@@ -96,17 +97,18 @@ enum class Language(
               (<w>体育</w>课 where the word is 体育课).
             - Chinese counts nouns with a measure word, and which of the two carries the tag is
               decided by the sense's own declared translations. Where those are measure words
-              (块, 条, 件), the English word is the counter, so tag the measure word: 一<w>块</w>派,
+              (块, 条, 件), the source word is the counter, so tag the measure word: 一<w>块</w>派,
               一<w>条</w>有用的建议. Where they are nouns (曲子, 文章, 枪), tag the noun and leave the
               measure word outside it: 两首优美的<w>曲子</w>, 一篇关于医学研究的<w>文章</w>,
               带着<w>枪</w>. Never tag the noun when the declared translations are measure words -
-              blanking 建议 asks the learner for "advice" rather than for the word being taught.
+              blanking 建议 asks the learner for the thing being counted rather than for the word
+              being taught.
             - Do not repeat a morpheme the surrounding words already supply: 正则表达式, 生理盐水 and
               母乳 each already contain the head, so choose wording that fits what is around it.
             - Keep parenthetical glosses out of the example sentences; that belongs in the sense
               clarification.
             - Transliterate foreign names so that they still read as foreign; 韦 is an ordinary
-              Chinese surname and cannot stand in for an English one.
+              Chinese surname and cannot stand in for a foreign one.
         """.trimIndent()
     );
 


### PR DESCRIPTION
## Problem

`Language.CHINESE.translationPromptNotes` is substituted into `TRANSLATION_SYSTEM_PROMPT` whenever Chinese is the **target** language. The source language is independent of that — currently any of `en`, `ru`, `nl`, `pl`.

The notes described the source word as English throughout, so a `ru→zh` or `pl→zh` run was told about an English word that is not in its input:

- "Mandarin has no lexical counterpart for many **English** function words"
- "a word-for-word mirror of **the English**"
- "the slot the **English** word held"
- "the **English** word is the counter"
- "cannot stand in for **an English** one"

## Change

Those five references now name the source language instead.

The sixth is less obvious and worth a look: `blanking 建议 asks the learner for "advice"` wasn't the word *English*, but it used an English gloss to stand in for what the learner is asked to produce, which only reads correctly when the source is English. It now says "the thing being counted".

No placeholder was added — the model receives `lang_code` in the request payload and the whole card is written in the source language, so "the source word" resolves without ambiguity. That keeps the change contained to the Chinese block: `EnhancerPrompts.kt` is untouched, and every other language's `translationPromptNotes` is empty, so nothing else carried the assumption.

## Risk

Wording only, no semantic change for `en→zh` — the path the existing zh corpus was generated from. The languages this actually fixes (`ru→zh`, `nl→zh`, `pl→zh`) have no zh corpus yet, so there is nothing to regress.

Not verified against live generation. `PromptNotesTest` passes (3/3), which confirms the notes still reach the provider verbatim for all 11 languages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)