### PR TITLE
Add tagging rules to the Chinese translation notes

### DIFF
--- a/shared/src/commonMain/kotlin/com/slovy/slovymovyapp/data/Language.kt
+++ b/shared/src/commonMain/kotlin/com/slovy/slovymovyapp/data/Language.kt
@@ -76,6 +76,11 @@ enum class Language(
               the slot Chinese grammar gives it rather than the slot the source word held. Usually
               this is a coverb: 我<w>给</w>妈妈买了礼物, 锻炼<w>对</w>你的健康很有益, 他用苹果<w>换</w>了
               一根香蕉.
+            - Before choosing what to tag, look at the sentence you have just written and check
+              whether a word already in it carries the sense. Usually one does, and it is the word
+              to tag - it does not have to be string-identical to a declared translation, a
+              contextual synonym is correct. Tag a different word only when nothing already present
+              carries the sense.
             - Where the sense is carried by structure alone - a bare duration complement (住了十年),
               了, 的, word order - write the natural sentence and leave it untagged. An untagged
               example translation is a correct answer, and takes precedence over the later
@@ -95,6 +100,15 @@ enum class Language(
             - Tag the declared translation exactly. Do not pull an added verb inside the tag
               (<w>去健身房</w> where the word is 健身房), and do not leave part of it outside
               (<w>体育</w>课 where the word is 体育课).
+            - The tagged span must be able to serve as the same part of speech as pos. If pos is
+              noun, the span must be a noun or noun phrase - never a verb, a verb-object compound,
+              or a measure word standing in for a noun that is itself declared. Where the declared
+              translations are themselves measure words, the measure word is the taught word and
+              takes the tag. Before you finalise an example, name the part of speech of the span
+              you tagged and confirm it matches pos. These are all one error, a noun sense with a
+              verb tagged: 我需要给老师<w>写</w>一封电子邮件 (email - tag 电子邮件),
+              她赢得了第一<w>名</w> (prize - 名 is rank), 我们决定<w>开车</w>去度假 (car - 开车 is a
+              verb phrase).
             - Chinese counts nouns with a measure word, and which of the two carries the tag is
               decided by the sense's own declared translations. Where those are measure words
               (块, 条, 件), the source word is the counter, so tag the measure word: 一<w>块</w>派,


### PR DESCRIPTION
Two insertions into `Language.CHINESE.translationPromptNotes`. **No existing sentence is changed, reordered or deleted** — 14 lines added, 0 removed.

That constraint is deliberate. Earlier attempts at this rewrote rules that other rules depended on, and each regressed on words it had not been tuned against. These two cannot, because nothing currently in the prompt refers to them.

## What they say

**1. Check the sentence before choosing a span** — inserted after the coverb bullet.

> Before choosing what to tag, look at the sentence you have just written and check whether a word already in it carries the sense. Usually one does, and it is the word to tag — it does not have to be string-identical to a declared translation, a contextual synonym is correct.

The permission for a contextual synonym is load-bearing. An earlier variant made this a hard constraint and it forced unnatural Chinese and dropped 15% of example translations.

**2. Part-of-speech agreement** — inserted after "Tag the declared translation exactly".

Requires the tagged span to serve as the same part of speech as `pos`, and to **name** that part of speech before finalising. Part-of-speech mismatch is the dominant defect shape across all four courses — identified independently by the English, Russian/Polish and Dutch reviews — and nothing in the prompt stated the constraint.

## The measure-word clause is narrowed

The original proposal said "never a bare measure word standing in for the noun". That collides with the existing rule that tags `一<w>块</w>派` when the declared translations are themselves measure words.

On a 20-word set built to trigger that collision, the blanket wording scored **below** production:

| arm | exact | sub | nomatch |
|---|---|---|---|
| production | 87.5% | 3.3% | 8.0% |
| blanket wording | 86.4% | 6.1% | 6.4% |
| **narrowed (this PR)** | **91.2%** | **2.7%** | **4.8%** |

The narrowed version recovers `cloud` (留下一`<w>团</w>`尘土, 蚊子`<w>群</w>`). One case, `article`, still tags 家具 rather than the declared 件.

## Measurement

99 words, 1,089 examples per arm, `gemini-3.1-flash-lite`, temperature 0, seed fixed. Fresh generation against the production request shape — no repair pass applied to either arm.

| arm | exact | sub | sup | nomatch | untagged | dropped |
|---|---|---|---|---|---|---|
| production | 80.2% | 13.8% | 0.5% | 5.5% | 1 | 16 |
| this PR | **85.5%** | **10.6%** | 0.3% | **3.7%** | 3 | 20 |

Direction is consistent across three separate samples (30 tuned, 30 holdout, 99 combined).

## Regression checks

**Dropped examples are pre-existing, not introduced.** The arms drop *different* words — `entire`/`swear` under production, `trap`/`nor`/`treatment` under the patch — at comparable rates (1.5% vs 1.8%), concentrated in a handful of long multi-sense entries.

**Script normalisation unaffected.** Zero Traditional, Cyrillic, kana or Hangul across 7,028 generated Chinese strings in both arms.

`PromptNotesTest` passes 3/3 — the notes still reach the provider verbatim for all 11 languages.

## Known limitation

The metric rewards matching the declared string, and that is not always better Chinese. `negative` (radio "no", declared 否定) shows it: production tags 否, correct radio usage; the patch tags 否定, the declared word, wrong register. That scores as a gain and is a loss for the learner. Some unknown share of the +5.3 points is this. Separating it needs judged evaluation of the ~250 changed tags, not the tag-matches-declaration metric.

🤖 Generated with [Claude Code](https://claude.com/claude-code)