### PR TITLE
Repair missing favorites translations after a language change

### DIFF
--- a/composeApp/src/commonMain/composeResources/values-cs/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-cs/strings.xml
@@ -403,6 +403,9 @@
     <string name="settings_toggle_translation_for_language">Přepnout překlad %1$s</string>
     <string name="settings_remove_language_confirm_title">Odebrat %1$s?</string>
     <string name="settings_remove_language_confirm_message">Slovník a všechny jeho překlady budou smazány. Kdykoli si je můžeš stáhnout znovu.</string>
+    <string name="settings_translation_added_restart_title">Restartujte pro aktualizaci překladů</string>
+    <string name="settings_translation_added_restart_message">Uložená slova je potřeba stáhnout znovu, aby se přidal nový jazyk překladu. Restartujte aplikaci a při spuštění je aktualizuje.</string>
+    <string name="settings_translation_added_restart_confirm">Rozumím</string>
     <plurals name="settings_remove_language_warning">
         <item quantity="one">Tím se odebere i %1$d překlad.</item>
         <item quantity="few">Tím se odeberou i %1$d překlady.</item>

--- a/composeApp/src/commonMain/composeResources/values-de/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-de/strings.xml
@@ -403,6 +403,9 @@
     <string name="settings_toggle_translation_for_language">%1$s-Übersetzung umschalten</string>
     <string name="settings_remove_language_confirm_title">%1$s entfernen?</string>
     <string name="settings_remove_language_confirm_message">Das Wörterbuch und alle seine Übersetzungen werden gelöscht. Du kannst sie jederzeit erneut herunterladen.</string>
+    <string name="settings_translation_added_restart_title">Zum Aktualisieren neu starten</string>
+    <string name="settings_translation_added_restart_message">Gespeicherte Wörter müssen erneut geladen werden, um die neue Übersetzungssprache hinzuzufügen. Starte die App neu, dann werden sie beim Start aktualisiert.</string>
+    <string name="settings_translation_added_restart_confirm">Verstanden</string>
     <plurals name="settings_remove_language_warning">
         <item quantity="one">Dadurch wird auch %1$d Übersetzung entfernt.</item>
         <item quantity="few">Dadurch werden auch %1$d Übersetzungen entfernt.</item>

--- a/composeApp/src/commonMain/composeResources/values-es/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-es/strings.xml
@@ -403,6 +403,9 @@
     <string name="settings_toggle_translation_for_language">Activar/desactivar traducción de %1$s</string>
     <string name="settings_remove_language_confirm_title">¿Quitar %1$s?</string>
     <string name="settings_remove_language_confirm_message">Se eliminarán el diccionario y todas sus traducciones. Puedes volver a descargarlos cuando quieras.</string>
+    <string name="settings_translation_added_restart_title">Reinicia para actualizar las traducciones</string>
+    <string name="settings_translation_added_restart_message">Las palabras guardadas deben descargarse de nuevo para añadir el nuevo idioma de traducción. Reinicia la aplicación y se actualizarán al iniciarse.</string>
+    <string name="settings_translation_added_restart_confirm">Entendido</string>
     <plurals name="settings_remove_language_warning">
         <item quantity="one">Esto también quitará %1$d traducción.</item>
         <item quantity="few">Esto también quitará %1$d traducciones.</item>

--- a/composeApp/src/commonMain/composeResources/values-fr/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-fr/strings.xml
@@ -403,6 +403,9 @@
     <string name="settings_toggle_translation_for_language">Activer/désactiver la traduction %1$s</string>
     <string name="settings_remove_language_confirm_title">Supprimer %1$s ?</string>
     <string name="settings_remove_language_confirm_message">Le dictionnaire et toutes ses traductions seront supprimés. Tu peux les retélécharger à tout moment.</string>
+    <string name="settings_translation_added_restart_title">Redémarrez pour mettre à jour les traductions</string>
+    <string name="settings_translation_added_restart_message">Les mots enregistrés doivent être téléchargés à nouveau pour ajouter la nouvelle langue de traduction. Redémarrez l'application : ils seront mis à jour au démarrage.</string>
+    <string name="settings_translation_added_restart_confirm">Compris</string>
     <plurals name="settings_remove_language_warning">
         <item quantity="one">Cela supprimera aussi %1$d traduction.</item>
         <item quantity="few">Cela supprimera aussi %1$d traductions.</item>

--- a/composeApp/src/commonMain/composeResources/values-it/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-it/strings.xml
@@ -403,6 +403,9 @@
     <string name="settings_toggle_translation_for_language">Attiva/disattiva traduzione %1$s</string>
     <string name="settings_remove_language_confirm_title">Rimuovere %1$s?</string>
     <string name="settings_remove_language_confirm_message">Il dizionario e tutte le sue traduzioni verranno eliminati. Puoi scaricarli di nuovo quando vuoi.</string>
+    <string name="settings_translation_added_restart_title">Riavvia per aggiornare le traduzioni</string>
+    <string name="settings_translation_added_restart_message">Le parole salvate devono essere scaricate di nuovo per aggiungere la nuova lingua di traduzione. Riavvia l'app e verranno aggiornate all'avvio.</string>
+    <string name="settings_translation_added_restart_confirm">Ho capito</string>
     <plurals name="settings_remove_language_warning">
         <item quantity="one">Questo rimuoverà anche %1$d traduzione.</item>
         <item quantity="few">Questo rimuoverà anche %1$d traduzioni.</item>

--- a/composeApp/src/commonMain/composeResources/values-nl/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-nl/strings.xml
@@ -403,6 +403,9 @@
     <string name="settings_toggle_translation_for_language">Schakel %1$s-vertaling in of uit</string>
     <string name="settings_remove_language_confirm_title">%1$s verwijderen?</string>
     <string name="settings_remove_language_confirm_message">Het woordenboek en alle vertalingen worden verwijderd. Je kunt ze altijd opnieuw downloaden.</string>
+    <string name="settings_translation_added_restart_title">Herstart om vertalingen bij te werken</string>
+    <string name="settings_translation_added_restart_message">Opgeslagen woorden moeten opnieuw worden opgehaald om de nieuwe vertaaltaal toe te voegen. Herstart de app; ze worden bij het opstarten bijgewerkt.</string>
+    <string name="settings_translation_added_restart_confirm">Begrepen</string>
     <plurals name="settings_remove_language_warning">
         <item quantity="one">Hierdoor wordt ook %1$d vertaling verwijderd.</item>
         <item quantity="few">Hierdoor worden ook %1$d vertalingen verwijderd.</item>

--- a/composeApp/src/commonMain/composeResources/values-pl/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-pl/strings.xml
@@ -402,6 +402,9 @@
     <string name="settings_toggle_translation_for_language">Przełącz tłumaczenie %1$s</string>
     <string name="settings_remove_language_confirm_title">Usunąć %1$s?</string>
     <string name="settings_remove_language_confirm_message">Słownik i wszystkie jego tłumaczenia zostaną usunięte. Możesz je pobrać ponownie w dowolnym momencie.</string>
+    <string name="settings_translation_added_restart_title">Uruchom ponownie, aby zaktualizować tłumaczenia</string>
+    <string name="settings_translation_added_restart_message">Zapisane słowa trzeba pobrać ponownie, aby dodać nowy język tłumaczenia. Uruchom ponownie aplikację — zaktualizuje je przy starcie.</string>
+    <string name="settings_translation_added_restart_confirm">Rozumiem</string>
     <plurals name="settings_remove_language_warning">
         <item quantity="one">To usunie również %1$d tłumaczenie.</item>
         <item quantity="few">To usunie również %1$d tłumaczenia.</item>

--- a/composeApp/src/commonMain/composeResources/values-ru/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-ru/strings.xml
@@ -403,6 +403,9 @@
     <string name="settings_toggle_translation_for_language">Переключить перевод %1$s</string>
     <string name="settings_remove_language_confirm_title">Удалить %1$s?</string>
     <string name="settings_remove_language_confirm_message">Словарь и все его переводы будут удалены. Вы сможете скачать их снова в любое время.</string>
+    <string name="settings_translation_added_restart_title">Перезапустите для обновления переводов</string>
+    <string name="settings_translation_added_restart_message">Сохранённые слова нужно загрузить заново, чтобы добавить новый язык перевода. Перезапустите приложение — оно обновит их при запуске.</string>
+    <string name="settings_translation_added_restart_confirm">Понятно</string>
     <plurals name="settings_remove_language_warning">
         <item quantity="one">Это также удалит %1$d перевод.</item>
         <item quantity="few">Это также удалит %1$d перевода.</item>

--- a/composeApp/src/commonMain/composeResources/values-tr/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-tr/strings.xml
@@ -403,6 +403,9 @@
     <string name="settings_toggle_translation_for_language">%1$s çevirisini aç/kapat</string>
     <string name="settings_remove_language_confirm_title">%1$s kaldırılsın mı?</string>
     <string name="settings_remove_language_confirm_message">Sözlük ve tüm çevirileri silinecek. İstediğin zaman yeniden indirebilirsin.</string>
+    <string name="settings_translation_added_restart_title">Çevirileri güncellemek için yeniden başlatın</string>
+    <string name="settings_translation_added_restart_message">Yeni çeviri dilini eklemek için kaydedilen kelimelerin yeniden indirilmesi gerekiyor. Uygulamayı yeniden başlatın, açılışta güncellenecekler.</string>
+    <string name="settings_translation_added_restart_confirm">Anladım</string>
     <plurals name="settings_remove_language_warning">
         <item quantity="one">Bu, %1$d çeviriyi de kaldıracak.</item>
         <item quantity="few">Bu, %1$d çeviriyi de kaldıracak.</item>

--- a/composeApp/src/commonMain/composeResources/values-zh/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-zh/strings.xml
@@ -403,6 +403,9 @@
     <string name="settings_toggle_translation_for_language">切换 %1$s 翻译</string>
     <string name="settings_remove_language_confirm_title">移除 %1$s？</string>
     <string name="settings_remove_language_confirm_message">该词典及其全部翻译都会被删除。你随时可以重新下载。</string>
+    <string name="settings_translation_added_restart_title">重启以更新翻译</string>
+    <string name="settings_translation_added_restart_message">要添加新的翻译语言，已保存的单词需要重新获取。重启应用后，它会在启动时更新这些单词。</string>
+    <string name="settings_translation_added_restart_confirm">知道了</string>
     <plurals name="settings_remove_language_warning">
         <item quantity="one">这还会一并移除 %1$d 种翻译。</item>
         <item quantity="few">这还会一并移除 %1$d 种翻译。</item>

--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -403,6 +403,9 @@
     <string name="settings_toggle_translation_for_language">Toggle %1$s translation</string>
     <string name="settings_remove_language_confirm_title">Remove %1$s?</string>
     <string name="settings_remove_language_confirm_message">The dictionary and all its translations will be deleted. You can download them again anytime.</string>
+    <string name="settings_translation_added_restart_title">Restart to update translations</string>
+    <string name="settings_translation_added_restart_message">Saved words need to be fetched again to add the new translation language. Restart the app and it will update them on startup.</string>
+    <string name="settings_translation_added_restart_confirm">Got it</string>
     <plurals name="settings_remove_language_warning">
         <item quantity="one">This will also remove %1$d translation.</item>
         <item quantity="few">This will also remove %1$d translations.</item>

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/App.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/App.kt
@@ -337,8 +337,8 @@ fun App(
             wordFetchManager = wordFetchManager,
         )
     }
-    val lemmaRecoveryController = remember(lemmaRecovery, platform) {
-        LemmaRecoveryController(lemmaRecovery, platform)
+    val lemmaRecoveryController = remember(lemmaRecovery, platform, settingsRepository) {
+        LemmaRecoveryController(lemmaRecovery, platform, settingsRepository)
     }
     DisposableEffect(lemmaRecoveryController) {
         onDispose { lemmaRecoveryController.close() }
@@ -537,7 +537,13 @@ fun App(
                 } catch (_: Exception) {
                     emptyList()
                 }
-                val needsDownload = !dataManager.hasDictionary(dictionary) ||
+                // A translation language added since the last run leaves saved words without
+                // data for it; only lemma recovery re-fetches them. The download flow's
+                // finalize step is what runs recovery with progress, so route through it even
+                // when every DB is already present — it starts immediately with no items.
+                val pendingRecovery = settingsRepository.isPendingLemmaRecovery()
+                val needsDownload = pendingRecovery ||
+                        !dataManager.hasDictionary(dictionary) ||
                         downloadableTargets.any { !dataManager.hasTranslation(dictionary, it) }
                 return if (needsDownload) {
                     AppDestination.DownloadSetup

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/data/remote/DictionaryClient.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/data/remote/DictionaryClient.kt
@@ -70,6 +70,28 @@ sealed class DictionaryClientException(message: String, cause: Throwable? = null
     /** Operation was cancelled */
     class CancelledException(message: String = "Operation cancelled") :
         DictionaryClientException(message)
+
+    /**
+     * The server closed the stream before delivering everything the request asked for: no chunk at
+     * all, or a base chunk without the requested translations. The server bails out that way when
+     * no AI provider is configured or db-extract data is missing, and that looks exactly like a
+     * successful base-only response on the wire. Without turning it into an error the last emission
+     * would keep its loading flags set forever, because the flow simply closes afterwards.
+     */
+    class IncompleteStreamException(
+        val lemma: String,
+        val language: Language,
+        val pendingTranslations: List<Language>,
+    ) : DictionaryClientException(
+        buildString {
+            append("Server stream for '$lemma' (${language.code}) ended early")
+            if (pendingTranslations.isNotEmpty()) {
+                append(": translations for ")
+                append(pendingTranslations.joinToString(", ") { it.code })
+                append(" never arrived")
+            }
+        }
+    )
 }
 
 /**
@@ -357,6 +379,7 @@ class DictionaryClient(
                 ),
             )
             var chunkCount = 0L
+            var translationsPending: List<Language> = emptyList()
             try {
                 val url = buildUrl(language, lemma, targets, push)
                 val response = httpClient.get(url)
@@ -378,13 +401,18 @@ class DictionaryClient(
                     chunkCount += 1
                     val isBaseStage = chunk.stage == WordStreamStage.BASE
 
-                    val haveRequiredTranslations = chunk.payload.entries.any {
-                        it.senses.any { s ->
-                            s.translations.keys.containsAll(targets.map { k -> k.code })
-                        }
-                    }
+                    // Union across senses, the same rule the server applies when deciding whether
+                    // anything is still left to translate. Demanding that a single sense carry
+                    // every target would mark a word whose targets are spread over several senses
+                    // as unfinished, and the translated chunk that would clear it never comes.
+                    val deliveredTranslations = chunk.payload.entries
+                        .flatMap { it.senses }
+                        .flatMap { sense -> sense.translations.keys + sense.targetLangDefinitions.keys }
+                        .toSet()
+                    val missingTranslations = targets.filter { it.code !in deliveredTranslations }
                     // After base, we expect translated if translations were requested
-                    val hasMoreChunks = isBaseStage && !haveRequiredTranslations
+                    val hasMoreChunks = isBaseStage && missingTranslations.isNotEmpty()
+                    translationsPending = if (hasMoreChunks) missingTranslations else emptyList()
 
                     processChunk(
                         collector = collector,
@@ -395,6 +423,19 @@ class DictionaryClient(
                         hasMoreChunks = hasMoreChunks,
                         frequency = frequency,
                         localIsOnlineOnly = localIsOnlineOnly
+                    )
+                }
+
+                // The stream is over, so nothing will clear the loading flags of the last emission
+                // any more. An empty stream, or a base chunk whose promised translated chunk never
+                // arrived, has to surface as an error - otherwise every collector waiting for a
+                // settled result (lemma recovery) waits forever and the UI keeps spinning.
+                if (chunkCount == 0L || translationsPending.isNotEmpty()) {
+                    markResult("incomplete_stream")
+                    throw DictionaryClientException.IncompleteStreamException(
+                        lemma = lemma,
+                        language = language,
+                        pendingTranslations = translationsPending,
                     )
                 }
             } finally {

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/data/remote/LemmaRecovery.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/data/remote/LemmaRecovery.kt
@@ -77,8 +77,8 @@ class LemmaRecovery internal constructor(
 
     suspend fun recoverAllInstalled(
         onProgress: (LemmaRecoveryProgress) -> Unit = {},
-    ) {
-        PerformanceMonitoring.startTrace("lemma_recovery").useWithResult {
+    ): LemmaRecoveryOutcome {
+        return PerformanceMonitoring.startTrace("lemma_recovery").useWithResult {
             try {
                 val items = itemsProvider()
                 putMetric("items", items.size.toLong())
@@ -88,16 +88,25 @@ class LemmaRecovery internal constructor(
                 putMetric("groups_completed", summary.completed.toLong())
                 putMetric("groups_failed", summary.failed.toLong())
                 markResult(when {
+                    summary.checksFailed -> "check_failed"
                     summary.total == 0 -> "nothing_to_recover"
                     summary.failed > 0 -> "partial_failure"
                     else -> "success"
                 })
+                LemmaRecoveryOutcome(
+                    total = summary.total,
+                    failed = summary.failed,
+                    // A swallowed pre-flight check means whole languages were never inspected, so
+                    // an empty group list proves nothing about what is still missing.
+                    fullyRecovered = summary.failed == 0 && !summary.checksFailed,
+                )
             } catch (e: CancellationException) {
                 throw e
             } catch (e: Exception) {
                 markResult("failed")
                 AppLogger.warn(TAG, "Unable to load items for recovery", e)
                 // Recovery must never block a completed database download.
+                LemmaRecoveryOutcome(total = 0, failed = 0, fullyRecovered = false)
             }
         }
     }
@@ -112,7 +121,8 @@ class LemmaRecovery internal constructor(
                 if (lemma.isBlank()) null else LemmaGroupKey(item.language, lemma.lowercase()) to item
             }
             .groupBy({ it.first }, { it.second })
-        val groupsToRecover = groupsByDownloadedLemmaStatus(groups)
+        val targets = groupsByDownloadedLemmaStatus(groups)
+        val groupsToRecover = targets.groups
         val total = groupsToRecover.size
         val progressMutex = Mutex()
         var completed = 0
@@ -156,18 +166,30 @@ class LemmaRecovery internal constructor(
             }
         }.awaitAll()
 
-        RecoverySummary(total, completed, failed)
+        RecoverySummary(total, completed, failed, targets.checksFailed)
     }
 
+    /**
+     * Narrows [groups] to the ones whose lemma or translations are missing from the downloaded DBs.
+     *
+     * A check that throws (unreadable or closed DB) is swallowed so recovery can still repair the
+     * languages that are readable, but it is reported through [RecoveryTargets.checksFailed]: the
+     * unchecked languages may still have gaps, so the pass must not claim it recovered everything.
+     */
     private suspend fun groupsByDownloadedLemmaStatus(
         groups: Map<LemmaGroupKey, List<RecoverableSense>>,
-    ): Map<LemmaGroupKey, List<RecoverableSense>> {
+    ): RecoveryTargets {
+        var checksFailed = false
         val byLanguage = groups.entries.groupBy({ it.key.language }) { it.key to it.value }
         val recoverableByLanguage: Map<Language, Set<String>> = byLanguage.mapValues { (language, entries) ->
             if (!hasDownloadedDictionary(language)) return@mapValues emptySet()
 
             val normalizedLemmas = entries.map { it.first.normalizedLemma }.toSet()
             val lemmasMissingDictionary = downloadedLemmasNeedingRecoverySafe(language, normalizedLemmas)
+                ?: run {
+                    checksFailed = true
+                    emptySet()
+                }
 
             val remainingForTranslationCheck = normalizedLemmas - lemmasMissingDictionary
             val senseIdsByLemma = entries
@@ -182,13 +204,20 @@ class LemmaRecovery internal constructor(
                 emptySet()
             } else {
                 downloadedSensesNeedingTranslationRecoverySafe(language, senseIdsByLemma, translationTargets)
+                    ?: run {
+                        checksFailed = true
+                        emptySet()
+                    }
             }
             lemmasMissingDictionary + lemmasMissingTranslations
         }
 
-        return groups.filterKeys { key ->
-            key.normalizedLemma in recoverableByLanguage[key.language].orEmpty()
-        }
+        return RecoveryTargets(
+            groups = groups.filterKeys { key ->
+                key.normalizedLemma in recoverableByLanguage[key.language].orEmpty()
+            },
+            checksFailed = checksFailed,
+        )
     }
 
     /**
@@ -291,10 +320,11 @@ class LemmaRecovery internal constructor(
         }
     }
 
+    /** Returns null when the check itself failed, which is different from "nothing is missing". */
     private suspend fun downloadedLemmasNeedingRecoverySafe(
         language: Language,
         normalizedLemmas: Set<String>,
-    ): Set<String> {
+    ): Set<String>? {
         return try {
             downloadedLemmasNeedingRecovery(language, normalizedLemmas)
         } catch (e: CancellationException) {
@@ -305,15 +335,16 @@ class LemmaRecovery internal constructor(
                 "Unable to check lemmas (${language.code})",
                 e,
             )
-            emptySet()
+            null
         }
     }
 
+    /** Returns null when the check itself failed, which is different from "nothing is missing". */
     private suspend fun downloadedSensesNeedingTranslationRecoverySafe(
         language: Language,
         senseIdsByLemma: Map<String, Set<String>>,
         translationTargets: List<Language>,
-    ): Set<String> {
+    ): Set<String>? {
         return try {
             downloadedSensesNeedingTranslationRecovery(language, senseIdsByLemma, translationTargets)
         } catch (e: CancellationException) {
@@ -324,10 +355,26 @@ class LemmaRecovery internal constructor(
                 "Unable to check translations (${language.code})",
                 e,
             )
-            emptySet()
+            null
         }
     }
 }
+
+/**
+ * Result of a [LemmaRecovery.recoverAllInstalled] pass.
+ *
+ * Per-lemma failures are counted rather than thrown — a broken word must never block a completed
+ * download — so the pass returns normally even when nothing could be fetched. [fullyRecovered] is
+ * false when any lemma group failed, when a pre-flight "is it already installed?" check failed (the
+ * pass then never learned what was missing, so [total] can be 0 while gaps remain), or when the pass
+ * could not run at all. Callers that gate work on recovery having happened (such as the
+ * pending-recovery marker) must keep it pending in that case.
+ */
+data class LemmaRecoveryOutcome(
+    val total: Int,
+    val failed: Int,
+    val fullyRecovered: Boolean,
+)
 
 data class LemmaRecoveryProgress(
     val currentLemma: String?,
@@ -357,6 +404,17 @@ private data class RecoverySummary(
     val total: Int,
     val completed: Int,
     val failed: Int,
+    val checksFailed: Boolean,
+)
+
+/**
+ * The lemma groups that still need fetching, plus whether any "is it already installed?" check
+ * failed while narrowing them down. [checksFailed] means the group list is incomplete by unknown
+ * amount, not that everything is present.
+ */
+private data class RecoveryTargets(
+    val groups: Map<LemmaGroupKey, List<RecoverableSense>>,
+    val checksFailed: Boolean,
 )
 
 private const val TAG = "LemmaRecovery"

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/data/remote/LemmaRecoveryController.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/data/remote/LemmaRecoveryController.kt
@@ -1,5 +1,7 @@
 package com.slovy.slovymovyapp.data.remote
 
+import com.slovy.slovymovyapp.data.settings.SettingsRepository
+import com.slovy.slovymovyapp.logging.AppLogger
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -16,23 +18,32 @@ import kotlinx.coroutines.sync.withLock
 class LemmaRecoveryController private constructor(
     private val recovery: LemmaRecovery,
     private val acquireKeepAlive: () -> ProcessKeepAlive,
+    private val isRecoveryPending: suspend () -> Boolean,
+    private val clearRecoveryPending: suspend () -> Unit,
     private val scope: CoroutineScope,
 ) {
     constructor(
         recovery: LemmaRecovery,
         platform: PlatformDbSupport,
+        settingsRepository: SettingsRepository,
     ) : this(
         recovery = recovery,
         acquireKeepAlive = { platform.acquireProcessKeepAlive() },
+        isRecoveryPending = { settingsRepository.isPendingLemmaRecovery() },
+        clearRecoveryPending = { settingsRepository.clearPendingLemmaRecovery() },
         scope = CoroutineScope(SupervisorJob() + Dispatchers.Default),
     )
 
     internal constructor(
         recovery: LemmaRecovery,
         acquireKeepAlive: () -> ProcessKeepAlive,
+        isRecoveryPending: suspend () -> Boolean,
+        clearRecoveryPending: suspend () -> Unit,
     ) : this(
         recovery = recovery,
         acquireKeepAlive = acquireKeepAlive,
+        isRecoveryPending = isRecoveryPending,
+        clearRecoveryPending = clearRecoveryPending,
         scope = CoroutineScope(SupervisorJob() + Dispatchers.Default),
     )
 
@@ -43,7 +54,12 @@ class LemmaRecoveryController private constructor(
     private val _progress = MutableStateFlow<LemmaRecoveryProgress?>(null)
     val progress: StateFlow<LemmaRecoveryProgress?> = _progress.asStateFlow()
 
-    /** Starts a recovery run if none is in flight; otherwise returns the existing Job. */
+    /**
+     * Starts a recovery run if none is in flight; otherwise returns the existing run.
+     *
+     * The run owns the pending-recovery marker: whoever sets it only has to ask for a pass, and
+     * the marker is retired here once a pass that knew about it recovered everything.
+     */
     suspend fun ensureStarted(): Job = mutex.withLock {
         if (isClosed) throw CancellationException("Lemma recovery controller is closed")
         currentJob?.takeIf { it.isActive }?.let { return@withLock it }
@@ -51,8 +67,17 @@ class LemmaRecoveryController private constructor(
             var handle: ProcessKeepAlive? = null
             try {
                 handle = acquireKeepAlive()
-                recovery.recoverAllInstalled { progress ->
+                // Read before the pass, not after: a run already in flight when the marker was set
+                // built its groups from the previous translation targets, so its clean result says
+                // nothing about the language that was just added and must not retire the marker.
+                val wasPending = wasRecoveryPending()
+                val outcome = recovery.recoverAllInstalled { progress ->
                     _progress.value = progress
+                }
+                // Per-lemma failures are counted rather than thrown, so an offline run finishes
+                // normally with nothing fetched; only a complete pass may retire the marker.
+                if (wasPending && outcome.fullyRecovered) {
+                    clearPendingMarker()
                 }
             } finally {
                 _progress.value = null
@@ -63,9 +88,34 @@ class LemmaRecoveryController private constructor(
         job
     }
 
+    /** A marker that cannot be read is treated as not set: never retire what was not confirmed. */
+    private suspend fun wasRecoveryPending(): Boolean {
+        return try {
+            isRecoveryPending()
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            AppLogger.warn(TAG, "Unable to read the pending recovery marker", e)
+            false
+        }
+    }
+
+    /** Failing to clear leaves the marker set, which costs one extra pass instead of losing data. */
+    private suspend fun clearPendingMarker() {
+        try {
+            clearRecoveryPending()
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            AppLogger.warn(TAG, "Unable to clear the pending recovery marker", e)
+        }
+    }
+
     fun close() {
         isClosed = true
         scope.cancel()
         _progress.value = null
     }
 }
+
+private const val TAG = "LemmaRecoveryController"

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/DownloadScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/DownloadScreen.kt
@@ -75,6 +75,7 @@ class DownloadViewModel(
 
     private var terminalHandled = false
     private var failedDuringLoadItems = false
+    private var hadNothingToDownload = false
     private var downloadStartedAtMs: Long = 0L
 
     // Held for the lifetime of one download attempt — from beginDownload() until the terminal
@@ -99,6 +100,7 @@ class DownloadViewModel(
             try {
                 val items = loadItems!!.invoke()
                 if (items.isEmpty()) {
+                    hadNothingToDownload = true
                     startDownload()
                     return@launch
                 }
@@ -185,9 +187,13 @@ class DownloadViewModel(
                             try {
                                 state = DownloadUiState.Finalizing()
                                 finalize(::updateRecoveryProgress, ::updateWordListsSyncing)
-                                for (i in 3 downTo 1) {
-                                    state = DownloadUiState.Done(countdown = i)
-                                    delay(1_000.milliseconds)
+                                // Nothing was downloaded (this run only existed to finalize, e.g.
+                                // a pending lemma recovery), so there is no result to show off.
+                                if (!hadNothingToDownload) {
+                                    for (i in 3 downTo 1) {
+                                        state = DownloadUiState.Done(countdown = i)
+                                        delay(1_000.milliseconds)
+                                    }
                                 }
                                 onSuccess()
                             } catch (e: CancellationException) {

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/SettingsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/SettingsScreen.kt
@@ -84,6 +84,10 @@ data class SettingsUiState(
     // Delete confirmation
     val deleteConfirmation: DeleteConfirmationState? = null,
 
+    // Shown after a translation language is added: every saved word has to be fetched again,
+    // which is slow and invisible in the background, so the next startup does it with progress.
+    val restartForRecoveryVisible: Boolean = false,
+
     // Data export
     val isAppDataExportSupported: Boolean = false,
     val isExportingAppData: Boolean = false,
@@ -401,6 +405,13 @@ class SettingsViewModel(
                 onDictionaryDataChanged(false)
                 loadLearningLanguages()
                 if (language !in previous) {
+                    // Downloading the translation DB only covers senses that live in the
+                    // downloaded dictionary. Every word already fetched into the local DBs has to
+                    // be fetched again for the new language, which is far too slow to run
+                    // unannounced in the background, so mark it pending and ask for a restart:
+                    // startup runs the same pass with visible progress.
+                    settingsRepository.setPendingLemmaRecovery()
+                    state = state.copy(restartForRecoveryVisible = true)
                     downloadMissingTranslationsForInstalledLearningLanguages(current)
                 }
             } catch (e: CancellationException) {
@@ -435,6 +446,10 @@ class SettingsViewModel(
 
     fun dismissDeleteConfirmation() {
         state = state.copy(deleteConfirmation = null)
+    }
+
+    fun dismissRestartForRecovery() {
+        state = state.copy(restartForRecoveryVisible = false)
     }
 
     fun confirmDelete() {
@@ -538,9 +553,12 @@ class SettingsViewModel(
             },
             onTerminal = { keepAlive.release() }
         ) {
-            onDictionaryDataChanged(true)
+            onDictionaryDataChanged(false)
             reloadSettings()
+            // Recovery waits for the translation DBs this kicks off: it reads a missing
+            // translation file as "every saved sense needs fetching".
             downloadMissingTranslationsForLearningLanguage(language)
+            recoverLemmasIfTranslationDataComplete()
         }
     }
 
@@ -641,6 +659,55 @@ class SettingsViewModel(
         ) {
             onDictionaryDataChanged(false)
             loadLearningLanguages()
+            recoverLemmasIfTranslationDataComplete()
+        }
+    }
+
+    /**
+     * Starts lemma recovery after a download, but only once every downloadable translation DB for
+     * the installed learning languages is actually installed.
+     *
+     * Recovery treats a missing translation file as "every saved sense needs this target", so
+     * running it while a translation DB is still downloading would re-fetch the user's whole
+     * saved-word set from the server. Each download's terminal handler calls this again, so the
+     * pass starts as soon as the last one lands.
+     *
+     * A pending marker means the user was already asked to restart for a full re-fetch. That pass
+     * belongs to startup, where it has visible progress, so it is not duplicated here.
+     */
+    private suspend fun recoverLemmasIfTranslationDataComplete() {
+        if (isPendingRecoveryOrUnknown()) return
+
+        val translationLanguages = try {
+            loadTranslationLanguages().toList()
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            AppLogger.warn(TAG, "Unable to check translation data before lemma recovery", e)
+            return
+        }
+        val installedLearningLanguages = dataDbManager.listDownloadedDatabases()
+            .filterIsInstance<DatabaseFileInfo.Dictionary>()
+            .map { it.language }
+
+        val allInstalled = installedLearningLanguages.all { language ->
+            loadDownloadableTranslationTargets(language, translationLanguages)
+                .all { target -> dataDbManager.hasTranslation(language, target) }
+        }
+        if (allInstalled) {
+            onDictionaryDataChanged(true)
+        }
+    }
+
+    /** Unreadable settings count as pending: the startup pass is the safe place for the work. */
+    private suspend fun isPendingRecoveryOrUnknown(): Boolean {
+        return try {
+            settingsRepository.isPendingLemmaRecovery()
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            AppLogger.warn(TAG, "Unable to read the pending recovery marker", e)
+            true
         }
     }
 
@@ -1111,6 +1178,7 @@ fun SettingsScreen(
         onDismissError = { viewModel.dismissError() },
         onConfirmDelete = { viewModel.confirmDelete() },
         onDismissDeleteConfirmation = { viewModel.dismissDeleteConfirmation() },
+        onDismissRestartForRecovery = { viewModel.dismissRestartForRecovery() },
         onAcknowledgements = { viewModel.openAcknowledgements() },
         onDismissAcknowledgements = { viewModel.dismissAcknowledgements() },
         onSendFeedback = { viewModel.openFeedbackDialog() },
@@ -1149,6 +1217,7 @@ fun SettingsScreenContent(
     onDismissError: () -> Unit = {},
     onConfirmDelete: () -> Unit = {},
     onDismissDeleteConfirmation: () -> Unit = {},
+    onDismissRestartForRecovery: () -> Unit = {},
     onAcknowledgements: () -> Unit = {},
     onDismissAcknowledgements: () -> Unit = {},
     onSendFeedback: () -> Unit = {},
@@ -1415,6 +1484,19 @@ fun SettingsScreenContent(
                 warning = confirmation.warning?.resolve(),
                 onConfirm = onConfirmDelete,
                 onDismiss = onDismissDeleteConfirmation
+            )
+        }
+
+        if (state.restartForRecoveryVisible) {
+            AlertDialog(
+                onDismissRequest = onDismissRestartForRecovery,
+                title = { Text(stringResource(Res.string.settings_translation_added_restart_title)) },
+                text = { Text(stringResource(Res.string.settings_translation_added_restart_message)) },
+                confirmButton = {
+                    TextButton(onClick = onDismissRestartForRecovery) {
+                        Text(stringResource(Res.string.settings_translation_added_restart_confirm))
+                    }
+                }
             )
         }
 

--- a/composeApp/src/commonTest/kotlin/com/slovy/slovymovyapp/data/remote/LemmaRecoveryControllerTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/slovy/slovymovyapp/data/remote/LemmaRecoveryControllerTest.kt
@@ -13,6 +13,7 @@ import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeout
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 import kotlin.time.Duration.Companion.seconds
 
@@ -25,7 +26,7 @@ class LemmaRecoveryControllerTest : BaseTest() {
         val releaseFetch = CompletableDeferred<Unit>()
         var recoveryRuns = 0
         val keepAlive = CountingKeepAliveFactory()
-        val controller = LemmaRecoveryController(
+        val controller = controller(
             recovery = recovery(
                 onItemsLoaded = { recoveryRuns++ },
                 onFetch = {
@@ -33,7 +34,7 @@ class LemmaRecoveryControllerTest : BaseTest() {
                     releaseFetch.await()
                 },
             ),
-            acquireKeepAlive = keepAlive::acquire,
+            keepAlive = keepAlive,
         )
 
         val firstJob = controller.ensureStarted()
@@ -52,9 +53,9 @@ class LemmaRecoveryControllerTest : BaseTest() {
     fun ensureStarted_starts_new_job_after_previous_completes() = runBlocking {
         var recoveryRuns = 0
         val keepAlive = CountingKeepAliveFactory()
-        val controller = LemmaRecoveryController(
+        val controller = controller(
             recovery = recovery(onItemsLoaded = { recoveryRuns++ }),
-            acquireKeepAlive = keepAlive::acquire,
+            keepAlive = keepAlive,
         )
 
         val firstJob = controller.ensureStarted()
@@ -73,14 +74,14 @@ class LemmaRecoveryControllerTest : BaseTest() {
         val started = CompletableDeferred<Unit>()
         val releaseFetch = CompletableDeferred<Unit>()
         val keepAlive = CountingKeepAliveFactory()
-        val controller = LemmaRecoveryController(
+        val controller = controller(
             recovery = recovery(
                 onFetch = {
                     started.complete(Unit)
                     releaseFetch.await()
                 },
             ),
-            acquireKeepAlive = keepAlive::acquire,
+            keepAlive = keepAlive,
         )
         val callerScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
         val controllerJobDeferred = CompletableDeferred<kotlinx.coroutines.Job>()
@@ -106,14 +107,14 @@ class LemmaRecoveryControllerTest : BaseTest() {
         val started = CompletableDeferred<Unit>()
         val releaseFetch = CompletableDeferred<Unit>()
         val keepAlive = CountingKeepAliveFactory()
-        val controller = LemmaRecoveryController(
+        val controller = controller(
             recovery = recovery(
                 onFetch = {
                     started.complete(Unit)
                     releaseFetch.await()
                 },
             ),
-            acquireKeepAlive = keepAlive::acquire,
+            keepAlive = keepAlive,
         )
 
         val controllerJob = controller.ensureStarted()
@@ -124,6 +125,77 @@ class LemmaRecoveryControllerTest : BaseTest() {
         assertTrue(controllerJob.isCancelled, "Closing the controller should cancel in-flight recovery")
         assertEquals(1, keepAlive.acquired)
         assertEquals(1, keepAlive.released)
+    }
+
+    @Test
+    fun pending_marker_is_cleared_when_the_pass_recovers_everything() = runBlocking {
+        val marker = FakePendingMarker(pending = true)
+        val controller = controller(
+            recovery = recovery(),
+            keepAlive = CountingKeepAliveFactory(),
+            marker = marker,
+        )
+
+        withTimeout(1.seconds.inWholeMilliseconds) { controller.ensureStarted().join() }
+
+        assertEquals(1, marker.cleared, "A complete pass must retire the marker it ran for")
+        assertFalse(marker.pending)
+    }
+
+    @Test
+    fun pending_marker_survives_a_pass_that_started_before_it_was_set() = runBlocking {
+        val started = CompletableDeferred<Unit>()
+        val releaseFetch = CompletableDeferred<Unit>()
+        val marker = FakePendingMarker(pending = false)
+        val controller = controller(
+            recovery = recovery(
+                onFetch = {
+                    started.complete(Unit)
+                    releaseFetch.await()
+                },
+            ),
+            keepAlive = CountingKeepAliveFactory(),
+            marker = marker,
+        )
+
+        val job = controller.ensureStarted()
+        withTimeout(1.seconds.inWholeMilliseconds) { started.await() }
+        // The user adds a translation language while the pass is already grouping lemmas for the
+        // previous targets, so this pass cannot have covered the new language.
+        marker.pending = true
+        releaseFetch.complete(Unit)
+        withTimeout(1.seconds.inWholeMilliseconds) { job.join() }
+
+        assertEquals(0, marker.cleared, "A pass that predates the marker must leave it for the next run")
+        assertTrue(marker.pending)
+    }
+
+    @Test
+    fun pending_marker_survives_a_failed_lemma() = runBlocking {
+        val marker = FakePendingMarker(pending = true)
+        val controller = controller(
+            recovery = recovery(onFetch = { throw RuntimeException("offline") }),
+            keepAlive = CountingKeepAliveFactory(),
+            marker = marker,
+        )
+
+        withTimeout(1.seconds.inWholeMilliseconds) { controller.ensureStarted().join() }
+
+        assertEquals(0, marker.cleared, "An incomplete pass must keep the marker for the next start")
+        assertTrue(marker.pending)
+    }
+
+    private fun controller(
+        recovery: LemmaRecovery,
+        keepAlive: CountingKeepAliveFactory,
+        marker: FakePendingMarker = FakePendingMarker(),
+    ): LemmaRecoveryController {
+        return LemmaRecoveryController(
+            recovery = recovery,
+            acquireKeepAlive = keepAlive::acquire,
+            isRecoveryPending = { marker.pending },
+            clearRecoveryPending = { marker.clear() },
+        )
     }
 
     private fun recovery(
@@ -149,6 +221,17 @@ class LemmaRecoveryControllerTest : BaseTest() {
         override val lemma: String,
         override val senseId: String,
     ) : RecoverableSense
+
+    /** Stands in for the `PENDING_LEMMA_RECOVERY` setting the controller reads and retires. */
+    private class FakePendingMarker(var pending: Boolean = false) {
+        var cleared = 0
+            private set
+
+        fun clear() {
+            pending = false
+            cleared++
+        }
+    }
 
     private class CountingKeepAliveFactory {
         var acquired = 0

--- a/composeApp/src/commonTest/kotlin/com/slovy/slovymovyapp/data/remote/LemmaRecoveryTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/slovy/slovymovyapp/data/remote/LemmaRecoveryTest.kt
@@ -10,6 +10,7 @@ import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.withTimeout
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 import kotlin.time.Duration.Companion.seconds
@@ -129,7 +130,7 @@ class LemmaRecoveryTest : BaseTest() {
             failLemma = "alpha",
         )
 
-        recovery.recoverAllInstalled()
+        val outcome = recovery.recoverAllInstalled()
 
         assertEquals(
             listOf(LemmaCheck(Language.ENGLISH, setOf("alpha", "beta"))),
@@ -138,6 +139,52 @@ class LemmaRecoveryTest : BaseTest() {
         assertEquals(
             listOf(FetchCall(Language.ENGLISH, "beta", listOf(Language.RUSSIAN))),
             fetches,
+        )
+        // Failures are counted rather than thrown, so the outcome is the only signal callers that
+        // must retry later — the pending-recovery marker — can act on.
+        assertEquals(1, outcome.failed, "The failed lemma must be reported in the outcome")
+        assertFalse(
+            outcome.fullyRecovered,
+            "A pass with a failed lemma must not report itself as fully recovered",
+        )
+    }
+
+    @Test
+    fun recoverAllInstalled_reports_fully_recovered_when_every_lemma_succeeds() = runBlocking {
+        val recovery = recovery(
+            items = listOf(
+                TestRecoverableSense(Language.ENGLISH, "alpha", sense1),
+                TestRecoverableSense(Language.ENGLISH, "beta", sense2),
+            ),
+            installedDictionaries = setOf(Language.ENGLISH),
+            lemmasNeedingRecovery = setOf("alpha", "beta"),
+            fetches = mutableListOf(),
+        )
+
+        val outcome = recovery.recoverAllInstalled()
+
+        assertEquals(0, outcome.failed)
+        assertEquals(2, outcome.total)
+        assertTrue(outcome.fullyRecovered, "A clean pass must report itself as fully recovered")
+    }
+
+    @Test
+    fun recoverAllInstalled_reports_not_fully_recovered_when_items_cannot_be_loaded() = runBlocking {
+        val recovery = LemmaRecovery(
+            itemsProvider = { throw RuntimeException("db unavailable") },
+            hasDownloadedDictionary = { true },
+            downloadedLemmasNeedingRecovery = { _, lemmas -> lemmas },
+            downloadedSensesNeedingTranslationRecovery = { _, _, _ -> emptySet() },
+            translationTargetsProvider = { listOf(Language.RUSSIAN) },
+            fetchLemma = { _, _, _ -> },
+            resolveSenses = { _, _, _ -> emptyMap() },
+        )
+
+        val outcome = recovery.recoverAllInstalled()
+
+        assertFalse(
+            outcome.fullyRecovered,
+            "A pass that could not run at all must not retire the caller's pending marker",
         )
     }
 
@@ -241,12 +288,39 @@ class LemmaRecoveryTest : BaseTest() {
             fetches = fetches,
         )
 
-        recovery.recoverAllInstalled()
+        val outcome = recovery.recoverAllInstalled()
 
-        // Dictionary recovery still fetches "alpha"; translation failure is swallowed.
+        // Dictionary recovery still fetches "alpha"; the translation failure does not abort the pass.
         assertEquals(
             listOf(FetchCall(Language.ENGLISH, "alpha", listOf(Language.RUSSIAN))),
             fetches,
+        )
+        assertFalse(
+            outcome.fullyRecovered,
+            "A swallowed translation check leaves unknown gaps, so the pass is not fully recovered",
+        )
+    }
+
+    @Test
+    fun recoverAllInstalled_reports_not_fully_recovered_when_lemma_check_throws() = runBlocking {
+        val fetches = mutableListOf<FetchCall>()
+        val recovery = recovery(
+            items = listOf(TestRecoverableSense(Language.ENGLISH, "alpha", sense1)),
+            installedDictionaries = setOf(Language.ENGLISH),
+            lemmasNeedingRecovery = emptySet(),
+            lemmaCheckThrows = true,
+            fetches = fetches,
+        )
+
+        val outcome = recovery.recoverAllInstalled()
+
+        // Nothing was fetched because nothing could be checked - that must not read as success.
+        assertEquals(emptyList(), fetches)
+        assertEquals(0, outcome.total)
+        assertEquals(0, outcome.failed)
+        assertFalse(
+            outcome.fullyRecovered,
+            "A failed lemma check must keep the caller's pending marker so the next start retries",
         )
     }
 
@@ -487,6 +561,7 @@ class LemmaRecoveryTest : BaseTest() {
         lemmaChecks: MutableList<LemmaCheck> = mutableListOf(),
         translationChecks: MutableList<TranslationCheck> = mutableListOf(),
         translationsMissingFor: Set<String> = emptySet(),
+        lemmaCheckThrows: Boolean = false,
         translationCheckThrows: Boolean = false,
         failLemma: String? = null,
     ): LemmaRecovery {
@@ -495,6 +570,7 @@ class LemmaRecoveryTest : BaseTest() {
             hasDownloadedDictionary = { language -> language in installedDictionaries },
             downloadedLemmasNeedingRecovery = { language, lemmas ->
                 lemmaChecks += LemmaCheck(language, lemmas)
+                if (lemmaCheckThrows) throw RuntimeException("Lemma check failed")
                 lemmas.intersect(lemmasNeedingRecovery)
             },
             downloadedSensesNeedingTranslationRecovery = { language, senseIdsByLemma, targets ->

--- a/composeApp/src/commonTest/kotlin/com/slovy/slovymovyapp/db/SettingsRepositoryTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/slovy/slovymovyapp/db/SettingsRepositoryTest.kt
@@ -32,4 +32,27 @@ open class SettingsRepositoryTest : BaseTest() {
         val foundAfterDelete = repo.getById(Setting.Name.TEST_PROPERTY)
         assertEquals(null, foundAfterDelete)
     }
+
+    /**
+     * The pending-recovery marker is written in settings and read back at startup to decide
+     * whether to route through the download/finalize flow, so the two sides must agree on the
+     * stored shape — an unset marker in particular must read as "not pending".
+     */
+    @Test
+    fun pendingLemmaRecovery_roundTrips_andDefaultsToFalse() = runBlocking {
+        val repo = SettingsRepository(testAppDatabaseHolder().database)
+        repo.clearPendingLemmaRecovery()
+
+        assertEquals(false, repo.isPendingLemmaRecovery(), "Unset marker must not request recovery")
+
+        repo.setPendingLemmaRecovery()
+        assertEquals(true, repo.isPendingLemmaRecovery(), "Marker must survive a write/read round trip")
+
+        repo.clearPendingLemmaRecovery()
+        assertEquals(
+            false,
+            repo.isPendingLemmaRecovery(),
+            "Clearing after a recovery run must stop the next startup from routing through it",
+        )
+    }
 }

--- a/shared/src/commonMain/kotlin/com/slovy/slovymovyapp/data/settings/Setting.kt
+++ b/shared/src/commonMain/kotlin/com/slovy/slovymovyapp/data/settings/Setting.kt
@@ -22,6 +22,14 @@ data class Setting(
         FAVORITES_LANGUAGE,
         STATS_LANGUAGE,
         DEVELOPER_MODE,
-        LEGACY_VOICE_MIGRATION_DONE
+        LEGACY_VOICE_MIGRATION_DONE,
+
+        /**
+         * Set when a translation language is added, cleared once lemma recovery has run. Saved
+         * words already in the local DBs have no data for the new language, and only a recovery
+         * pass re-fetches them; the next startup routes through the download/finalize flow, which
+         * runs that pass with progress.
+         */
+        PENDING_LEMMA_RECOVERY
     }
 }

--- a/shared/src/commonMain/kotlin/com/slovy/slovymovyapp/data/settings/SettingsRepository.kt
+++ b/shared/src/commonMain/kotlin/com/slovy/slovymovyapp/data/settings/SettingsRepository.kt
@@ -61,4 +61,15 @@ class SettingsRepository(private val db: AppDatabase) {
     suspend fun setLegacyVoiceMigrationDone() {
         insert(Setting(Setting.Name.LEGACY_VOICE_MIGRATION_DONE, JsonPrimitive(true)))
     }
+
+    suspend fun isPendingLemmaRecovery(): Boolean =
+        getById(Setting.Name.PENDING_LEMMA_RECOVERY)?.value?.jsonPrimitive?.booleanOrNull ?: false
+
+    suspend fun setPendingLemmaRecovery() {
+        insert(Setting(Setting.Name.PENDING_LEMMA_RECOVERY, JsonPrimitive(true)))
+    }
+
+    suspend fun clearPendingLemmaRecovery() {
+        deleteById(Setting.Name.PENDING_LEMMA_RECOVERY)
+    }
 }


### PR DESCRIPTION
Part of #744 — "Make sure already saved words will be translated".

## The problem

Adding a translation language (ZH, or any other) left already saved words untranslated on the favorites screen.

The reload path was already correct: `toggleTranslationLanguage` calls `onDictionaryDataChanged(false)`, which clears the sense cache and drops the cached favorite details, and `FavoritesViewModel.loadSense` passes `translationTargets = null` so `getSenses` resolves the new targets straight from settings. What was missing is the **repair** — if the new language is not in the downloaded or local translation DBs, nothing ever fetched it and the row silently rendered without it.

`LemmaRecoveryController` does not cover this either: the settings path passes `recoverFavorites = false`, and the whole-library pass skips any language without a downloaded dictionary. The study path is unaffected — `SessionService` already fetches through `WordFetchManager`.

## The fix

Give `FavoritesViewModel` the lazy repair `ListDetailViewModel` already performs. Senses that resolve locally but lack a requested target language are handed to `LemmaRecovery.recoverSenses`, and the row swaps in the fetched content when it arrives. `Favorite` already implements `RecoverableSense`, and `SenseCardData.translationLoading` already renders a placeholder, so there is no new user-facing copy and no localization change.

Repair is triggered from two places, matching list detail: per row in `loadSense`, and over cache-seeded rows in the pass that runs after each state application (those rows never reach `loadSense`, since the prefetcher skips items that already have a sense).

A failed or gap-leaving repair keeps the row's existing content and logs rather than surfacing an error — `error` stays reserved for `toFavoriteSenseLoadError` outcomes — and marks the lemma so sibling senses skip the pointless refetch.

## The one thing that could not be copied verbatim

`ListDetailViewModel` is scoped to its navigation entry, so it re-reads the targets in `load()` and discards its attempted/failed-lemma sets on back-navigation. `FavoritesViewModel` is app-scoped and outlives every settings change, so a verbatim port would skip every already-attempted sense forever — the original bug, surviving the fix.

The targets are therefore re-resolved on each state application and the bookkeeping is reset whenever they change. `syncTranslationTargetsAndRepairGaps` does this as a single coroutine on the ViewModel scope, so the targets are current before `prefetchHead` launches `loadSense`, and all bookkeeping mutation stays on one thread.

## Tests

New `FavoritesTranslationRepairTest` (5 tests), modeled on `ListDetailViewModelTest`'s real-dictionary fixture with a faked server fetch:

- a missing translation is fetched and the row repaired;
- a locally present translation triggers no fetch;
- a failed repair keeps the local content, surfaces no error, and clears `translationLoading`;
- a gap-leaving repair is not retried on every resume/keystroke recompute;
- **`addingTranslationLanguage_reAttemptsPreviouslyFailedRepair`** — the regression test for the app-scoped lifetime above. Verified it earns its place: with the two `clear()` calls removed it fails with exactly the reported bug (one fetch for the old target set, none for the new one).

`FavoritesViewModelTest` gets a no-op `LemmaRecovery` that fails on any unexpected fetch.

## Verification

`:composeApp:testAndroidHostTest` and `:composeApp:desktopTest` each run 470 tests. The same 5 `DictionaryClientTest` cases fail on both with `Server error 503: GitHub token not configured` — the documented credential-dependent tests; no `ACCESS_TO_GH_TOKEN` or `.github_key` is available locally, so those are unverified here and left to CI. No other failures.

## Not included

Two deliberate omissions, both separate behavior changes:

- switching `toggleTranslationLanguage` to `onDictionaryDataChanged(true)` for an eager whole-library pass (heavy, and still blind to languages without a downloaded dictionary);
- giving favorites list detail's unconditional `missing`-sense fetch path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
