### PR TITLE
Rethrow CancellationException before mapping coroutine errors

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/App.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/App.kt
@@ -599,6 +599,8 @@ fun App(
                                     navController.navigate(AppDestination.SetupLanguages) {
                                         popUpTo<AppDestination.Welcome> { inclusive = true }
                                     }
+                                } catch (e: CancellationException) {
+                                    throw e
                                 } catch (_: Exception) {
                                     viewModel.onError()
                                 }

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/DeveloperScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/DeveloperScreen.kt
@@ -297,6 +297,8 @@ class DeveloperViewModel(
                 AppLogger.info(TAG, "Action finished: $result", null)
                 message = result
                 duration = SnackbarDuration.Long
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 val error = "$actionName failed: ${describe(e)}"
                 AppLogger.warn(TAG, error, e)
@@ -374,6 +376,8 @@ class DeveloperViewModel(
                     isStatsLoading = false,
                     statsErrorLabel = null,
                 )
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 AppLogger.warn(TAG, "Card schedule stats failed", e)
                 state = state.copy(

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/DeveloperTerminalOverlay.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/DeveloperTerminalOverlay.kt
@@ -52,6 +52,7 @@ import androidx.compose.ui.unit.dp
 import com.slovy.slovymovyapp.logging.AppLogger
 import com.slovy.slovymovyapp.ui.theme.AppElevation
 import com.slovy.slovymovyapp.ui.theme.AppSpacing
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import org.jetbrains.compose.resources.stringResource
@@ -150,6 +151,8 @@ fun DeveloperTerminalOverlay(
                         try {
                             onShiftLearningTime(option.duration)
                             AppLogger.info(TAG, "Action finished: Shifted learning time ${option.label}", null)
+                        } catch (e: CancellationException) {
+                            throw e
                         } catch (e: Exception) {
                             AppLogger.warn(TAG, "Shift ${option.label} failed: ${e.toLogLabel()}", e)
                         } finally {

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/FavoritesScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/FavoritesScreen.kt
@@ -709,6 +709,8 @@ class FavoritesViewModel(
                     error = error
                 )
             }
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Throwable) {
             updateSense(item.senseId) {
                 it.copy(

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/SettingsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/SettingsScreen.kt
@@ -472,6 +472,8 @@ class SettingsViewModel(
 
                 reloadSettings()
                 showSnackbar(toastMessage)
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 state = state.copy(
                     errorMessage = UiText.Resource(
@@ -501,6 +503,8 @@ class SettingsViewModel(
                     onDictionaryDataChanged(false)
                     loadLearningLanguages()
                     showSnackbar(toastMsg)
+                } catch (e: CancellationException) {
+                    throw e
                 } catch (e: Exception) {
                     state = state.copy(
                         errorMessage = UiText.Resource(
@@ -710,6 +714,8 @@ class SettingsViewModel(
             try {
                 refreshVoices(language)
                 updateLanguageState(language) { it.copy(isLoadingVoices = false) }
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 AppLogger.warn(TAG, "Unable to load voices for ${language.language.code}", e)
                 updateLanguageState(language) { it.copy(isLoadingVoices = false) }
@@ -824,6 +830,8 @@ class SettingsViewModel(
 
                 voiceFilterHelper.setEnabledVoices(language, newEnabled)
                 updateLanguageState(language) { it.copy(enabledVoiceIds = newEnabled) }
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 state = state.copy(
                     errorMessage = UiText.Resource(
@@ -949,6 +957,8 @@ class SettingsViewModel(
                     feedbackError = null,
                     feedbackDiscussionUrl = response.discussionUrl
                 )
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 state = state.copy(
                     feedbackSubmitting = false,

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/word/WordDetailsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/word/WordDetailsScreen.kt
@@ -677,6 +677,8 @@ class WordDetailViewModel(
                         feedbackIssueUrl = feedbackResponse.issueUrl
                     )
                 }
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 val latest = state as? WordDetailUiState.Content ?: return@launch
                 state = latest.copy(


### PR DESCRIPTION
## Contributor terms

- [ ] I have read and agree to the contributor terms in `CONTRIBUTING.md`.
- [ ] I have the right to submit these changes under those terms.

## Summary

Ten broad `catch` blocks inside coroutines mapped every failure to a user-facing error state without first rethrowing `CancellationException`. When the enclosing scope was cancelled mid-suspend — leaving a screen, switching language, a configuration change — the cancellation was classified as a network/IO failure and a false error was written into `UiState` instead of the coroutine unwinding.

This restores the convention already documented in `CLAUDE.md` ("In coroutine catch blocks, rethrow `CancellationException` before retrying, logging, or mapping errors") and already followed by neighbouring handlers in the same files — `SearchScreen.submitListSuggestion` and `SettingsScreen.exportAppData` were already correct, so the two conventions were sitting side by side.

| File | Call site |
| --- | --- |
| `SettingsScreen.kt` | `deleteDictionary`, `deleteTranslation`, `loadVoicesForLanguage`, `toggleVoiceEnabled`, `submitFeedback` |
| `DeveloperScreen.kt` | `runAction`, `refreshSchedulingStats` |
| `DeveloperTerminalOverlay.kt` | `onShift` |
| `WordDetailsScreen.kt` | `submitFeedback` |
| `FavoritesScreen.kt` | `loadSense` |
| `App.kt` | welcome `onGetStarted` |

The change is purely additive — one `catch (e: CancellationException) { throw e }` clause ahead of each existing handler, plus one import. No behaviour changes for genuine failures.

### Selection criterion

A site was only changed when the guarded block contains at least one suspension point. Every broad `catch` in `composeApp/src/commonMain` was reviewed against that rule; 16 were deliberately left alone:

- **cleanup-then-rethrow** — `LocalDbManager.leaseLocalDictionary`/`leaseLocalTranslation`, `AppDataSnapshotter`, `AppDataArchiveWriter`. These already propagate everything, which is correct lease/temp-file handling.
- **no suspension point** — `DataDbManager.probeDownloadedDb`, `enforceQueryOnly`, `DictionaryRepository.installedDictionaries`, `RowAudioController.speak`, `SettingsScreen.testVoice`, `WordDetailsScreen.doPlayWord`, and the inner `catch` around `shareExport` (a non-`suspend` call whose outer handler already rethrows). Cancellation cannot surface in these blocks.

## Testing

- `./gradlew :composeApp:compileKotlinDesktop --rerun` — BUILD SUCCESSFUL
- `./gradlew :composeApp:desktopTest --tests "*FavoritesViewModelTest*" --tests "*ListDetailViewModelTest*" --tests "*StudySessionMapperTest*" --tests "*StudySessionCompleteResolverTest*"` — 68 tests, 0 failures

Android and iOS targets were not built here (no Android SDK in this environment); the change is in `commonMain` and platform-agnostic, so CI should cover those.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FCSWCybtaTofzpkNa5cSpW)_