### PR TITLE
Extract LanguageFilterDropdown from three screens

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/FavoritesScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/FavoritesScreen.kt
@@ -71,6 +71,7 @@ import com.slovy.slovymovyapp.speech.SpeechPlayer
 import com.slovy.slovymovyapp.speech.VoiceFilterHelper
 import com.slovy.slovymovyapp.ui.components.AppSearchBar
 import com.slovy.slovymovyapp.ui.components.EmptyState
+import com.slovy.slovymovyapp.ui.components.LanguageFilterDropdown
 import com.slovy.slovymovyapp.ui.icons.NoFavsImage
 import com.slovy.slovymovyapp.ui.icons.SearchOtter
 import com.slovy.slovymovyapp.ui.icons.SlovyIcons
@@ -913,64 +914,13 @@ fun FavoritesScreenContent(
                             )
 
                             if (state.showLanguagePicker) {
-                                val currentLanguage = state.selectedLanguage
-                                    ?: state.availableLanguages.firstOrNull()
-
-                                ExposedDropdownMenuBox(
+                                LanguageFilterDropdown(
+                                    languages = state.availableLanguages,
+                                    selectedLanguage = state.selectedLanguage,
                                     expanded = state.isLanguageDropdownExpanded,
-                                    onExpandedChange = onSetLanguageDropdownExpanded
-                                ) {
-                                    Surface(
-                                        modifier = Modifier
-                                            .menuAnchor(ExposedDropdownMenuAnchorType.PrimaryEditable)
-                                            .height(56.dp)
-                                            .widthIn(min = 56.dp),
-                                        shape = MaterialTheme.shapes.extraLarge,
-                                        tonalElevation = 1.dp,
-                                        shadowElevation = 1.dp,
-                                        color = MaterialTheme.colorScheme.surfaceContainerHighest
-                                    ) {
-                                        Row(
-                                            modifier = Modifier.padding(start = 16.dp, end = 8.dp),
-                                            verticalAlignment = Alignment.CenterVertically
-                                        ) {
-                                            Text(
-                                                text = currentLanguage?.flag ?: "",
-                                                style = MaterialTheme.typography.bodyLarge
-                                            )
-                                            ExposedDropdownMenuDefaults.TrailingIcon(
-                                                expanded = state.isLanguageDropdownExpanded
-                                            )
-                                        }
-                                    }
-                                    ExposedDropdownMenu(
-                                        expanded = state.isLanguageDropdownExpanded,
-                                        onDismissRequest = { onSetLanguageDropdownExpanded(false) },
-                                        modifier = Modifier.width(200.dp),
-                                        shape = MaterialTheme.shapes.small,
-                                        containerColor = MaterialTheme.colorScheme.surfaceContainerHigh,
-                                        shadowElevation = 2.dp
-                                    ) {
-                                        state.availableLanguages.forEach { language ->
-                                            DropdownMenuItem(
-                                                text = {
-                                                    Row(
-                                                        horizontalArrangement = Arrangement.spacedBy(8.dp),
-                                                        verticalAlignment = Alignment.CenterVertically
-                                                    ) {
-                                                        Text(language.flag)
-                                                        Text(language.selfName)
-                                                    }
-                                                },
-                                                onClick = {
-                                                    onLanguageSelected(language)
-                                                    onSetLanguageDropdownExpanded(false)
-                                                },
-                                                contentPadding = ExposedDropdownMenuDefaults.ItemContentPadding
-                                            )
-                                        }
-                                    }
-                                }
+                                    onExpandedChange = onSetLanguageDropdownExpanded,
+                                    onLanguageSelected = onLanguageSelected,
+                                )
                             }
                         }
                         Spacer(modifier = Modifier.height(4.dp))

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/SearchScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/SearchScreen.kt
@@ -22,7 +22,6 @@ import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material.icons.filled.Settings
 import androidx.compose.foundation.Image
 import androidx.compose.material3.*
-import androidx.compose.material3.ExposedDropdownMenuAnchorType.Companion.PrimaryEditable
 import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.runtime.*
 import androidx.compose.runtime.saveable.rememberSaveable
@@ -70,6 +69,7 @@ import kotlinx.serialization.json.jsonPrimitive
 import com.slovy.slovymovyapp.data.remote.PartOfSpeech
 import com.slovy.slovymovyapp.ui.components.AppSearchBar
 import com.slovy.slovymovyapp.ui.components.EmptyState
+import com.slovy.slovymovyapp.ui.components.LanguageFilterDropdown
 import com.slovy.slovymovyapp.ui.icons.NoDictionaryIcon
 import com.slovy.slovymovyapp.ui.icons.SearchOtter
 import com.slovy.slovymovyapp.ui.icons.SlovyIcons
@@ -597,64 +597,14 @@ fun SearchScreenContent(
                     )
 
                     // Language filter dropdown
-                    if (state.availableLanguages.isNotEmpty() && state.availableLanguages.size > 1) {
-                        val currentLanguage = state.selectedLanguage ?: state.availableLanguages.firstOrNull()
-
-                        ExposedDropdownMenuBox(
+                    if (state.availableLanguages.size > 1) {
+                        LanguageFilterDropdown(
+                            languages = state.availableLanguages,
+                            selectedLanguage = state.selectedLanguage,
                             expanded = state.isLanguageDropdownExpanded,
-                            onExpandedChange = onSetLanguageDropdownExpanded
-                        ) {
-                            Surface(
-                                modifier = Modifier
-                                    .menuAnchor(PrimaryEditable)
-                                    .height(56.dp)
-                                    .widthIn(min = 56.dp),
-                                shape = MaterialTheme.shapes.extraLarge,
-                                tonalElevation = 1.dp,
-                                shadowElevation = 1.dp,
-                                color = MaterialTheme.colorScheme.surfaceContainerHighest
-                            ) {
-                                Row(
-                                    modifier = Modifier.padding(start = 16.dp, end = 8.dp),
-                                    verticalAlignment = Alignment.CenterVertically
-                                ) {
-                                    Text(
-                                        text = currentLanguage?.flag ?: "",
-                                        style = MaterialTheme.typography.bodyLarge
-                                    )
-                                    ExposedDropdownMenuDefaults.TrailingIcon(
-                                        expanded = state.isLanguageDropdownExpanded
-                                    )
-                                }
-                            }
-                            ExposedDropdownMenu(
-                                expanded = state.isLanguageDropdownExpanded,
-                                onDismissRequest = { onSetLanguageDropdownExpanded(false) },
-                                modifier = Modifier.width(200.dp),
-                                shape = MaterialTheme.shapes.small,
-                                containerColor = MaterialTheme.colorScheme.surfaceContainerHigh,
-                                shadowElevation = 2.dp
-                            ) {
-                                state.availableLanguages.forEach { language ->
-                                    DropdownMenuItem(
-                                        text = {
-                                            Row(
-                                                horizontalArrangement = Arrangement.spacedBy(8.dp),
-                                                verticalAlignment = Alignment.CenterVertically
-                                            ) {
-                                                Text(language.flag)
-                                                Text(language.selfName)
-                                            }
-                                        },
-                                        onClick = {
-                                            onLanguageSelected(language)
-                                            onSetLanguageDropdownExpanded(false)
-                                        },
-                                        contentPadding = ExposedDropdownMenuDefaults.ItemContentPadding
-                                    )
-                                }
-                            }
-                        }
+                            onExpandedChange = onSetLanguageDropdownExpanded,
+                            onLanguageSelected = onLanguageSelected,
+                        )
                     }
                 }
 

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/StatsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/StatsScreen.kt
@@ -46,6 +46,7 @@ import com.slovy.slovymovyapp.data.settings.Setting
 import com.slovy.slovymovyapp.data.settings.SettingsRepository
 import com.slovy.slovymovyapp.i18n.NumberFormatter
 import com.slovy.slovymovyapp.i18n.ShortDuration
+import com.slovy.slovymovyapp.ui.components.LanguageFilterDropdown
 import com.slovy.slovymovyapp.ui.theme.serifFontFamily
 import com.slovy.slovymovyapp.ui.theme.uiItalic
 import kotlinx.coroutines.Dispatchers
@@ -321,7 +322,6 @@ fun StatsScreenContent(
     }
 }
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun StatsHeader(
     state: StatsUiState,
@@ -348,77 +348,13 @@ private fun StatsHeader(
             modifier = Modifier.weight(1f),
         )
         if (state.showLanguagePicker) {
-            StatsLanguageDropdown(
+            LanguageFilterDropdown(
                 languages = state.learningLanguages,
                 selectedLanguage = state.selectedLanguage,
                 expanded = state.languageDropdownExpanded,
                 onExpandedChange = onLanguageDropdownExpandedChange,
-                onSelectedLanguageChange = onSelectedLanguageChange,
+                onLanguageSelected = onSelectedLanguageChange,
             )
-        }
-    }
-}
-
-@OptIn(ExperimentalMaterial3Api::class)
-@Composable
-private fun StatsLanguageDropdown(
-    languages: List<Language>,
-    selectedLanguage: Language,
-    expanded: Boolean,
-    onExpandedChange: (Boolean) -> Unit,
-    onSelectedLanguageChange: (Language) -> Unit,
-) {
-    ExposedDropdownMenuBox(
-        expanded = expanded,
-        onExpandedChange = onExpandedChange,
-    ) {
-        Surface(
-            modifier = Modifier
-                .menuAnchor(ExposedDropdownMenuAnchorType.PrimaryEditable)
-                .height(56.dp)
-                .widthIn(min = 56.dp),
-            shape = MaterialTheme.shapes.extraLarge,
-            tonalElevation = 1.dp,
-            shadowElevation = 1.dp,
-            color = MaterialTheme.colorScheme.surfaceContainerHighest,
-        ) {
-            Row(
-                modifier = Modifier.padding(start = 16.dp, end = 8.dp),
-                verticalAlignment = Alignment.CenterVertically,
-            ) {
-                Text(
-                    text = selectedLanguage.flag,
-                    style = MaterialTheme.typography.bodyLarge,
-                )
-                ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded)
-            }
-        }
-        ExposedDropdownMenu(
-            expanded = expanded,
-            onDismissRequest = { onExpandedChange(false) },
-            modifier = Modifier.width(200.dp),
-            shape = MaterialTheme.shapes.small,
-            containerColor = MaterialTheme.colorScheme.surfaceContainerHigh,
-            shadowElevation = 2.dp,
-        ) {
-            languages.forEach { language ->
-                DropdownMenuItem(
-                    text = {
-                        Row(
-                            horizontalArrangement = Arrangement.spacedBy(8.dp),
-                            verticalAlignment = Alignment.CenterVertically,
-                        ) {
-                            Text(language.flag)
-                            Text(language.selfName)
-                        }
-                    },
-                    onClick = {
-                        onSelectedLanguageChange(language)
-                        onExpandedChange(false)
-                    },
-                    contentPadding = ExposedDropdownMenuDefaults.ItemContentPadding,
-                )
-            }
         }
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/components/LanguageFilterDropdown.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/components/LanguageFilterDropdown.kt
@@ -1,0 +1,156 @@
+package com.slovy.slovymovyapp.ui.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExposedDropdownMenuAnchorType
+import androidx.compose.material3.ExposedDropdownMenuBox
+import androidx.compose.material3.ExposedDropdownMenuDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewParameter
+import androidx.compose.ui.unit.dp
+import com.slovy.slovymovyapp.data.Language
+import com.slovy.slovymovyapp.ui.ThemePreviewProvider
+import com.slovy.slovymovyapp.ui.ThemedPreview
+import com.slovy.slovymovyapp.ui.theme.AppElevation
+import com.slovy.slovymovyapp.ui.theme.AppSpacing
+
+/** Matches the height of [AppSearchBar] so the two sit level when placed in the same row. */
+private val AnchorHeight = 56.dp
+
+/** Keeps the collapsed anchor square around the flag glyph. */
+private val AnchorMinWidth = 56.dp
+
+/** Wide enough for a flag plus the longest `Language.selfName`. */
+private val MenuWidth = 200.dp
+
+/**
+ * Compact language picker used to filter a screen by learning language.
+ *
+ * Renders as a square anchor showing the current language's flag, expanding to a menu of
+ * flag + self-name rows. Sized to sit next to [AppSearchBar] in a search row, and also used
+ * standalone in a screen header.
+ *
+ * The caller owns the expanded state so it can live in the screen's `UiState` and survive
+ * recomposition and configuration changes.
+ *
+ * @param languages Languages offered in the menu, in display order.
+ * @param selectedLanguage Language whose flag the anchor shows; when null the first entry of
+ *   [languages] is shown instead, so the anchor is never blank while a selection is resolving.
+ * @param expanded Whether the menu is open.
+ * @param onExpandedChange Called when the menu wants to open or close.
+ * @param onLanguageSelected Called with the chosen language; the menu closes itself afterwards.
+ * @param modifier Modifier applied to the dropdown container.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun LanguageFilterDropdown(
+    languages: List<Language>,
+    selectedLanguage: Language?,
+    expanded: Boolean,
+    onExpandedChange: (Boolean) -> Unit,
+    onLanguageSelected: (Language) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val currentLanguage = selectedLanguage ?: languages.firstOrNull()
+
+    ExposedDropdownMenuBox(
+        expanded = expanded,
+        onExpandedChange = onExpandedChange,
+        modifier = modifier,
+    ) {
+        Surface(
+            modifier = Modifier
+                .menuAnchor(ExposedDropdownMenuAnchorType.PrimaryEditable)
+                .height(AnchorHeight)
+                .widthIn(min = AnchorMinWidth),
+            shape = MaterialTheme.shapes.extraLarge,
+            tonalElevation = AppElevation.level1,
+            shadowElevation = AppElevation.level1,
+            color = MaterialTheme.colorScheme.surfaceContainerHighest,
+        ) {
+            Row(
+                modifier = Modifier.padding(start = AppSpacing.lg, end = AppSpacing.sm),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Text(
+                    text = currentLanguage?.flag ?: "",
+                    style = MaterialTheme.typography.bodyLarge,
+                )
+                ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded)
+            }
+        }
+        ExposedDropdownMenu(
+            expanded = expanded,
+            onDismissRequest = { onExpandedChange(false) },
+            modifier = Modifier.width(MenuWidth),
+            shape = MaterialTheme.shapes.small,
+            containerColor = MaterialTheme.colorScheme.surfaceContainerHigh,
+            shadowElevation = 2.dp,
+        ) {
+            languages.forEach { language ->
+                DropdownMenuItem(
+                    text = {
+                        Row(
+                            horizontalArrangement = Arrangement.spacedBy(AppSpacing.sm),
+                            verticalAlignment = Alignment.CenterVertically,
+                        ) {
+                            Text(language.flag)
+                            Text(language.selfName)
+                        }
+                    },
+                    onClick = {
+                        onLanguageSelected(language)
+                        onExpandedChange(false)
+                    },
+                    contentPadding = ExposedDropdownMenuDefaults.ItemContentPadding,
+                )
+            }
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun LanguageFilterDropdownCollapsedPreview(
+    @PreviewParameter(ThemePreviewProvider::class) isDark: Boolean,
+) {
+    ThemedPreview(darkTheme = isDark) {
+        LanguageFilterDropdown(
+            languages = listOf(Language.ENGLISH, Language.RUSSIAN, Language.DUTCH),
+            selectedLanguage = Language.RUSSIAN,
+            expanded = false,
+            onExpandedChange = {},
+            onLanguageSelected = {},
+            modifier = Modifier.padding(AppSpacing.lg),
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun LanguageFilterDropdownNoSelectionPreview(
+    @PreviewParameter(ThemePreviewProvider::class) isDark: Boolean,
+) {
+    ThemedPreview(darkTheme = isDark) {
+        LanguageFilterDropdown(
+            languages = listOf(Language.ENGLISH, Language.POLISH),
+            selectedLanguage = null,
+            expanded = false,
+            onExpandedChange = {},
+            onLanguageSelected = {},
+            modifier = Modifier.padding(AppSpacing.lg),
+        )
+    }
+}


### PR DESCRIPTION
## Contributor terms

- [ ] I have read and agree to the contributor terms in `CONTRIBUTING.md`.
- [ ] I have the right to submit these changes under those terms.

## Summary

Favorites and Search each carried a byte-for-byte copy of the same 60-line `ExposedDropdownMenuBox`; a `diff` of the two blocks differed only in indentation and the visibility guard. Stats carried a third variant, already pulled into a private `StatsLanguageDropdown`. All three agreed on every dimension, shape, elevation and colour, so changing the control meant editing three places — or letting them drift.

Replaced by `ui/components/LanguageFilterDropdown.kt`, sitting alongside the existing `AppSearchBar` it is sized to pair with.

**Net: 182 lines removed from the three screens, one component added.**

### Behaviour

Unchanged. The one generalization is `selectedLanguage` becoming nullable, with the "fall back to the first available language" rule moved inside the component:

- Favorites and Search both applied that rule at the call site (`state.selectedLanguage ?: state.availableLanguages.firstOrNull()`), so they are exactly equivalent.
- Stats passes a non-null `Language`, so the fallback never triggers there.

Search's guard also loses a redundant `isNotEmpty()` that `size > 1` already implies.

### Incidental cleanups

- Dimensions that map exactly onto the existing scales now use them — `AppSpacing.lg`/`sm`, `AppElevation.level1`. The anchor height/min-width and menu width become named constants with a note on what each is sized against.
- The 2dp menu shadow stays a literal on purpose: `AppElevation.level2` is 3dp, so substituting it would change the rendering.
- `StatsHeader` no longer opts into `ExperimentalMaterial3Api` — the experimental dropdown API is now encapsulated in the component.

### Not included

The anchor renders a bare flag emoji with no `contentDescription`, so screen readers announce the emoji name rather than the language. That is a real gap, but fixing it needs a new localized string across all six localized resource sets, which does not belong in a behaviour-preserving extraction. Worth a follow-up.

## Testing

- `./gradlew :composeApp:compileKotlinDesktop` — BUILD SUCCESSFUL
- `./gradlew :composeApp:verifyLocalizationKeys` — BUILD SUCCESSFUL
- `./gradlew :composeApp:desktopTest --tests "*ViewModelTest*" --tests "*StatsScreenDataTest*" --tests "*StudySession*"` — 84 tests, 0 failures

`DictionaryClientTest` fails 5 of its 9 tests in this environment, but it does so identically on the base commit with the working tree clean — the test server returns `500 Failed to process word` because no AI provider keys are configured here. Unrelated to this change; verified by stashing and re-running against `main`.

Android and iOS targets were not built locally (no Android SDK in this environment); the change is `commonMain`-only, so CI covers those.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FCSWCybtaTofzpkNa5cSpW)_