### PR TITLE
Collapse the feedback vertical across client, server and ViewModels

### DIFF
--- a/composeApp/src/commonMain/composeResources/values-cs/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-cs/strings.xml
@@ -426,7 +426,7 @@
     <string name="settings_error_update_voice_selection_with_reason">Aktualizace výběru hlasu se nezdařila: %1$s</string>
     <string name="settings_feedback_sent">Zpětná vazba odeslána</string>
     <string name="settings_feedback_view">Zobrazit</string>
-    <string name="settings_feedback_comment_required">Komentář je povinný</string>
+    <string name="feedback_dialog_comment_required">Komentář je povinný</string>
     <string name="settings_download_cancelled">Stahování zrušeno</string>
     <string name="common_search">Hledat</string>
     <string name="common_clear">Vymazat</string>

--- a/composeApp/src/commonMain/composeResources/values-de/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-de/strings.xml
@@ -426,7 +426,7 @@
     <string name="settings_error_update_voice_selection_with_reason">Stimmenauswahl konnte nicht aktualisiert werden: %1$s</string>
     <string name="settings_feedback_sent">Feedback gesendet</string>
     <string name="settings_feedback_view">Anzeigen</string>
-    <string name="settings_feedback_comment_required">Kommentar ist erforderlich</string>
+    <string name="feedback_dialog_comment_required">Kommentar ist erforderlich</string>
     <string name="settings_download_cancelled">Download abgebrochen</string>
     <string name="common_search">Suchen</string>
     <string name="common_clear">Löschen</string>

--- a/composeApp/src/commonMain/composeResources/values-es/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-es/strings.xml
@@ -426,7 +426,7 @@
     <string name="settings_error_update_voice_selection_with_reason">No se pudo actualizar la selección de voz: %1$s</string>
     <string name="settings_feedback_sent">Comentarios enviados</string>
     <string name="settings_feedback_view">Ver</string>
-    <string name="settings_feedback_comment_required">El comentario es obligatorio</string>
+    <string name="feedback_dialog_comment_required">El comentario es obligatorio</string>
     <string name="settings_download_cancelled">Descarga cancelada</string>
     <string name="common_search">Buscar</string>
     <string name="common_clear">Borrar</string>

--- a/composeApp/src/commonMain/composeResources/values-fr/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-fr/strings.xml
@@ -426,7 +426,7 @@
     <string name="settings_error_update_voice_selection_with_reason">Échec de la mise à jour de la sélection de voix : %1$s</string>
     <string name="settings_feedback_sent">Avis envoyé</string>
     <string name="settings_feedback_view">Voir</string>
-    <string name="settings_feedback_comment_required">Le commentaire est obligatoire</string>
+    <string name="feedback_dialog_comment_required">Le commentaire est obligatoire</string>
     <string name="settings_download_cancelled">Téléchargement annulé</string>
     <string name="common_search">Rechercher</string>
     <string name="common_clear">Effacer</string>

--- a/composeApp/src/commonMain/composeResources/values-it/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-it/strings.xml
@@ -426,7 +426,7 @@
     <string name="settings_error_update_voice_selection_with_reason">Impossibile aggiornare la selezione della voce: %1$s</string>
     <string name="settings_feedback_sent">Feedback inviato</string>
     <string name="settings_feedback_view">Visualizza</string>
-    <string name="settings_feedback_comment_required">Il commento è obbligatorio</string>
+    <string name="feedback_dialog_comment_required">Il commento è obbligatorio</string>
     <string name="settings_download_cancelled">Download annullato</string>
     <string name="common_search">Cerca</string>
     <string name="common_clear">Cancella</string>

--- a/composeApp/src/commonMain/composeResources/values-nl/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-nl/strings.xml
@@ -426,7 +426,7 @@
     <string name="settings_error_update_voice_selection_with_reason">Bijwerken van stemselectie mislukt: %1$s</string>
     <string name="settings_feedback_sent">Feedback verzonden</string>
     <string name="settings_feedback_view">Bekijk</string>
-    <string name="settings_feedback_comment_required">Opmerking is verplicht</string>
+    <string name="feedback_dialog_comment_required">Opmerking is verplicht</string>
     <string name="settings_download_cancelled">Download geannuleerd</string>
     <string name="common_search">Zoeken</string>
     <string name="common_clear">Wissen</string>

--- a/composeApp/src/commonMain/composeResources/values-pl/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-pl/strings.xml
@@ -425,7 +425,7 @@
     <string name="settings_error_update_voice_selection_with_reason">Nie udało się zaktualizować wyboru głosu: %1$s</string>
     <string name="settings_feedback_sent">Opinia została wysłana</string>
     <string name="settings_feedback_view">Pokaż</string>
-    <string name="settings_feedback_comment_required">Komentarz jest wymagany</string>
+    <string name="feedback_dialog_comment_required">Komentarz jest wymagany</string>
     <string name="settings_download_cancelled">Pobieranie anulowane</string>
     <string name="common_search">Szukaj</string>
     <string name="common_clear">Wyczyść</string>

--- a/composeApp/src/commonMain/composeResources/values-ru/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-ru/strings.xml
@@ -426,7 +426,7 @@
     <string name="settings_error_update_voice_selection_with_reason">Не удалось сохранить выбор голоса: %1$s</string>
     <string name="settings_feedback_sent">Отзыв отправлен. Спасибо!</string>
     <string name="settings_feedback_view">Посмотреть</string>
-    <string name="settings_feedback_comment_required">Пожалуйста, добавьте комментарий</string>
+    <string name="feedback_dialog_comment_required">Пожалуйста, добавьте комментарий</string>
     <string name="settings_download_cancelled">Скачивание отменено</string>
     <string name="common_search">Поиск</string>
     <string name="common_clear">Очистить</string>

--- a/composeApp/src/commonMain/composeResources/values-tr/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-tr/strings.xml
@@ -426,7 +426,7 @@
     <string name="settings_error_update_voice_selection_with_reason">Ses seçimi güncellenemedi: %1$s</string>
     <string name="settings_feedback_sent">Geri bildirim gönderildi</string>
     <string name="settings_feedback_view">Görüntüle</string>
-    <string name="settings_feedback_comment_required">Yorum gerekli</string>
+    <string name="feedback_dialog_comment_required">Yorum gerekli</string>
     <string name="settings_download_cancelled">İndirme iptal edildi</string>
     <string name="common_search">Ara</string>
     <string name="common_clear">Temizle</string>

--- a/composeApp/src/commonMain/composeResources/values-zh/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-zh/strings.xml
@@ -426,7 +426,7 @@
     <string name="settings_error_update_voice_selection_with_reason">更新语音选择失败：%1$s</string>
     <string name="settings_feedback_sent">反馈已发送</string>
     <string name="settings_feedback_view">查看</string>
-    <string name="settings_feedback_comment_required">请填写内容</string>
+    <string name="feedback_dialog_comment_required">请填写内容</string>
     <string name="settings_download_cancelled">下载已取消</string>
     <string name="common_search">搜索</string>
     <string name="common_clear">清除</string>

--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -426,7 +426,7 @@
     <string name="settings_error_update_voice_selection_with_reason">Failed to update voice selection: %1$s</string>
     <string name="settings_feedback_sent">Feedback sent</string>
     <string name="settings_feedback_view">View</string>
-    <string name="settings_feedback_comment_required">Comment is required</string>
+    <string name="feedback_dialog_comment_required">Comment is required</string>
     <string name="settings_download_cancelled">Download cancelled</string>
     <string name="common_search">Search</string>
     <string name="common_clear">Clear</string>

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/data/remote/DictionaryClient.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/data/remote/DictionaryClient.kt
@@ -24,6 +24,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.FlowCollector
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOn
+import kotlinx.serialization.DeserializationStrategy
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 import kotlin.coroutines.cancellation.CancellationException
@@ -548,92 +549,53 @@ class DictionaryClient(
         translationTargets: List<Language>,
         comment: String,
         email: String? = null
-    ): FeedbackResponse {
-        val url = buildFeedbackUrl(language, lemma, translationTargets)
-
-        try {
-            val response = httpClient.post(url) {
-                contentType(ContentType.Application.Json)
-                val trimmedEmail = email?.trim()?.takeIf { it.isNotBlank() }
-                setBody(
-                    json.encodeToString(
-                        FeedbackRequest.serializer(),
-                        FeedbackRequest(comment.trim(), trimmedEmail)
-                    )
-                )
-            }
-
-            if (!response.status.isSuccess()) {
-                val body = response.bodyAsText()
-                throw DictionaryClientException.ServerException(response.status.value, body)
-            }
-
-            val body = response.bodyAsText()
-            return json.decodeFromString(FeedbackResponse.serializer(), body)
-        } catch (e: CancellationException) {
-            AppLogger.warn(TAG, "sendFeedback cancelled for $language/$lemma", e)
-            throw e
-        } catch (e: Exception) {
-            if (e is DictionaryClientException) {
-                AppLogger.error(TAG, "sendFeedback failed for $language/$lemma", e)
-                throw e
-            }
-            AppLogger.error(TAG, "sendFeedback failed for $language/$lemma", e)
-            throw DictionaryClientException.NetworkException(
-                NetworkErrorClassifier.userMessage(e),
-                e
-            )
-        }
-    }
+    ): FeedbackResponse = postFeedback(
+        url = buildFeedbackUrl(language, lemma, translationTargets),
+        comment = comment,
+        email = email,
+        responseSerializer = FeedbackResponse.serializer(),
+        opLabel = "sendFeedback for $language/$lemma"
+    )
 
     suspend fun sendListSuggestion(
         language: Language,
         comment: String,
         email: String? = null
-    ): FeedbackResponse {
-        val url = "$serverBaseUrl/list-suggestion/${language.code}"
-
-        try {
-            val response = httpClient.post(url) {
-                contentType(ContentType.Application.Json)
-                val trimmedEmail = email?.trim()?.takeIf { it.isNotBlank() }
-                setBody(
-                    json.encodeToString(
-                        FeedbackRequest.serializer(),
-                        FeedbackRequest(comment.trim(), trimmedEmail)
-                    )
-                )
-            }
-
-            if (!response.status.isSuccess()) {
-                val body = response.bodyAsText()
-                throw DictionaryClientException.ServerException(response.status.value, body)
-            }
-
-            val body = response.bodyAsText()
-            return json.decodeFromString(FeedbackResponse.serializer(), body)
-        } catch (e: CancellationException) {
-            AppLogger.warn(TAG, "sendListSuggestion cancelled for ${language.code}", e)
-            throw e
-        } catch (e: Exception) {
-            if (e is DictionaryClientException) {
-                AppLogger.error(TAG, "sendListSuggestion failed for ${language.code}", e)
-                throw e
-            }
-            AppLogger.error(TAG, "sendListSuggestion failed for ${language.code}", e)
-            throw DictionaryClientException.NetworkException(
-                NetworkErrorClassifier.userMessage(e),
-                e
-            )
-        }
-    }
+    ): FeedbackResponse = postFeedback(
+        url = "$serverBaseUrl/list-suggestion/${language.code}",
+        comment = comment,
+        email = email,
+        responseSerializer = FeedbackResponse.serializer(),
+        opLabel = "sendListSuggestion for ${language.code}"
+    )
 
     suspend fun sendGeneralFeedback(
         comment: String,
         email: String? = null
-    ): GeneralFeedbackResponse {
-        val url = "$serverBaseUrl/feedback"
+    ): GeneralFeedbackResponse = postFeedback(
+        url = "$serverBaseUrl/feedback",
+        comment = comment,
+        email = email,
+        responseSerializer = GeneralFeedbackResponse.serializer(),
+        opLabel = "sendGeneralFeedback"
+    )
 
+    /**
+     * Posts a [FeedbackRequest] and decodes the response, which is the whole of what the three
+     * feedback endpoints do differently only by URL and response shape.
+     *
+     * Comment and email are trimmed here so every caller sends the same normalized body, and a
+     * blank email is dropped rather than sent as an empty string.
+     *
+     * @param opLabel Names the operation in the logs; it is the only per-caller diagnostic.
+     */
+    private suspend fun <T> postFeedback(
+        url: String,
+        comment: String,
+        email: String?,
+        responseSerializer: DeserializationStrategy<T>,
+        opLabel: String
+    ): T {
         try {
             val response = httpClient.post(url) {
                 contentType(ContentType.Application.Json)
@@ -652,16 +614,13 @@ class DictionaryClient(
             }
 
             val body = response.bodyAsText()
-            return json.decodeFromString(GeneralFeedbackResponse.serializer(), body)
+            return json.decodeFromString(responseSerializer, body)
         } catch (e: CancellationException) {
-            AppLogger.warn(TAG, "sendGeneralFeedback cancelled", e)
+            AppLogger.warn(TAG, "$opLabel cancelled", e)
             throw e
         } catch (e: Exception) {
-            if (e is DictionaryClientException) {
-                AppLogger.error(TAG, "sendGeneralFeedback failed", e)
-                throw e
-            }
-            AppLogger.error(TAG, "sendGeneralFeedback failed", e)
+            AppLogger.error(TAG, "$opLabel failed", e)
+            if (e is DictionaryClientException) throw e
             throw DictionaryClientException.NetworkException(
                 NetworkErrorClassifier.userMessage(e),
                 e

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/FeedbackFormState.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/FeedbackFormState.kt
@@ -1,0 +1,48 @@
+package com.slovy.slovymovyapp.ui
+
+import com.slovy.slovymovyapp.i18n.UiText
+
+/**
+ * State of a [FeedbackDialog] form, shared by every screen that submits a comment to GitHub:
+ * app feedback in Settings, word feedback in Word Details, and list suggestions in Search.
+ *
+ * Screens embed this as a single field in their own `UiState` rather than repeating the six
+ * values, and drive it through the transitions below so that opening, dismissing, and the
+ * submit lifecycle behave identically everywhere.
+ *
+ * What each screen still owns is the submission itself — which client call to make, what must be
+ * true before sending, and what to do once a URL comes back — because those genuinely differ.
+ */
+data class FeedbackFormState(
+    val dialogVisible: Boolean = false,
+    val comment: String = "",
+    val email: String = "",
+    val submitting: Boolean = false,
+    val error: UiText? = null,
+    /** URL of the created issue or discussion; non-null switches the dialog to its sent state. */
+    val resultUrl: String? = null,
+) {
+    val trimmedComment: String get() = comment.trim()
+
+    /** Trimmed email, or null when blank, so an empty field is omitted rather than sent as "". */
+    val trimmedEmail: String? get() = email.trim().takeIf { it.isNotBlank() }
+
+    /** Opens a blank form, discarding anything left over from a previous submission. */
+    fun opened(): FeedbackFormState = FeedbackFormState(dialogVisible = true)
+
+    /** Closes and clears the form. Callers guard this while [submitting] is true. */
+    fun dismissed(): FeedbackFormState = FeedbackFormState()
+
+    /** Typing clears the error so a rejected comment stops looking rejected as it is fixed. */
+    fun withComment(value: String): FeedbackFormState = copy(comment = value, error = null)
+
+    fun withEmail(value: String): FeedbackFormState = copy(email = value)
+
+    fun submissionStarted(): FeedbackFormState = copy(submitting = true, error = null)
+
+    fun submissionSucceeded(url: String?): FeedbackFormState =
+        copy(submitting = false, error = null, resultUrl = url)
+
+    fun submissionFailed(message: UiText): FeedbackFormState =
+        copy(submitting = false, error = message)
+}

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/SearchScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/SearchScreen.kt
@@ -67,6 +67,8 @@ import com.slovy.slovymovyapp.data.settings.SettingsRepository
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.jsonPrimitive
 import com.slovy.slovymovyapp.data.remote.PartOfSpeech
+import com.slovy.slovymovyapp.i18n.UiText
+import com.slovy.slovymovyapp.i18n.resolve
 import com.slovy.slovymovyapp.ui.components.AppSearchBar
 import com.slovy.slovymovyapp.ui.components.EmptyState
 import com.slovy.slovymovyapp.ui.components.LanguageFilterDropdown
@@ -105,12 +107,7 @@ data class SearchUiState(
     // Gates the empty-state body so it renders once fully populated instead of flashing
     // the favorites/"start typing" fallback before curated lists finish loading.
     val isEmptyStateLoading: Boolean = false,
-    val listSuggestionDialogVisible: Boolean = false,
-    val listSuggestionComment: String = "",
-    val listSuggestionEmail: String = "",
-    val listSuggestionSubmitting: Boolean = false,
-    val listSuggestionError: String? = null,
-    val listSuggestionIssueUrl: String? = null
+    val listSuggestion: FeedbackFormState = FeedbackFormState()
 )
 
 class SearchViewModel(
@@ -289,61 +286,48 @@ class SearchViewModel(
     }
 
     fun openListSuggestionDialog() {
-        state = state.copy(
-            listSuggestionDialogVisible = true,
-            listSuggestionComment = "",
-            listSuggestionEmail = "",
-            listSuggestionSubmitting = false,
-            listSuggestionError = null,
-            listSuggestionIssueUrl = null
-        )
+        state = state.copy(listSuggestion = state.listSuggestion.opened())
     }
 
     fun dismissListSuggestionDialog() {
-        if (state.listSuggestionSubmitting) return
-        state = state.copy(
-            listSuggestionDialogVisible = false,
-            listSuggestionComment = "",
-            listSuggestionEmail = "",
-            listSuggestionError = null,
-            listSuggestionIssueUrl = null
-        )
+        if (state.listSuggestion.submitting) return
+        state = state.copy(listSuggestion = state.listSuggestion.dismissed())
     }
 
     fun updateListSuggestionComment(comment: String) {
-        state = state.copy(listSuggestionComment = comment, listSuggestionError = null)
+        state = state.copy(listSuggestion = state.listSuggestion.withComment(comment))
     }
 
     fun updateListSuggestionEmail(email: String) {
-        state = state.copy(listSuggestionEmail = email)
+        state = state.copy(listSuggestion = state.listSuggestion.withEmail(email))
     }
 
     fun submitListSuggestion() {
-        if (state.listSuggestionSubmitting) return
+        val form = state.listSuggestion
+        if (form.submitting) return
         val language = state.selectedLanguage ?: return
 
-        val comment = state.listSuggestionComment.trim()
+        val comment = form.trimmedComment
         if (comment.isBlank()) return
 
-        state = state.copy(listSuggestionSubmitting = true, listSuggestionError = null)
+        state = state.copy(listSuggestion = form.submissionStarted())
         viewModelScope.launch {
             try {
                 val response = dictionaryClient.sendListSuggestion(
                     language = language,
                     comment = comment,
-                    email = state.listSuggestionEmail.trim().takeIf { it.isNotBlank() }
+                    email = form.trimmedEmail
                 )
                 state = state.copy(
-                    listSuggestionSubmitting = false,
-                    listSuggestionError = null,
-                    listSuggestionIssueUrl = response.issueUrl
+                    listSuggestion = state.listSuggestion.submissionSucceeded(response.issueUrl)
                 )
             } catch (e: CancellationException) {
                 throw e
             } catch (e: Exception) {
                 state = state.copy(
-                    listSuggestionSubmitting = false,
-                    listSuggestionError = NetworkErrorClassifier.userMessage(e)
+                    listSuggestion = state.listSuggestion.submissionFailed(
+                        UiText.Plain(NetworkErrorClassifier.userMessage(e))
+                    )
                 )
             }
         }
@@ -672,16 +656,16 @@ fun SearchScreenContent(
             }
         }
 
-    if (state.listSuggestionDialogVisible) {
+    if (state.listSuggestion.dialogVisible) {
         FeedbackDialog(
             title = stringResource(Res.string.search_suggest_list_dialog_title),
             commentPlaceholder = stringResource(Res.string.search_suggest_list_placeholder),
             commentLabel = stringResource(Res.string.feedback_dialog_comment_label),
-            comment = state.listSuggestionComment,
-            email = state.listSuggestionEmail,
-            isSending = state.listSuggestionSubmitting,
-            error = state.listSuggestionError,
-            resultUrl = state.listSuggestionIssueUrl,
+            comment = state.listSuggestion.comment,
+            email = state.listSuggestion.email,
+            isSending = state.listSuggestion.submitting,
+            error = state.listSuggestion.error?.resolve(),
+            resultUrl = state.listSuggestion.resultUrl,
             onCommentChange = onListSuggestionCommentChange,
             onEmailChange = onListSuggestionEmailChange,
             onDismiss = onDismissListSuggestion,

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/SettingsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/SettingsScreen.kt
@@ -93,12 +93,7 @@ data class SettingsUiState(
     val acknowledgementsVisible: Boolean = false,
 
     // Feedback
-    val feedbackDialogVisible: Boolean = false,
-    val feedbackComment: String = "",
-    val feedbackEmail: String = "",
-    val feedbackSubmitting: Boolean = false,
-    val feedbackError: UiText? = null,
-    val feedbackDiscussionUrl: String? = null,
+    val feedback: FeedbackFormState = FeedbackFormState(),
 
     // Developer
     val developerModeEnabled: Boolean = false
@@ -894,26 +889,13 @@ class SettingsViewModel(
     }
 
     fun openFeedbackDialog() {
-        state = state.copy(
-            feedbackDialogVisible = true,
-            feedbackComment = "",
-            feedbackEmail = "",
-            feedbackSubmitting = false,
-            feedbackError = null,
-            feedbackDiscussionUrl = null
-        )
+        state = state.copy(feedback = state.feedback.opened())
     }
 
     fun dismissFeedbackDialog() {
-        if (state.feedbackSubmitting) return
-        val discussionUrl = state.feedbackDiscussionUrl
-        state = state.copy(
-            feedbackDialogVisible = false,
-            feedbackComment = "",
-            feedbackEmail = "",
-            feedbackError = null,
-            feedbackDiscussionUrl = null
-        )
+        if (state.feedback.submitting) return
+        val discussionUrl = state.feedback.resultUrl
+        state = state.copy(feedback = state.feedback.dismissed())
         if (discussionUrl != null) {
             viewModelScope.launch {
                 val result = showSnackbar(
@@ -929,40 +911,44 @@ class SettingsViewModel(
     }
 
     fun updateFeedbackComment(comment: String) {
-        state = state.copy(feedbackComment = comment, feedbackError = null)
+        state = state.copy(feedback = state.feedback.withComment(comment))
     }
 
     fun updateFeedbackEmail(email: String) {
-        state = state.copy(feedbackEmail = email)
+        state = state.copy(feedback = state.feedback.withEmail(email))
     }
 
     fun submitFeedback() {
-        if (state.feedbackSubmitting) return
+        val form = state.feedback
+        if (form.submitting) return
 
-        val comment = state.feedbackComment.trim()
+        val comment = form.trimmedComment
         if (comment.isBlank()) {
-            state = state.copy(feedbackError = UiText.Resource(Res.string.settings_feedback_comment_required))
+            state = state.copy(
+                feedback = form.submissionFailed(
+                    UiText.Resource(Res.string.feedback_dialog_comment_required)
+                )
+            )
             return
         }
 
-        state = state.copy(feedbackSubmitting = true, feedbackError = null)
+        state = state.copy(feedback = form.submissionStarted())
         viewModelScope.launch {
             try {
                 val response = dictionaryClient.sendGeneralFeedback(
                     comment = comment,
-                    email = state.feedbackEmail.trim().takeIf { it.isNotBlank() }
+                    email = form.trimmedEmail
                 )
                 state = state.copy(
-                    feedbackSubmitting = false,
-                    feedbackError = null,
-                    feedbackDiscussionUrl = response.discussionUrl
+                    feedback = state.feedback.submissionSucceeded(response.discussionUrl)
                 )
             } catch (e: CancellationException) {
                 throw e
             } catch (e: Exception) {
                 state = state.copy(
-                    feedbackSubmitting = false,
-                    feedbackError = UiText.Plain(NetworkErrorClassifier.userMessage(e))
+                    feedback = state.feedback.submissionFailed(
+                        UiText.Plain(NetworkErrorClassifier.userMessage(e))
+                    )
                 )
             }
         }
@@ -1432,16 +1418,16 @@ fun SettingsScreenContent(
             AcknowledgementsBottomSheet(onDismiss = onDismissAcknowledgements)
         }
 
-        if (state.feedbackDialogVisible) {
+        if (state.feedback.dialogVisible) {
             FeedbackDialog(
                 title = stringResource(Res.string.feedback_dialog_title),
                 commentPlaceholder = stringResource(Res.string.feedback_dialog_placeholder),
                 commentLabel = stringResource(Res.string.feedback_dialog_comment_label),
-                comment = state.feedbackComment,
-                email = state.feedbackEmail,
-                isSending = state.feedbackSubmitting,
-                error = state.feedbackError?.resolve(),
-                resultUrl = state.feedbackDiscussionUrl,
+                comment = state.feedback.comment,
+                email = state.feedback.email,
+                isSending = state.feedback.submitting,
+                error = state.feedback.error?.resolve(),
+                resultUrl = state.feedback.resultUrl,
                 onCommentChange = onFeedbackCommentChange,
                 onEmailChange = onFeedbackEmailChange,
                 onDismiss = onDismissFeedback,

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/word/WordDetailsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/word/WordDetailsScreen.kt
@@ -50,7 +50,10 @@ import com.slovy.slovymovyapp.data.favorites.FavoritesRepository
 import com.slovy.slovymovyapp.data.remote.*
 import com.slovy.slovymovyapp.logging.AppLogger
 import com.slovy.slovymovyapp.speech.*
+import com.slovy.slovymovyapp.i18n.UiText
+import com.slovy.slovymovyapp.i18n.resolve
 import com.slovy.slovymovyapp.ui.AppNavigationBar
+import com.slovy.slovymovyapp.ui.FeedbackFormState
 import com.slovy.slovymovyapp.ui.SpeakerVector
 import com.slovy.slovymovyapp.ui.VoiceSetupBottomSheet
 import com.slovy.slovymovyapp.ui.components.SpinningProgressIndicator
@@ -84,12 +87,7 @@ sealed interface WordDetailUiState {
         val cardError: String? = null,
         val translationLoading: Boolean = false,
         val translationError: String? = null,
-        val feedbackDialogVisible: Boolean = false,
-        val feedbackComment: String = "",
-        val feedbackEmail: String = "",
-        val feedbackSubmitting: Boolean = false,
-        val feedbackError: String? = null,
-        val feedbackIssueUrl: String? = null,
+        val feedback: FeedbackFormState = FeedbackFormState(),
         val isRefreshing: Boolean = false
     ) : WordDetailUiState
 }
@@ -400,12 +398,7 @@ class WordDetailViewModel(
                 cardError = if (wasWordLoading && errorMessage != null) errorMessage else null,
                 translationLoading = result.isTranslationLoading,
                 translationError = if (wasTranslationLoading && errorMessage != null) errorMessage else null,
-                feedbackDialogVisible = current?.feedbackDialogVisible ?: false,
-                feedbackComment = current?.feedbackComment ?: "",
-                feedbackEmail = current?.feedbackEmail ?: "",
-                feedbackSubmitting = current?.feedbackSubmitting ?: false,
-                feedbackError = current?.feedbackError,
-                feedbackIssueUrl = current?.feedbackIssueUrl
+                feedback = current?.feedback ?: FeedbackFormState()
             )
         } else if (result.error != null) {
             state = WordDetailUiState.Empty(
@@ -604,27 +597,14 @@ class WordDetailViewModel(
 
     fun openFeedbackDialog() {
         val current = state as? WordDetailUiState.Content ?: return
-        state = current.copy(
-            feedbackDialogVisible = true,
-            feedbackComment = "",
-            feedbackEmail = "",
-            feedbackSubmitting = false,
-            feedbackError = null,
-            feedbackIssueUrl = null
-        )
+        state = current.copy(feedback = current.feedback.opened())
     }
 
     fun dismissFeedbackDialog() {
         val current = state as? WordDetailUiState.Content ?: return
-        if (current.feedbackSubmitting) return
-        val issueUrl = current.feedbackIssueUrl
-        state = current.copy(
-            feedbackDialogVisible = false,
-            feedbackComment = "",
-            feedbackEmail = "",
-            feedbackError = null,
-            feedbackIssueUrl = null
-        )
+        if (current.feedback.submitting) return
+        val issueUrl = current.feedback.resultUrl
+        state = current.copy(feedback = current.feedback.dismissed())
         if (issueUrl != null) {
             viewModelScope.launch {
                 val result = snackbarHostState.showSnackbar(
@@ -641,25 +621,30 @@ class WordDetailViewModel(
 
     fun updateFeedbackComment(comment: String) {
         val current = state as? WordDetailUiState.Content ?: return
-        state = current.copy(feedbackComment = comment, feedbackError = null)
+        state = current.copy(feedback = current.feedback.withComment(comment))
     }
 
     fun updateFeedbackEmail(email: String) {
         val current = state as? WordDetailUiState.Content ?: return
-        state = current.copy(feedbackEmail = email)
+        state = current.copy(feedback = current.feedback.withEmail(email))
     }
 
     fun submitFeedback() {
         val current = state as? WordDetailUiState.Content ?: return
-        if (current.feedbackSubmitting) return
+        val form = current.feedback
+        if (form.submitting) return
 
-        val comment = current.feedbackComment.trim()
+        val comment = form.trimmedComment
         if (comment.isBlank()) {
-            state = current.copy(feedbackError = "Comment is required")
+            state = current.copy(
+                feedback = form.submissionFailed(
+                    UiText.Resource(Res.string.feedback_dialog_comment_required)
+                )
+            )
             return
         }
 
-        state = current.copy(feedbackSubmitting = true, feedbackError = null)
+        state = current.copy(feedback = form.submissionStarted())
         viewModelScope.launch {
             try {
                 val feedbackResponse = dictionaryClient.sendFeedback(
@@ -667,14 +652,12 @@ class WordDetailViewModel(
                     lemma = lemma,
                     translationTargets = requestedTranslationLanguages,
                     comment = comment,
-                    email = current.feedbackEmail.trim().takeIf { it.isNotBlank() }
+                    email = form.trimmedEmail
                 )
                 val latest = state as? WordDetailUiState.Content
                 if (latest != null) {
                     state = latest.copy(
-                        feedbackSubmitting = false,
-                        feedbackError = null,
-                        feedbackIssueUrl = feedbackResponse.issueUrl
+                        feedback = latest.feedback.submissionSucceeded(feedbackResponse.issueUrl)
                     )
                 }
             } catch (e: CancellationException) {
@@ -682,8 +665,9 @@ class WordDetailViewModel(
             } catch (e: Exception) {
                 val latest = state as? WordDetailUiState.Content ?: return@launch
                 state = latest.copy(
-                    feedbackSubmitting = false,
-                    feedbackError = NetworkErrorClassifier.userMessage(e)
+                    feedback = latest.feedback.submissionFailed(
+                        UiText.Plain(NetworkErrorClassifier.userMessage(e))
+                    )
                 )
             }
         }
@@ -1087,16 +1071,16 @@ fun WordDetailScreenContent(
         )
     }
 
-    if (state is WordDetailUiState.Content && state.feedbackDialogVisible) {
+    if (state is WordDetailUiState.Content && state.feedback.dialogVisible) {
         com.slovy.slovymovyapp.ui.FeedbackDialog(
             title = stringResource(Res.string.word_details_feedback_title),
             commentPlaceholder = stringResource(Res.string.word_details_feedback_placeholder),
             commentLabel = stringResource(Res.string.feedback_dialog_comment_label),
-            comment = state.feedbackComment,
-            email = state.feedbackEmail,
-            isSending = state.feedbackSubmitting,
-            error = state.feedbackError,
-            resultUrl = state.feedbackIssueUrl,
+            comment = state.feedback.comment,
+            email = state.feedback.email,
+            isSending = state.feedback.submitting,
+            error = state.feedback.error?.resolve(),
+            resultUrl = state.feedback.resultUrl,
             onCommentChange = onFeedbackCommentChange,
             onEmailChange = onFeedbackEmailChange,
             onDismiss = onDismissFeedback,

--- a/server/src/main/kotlin/com/slovy/slovymovyapp/Application.kt
+++ b/server/src/main/kotlin/com/slovy/slovymovyapp/Application.kt
@@ -47,44 +47,30 @@ const val updateRepoPath = "/internal/update-repo/"
 const val SERVER_PORT_ENV = "SERVER_PORT"
 const val SERVER_PORT = 8080
 
+/** Wire body shared by every feedback-style endpoint; the client posts this same shape to all. */
 @Serializable
-private data class FeedbackIssueRequest(
+private data class FeedbackSubmissionRequest(
     val comment: String,
     val email: String? = null
 )
 
+/** Reply for the endpoints that create an issue: word feedback and list suggestions. */
 @Serializable
-private data class FeedbackIssueResponse(
+private data class GitHubIssueResponse(
     val issueNumber: Int,
     val issueTitle: String,
     val issueUrl: String
 )
 
-@Serializable
-private data class ListSuggestionRequest(
-    val comment: String,
-    val email: String? = null
-)
-
-@Serializable
-private data class ListSuggestionResponse(
-    val issueNumber: Int,
-    val issueTitle: String,
-    val issueUrl: String
-)
-
-@Serializable
-private data class GeneralFeedbackRequest(
-    val comment: String,
-    val email: String? = null
-)
-
+/** Reply for general feedback, which creates a discussion rather than an issue. */
 @Serializable
 private data class GeneralFeedbackResponse(
     val discussionNumber: Int,
     val discussionTitle: String,
     val discussionUrl: String
 )
+
+private val feedbackJson = Json { ignoreUnknownKeys = true }
 
 fun main() {
     val port = System.getenv(SERVER_PORT_ENV)?.toIntOrNull() ?: SERVER_PORT
@@ -296,166 +282,61 @@ fun Application.module() {
             }
         }
 
-        post("/feedback") {
-            if (!GitHubClient.isAvailable()) {
-                call.respond(HttpStatusCode.ServiceUnavailable, "GitHub token not configured")
-                return@post
-            }
-
-            val json = Json { ignoreUnknownKeys = true }
-            val feedbackRequest = try {
-                json.decodeFromString(
-                    GeneralFeedbackRequest.serializer(),
-                    call.receiveText()
-                )
-            } catch (_: Exception) {
-                call.respond(HttpStatusCode.BadRequest, "Invalid request body")
-                return@post
-            }
-
-            val comment = feedbackRequest.comment.trim()
-            if (comment.isBlank()) {
-                call.respond(HttpStatusCode.BadRequest, "Missing comment")
-                return@post
-            }
-
-            try {
-                val discussion = GitHubClient.createFeedbackDiscussion(
-                    comment = comment,
-                    email = feedbackRequest.email
-                )
-                val response = GeneralFeedbackResponse(
+        feedbackSubmission(
+            path = "/feedback",
+            artifactName = "feedback discussion"
+        ) { _, comment, email ->
+            val discussion = GitHubClient.createFeedbackDiscussion(comment = comment, email = email)
+            feedbackJson.encodeToString(
+                GeneralFeedbackResponse.serializer(),
+                GeneralFeedbackResponse(
                     discussionNumber = discussion.number,
                     discussionTitle = discussion.title,
                     discussionUrl = discussion.url
                 )
-                call.respondText(
-                    text = json.encodeToString(GeneralFeedbackResponse.serializer(), response),
-                    contentType = ContentType.Application.Json,
-                    status = HttpStatusCode.Created
-                )
-            } catch (e: Exception) {
-                call.application.environment.log.error(
-                    "Failed to create feedback discussion: ${e.message}",
-                    e
-                )
-                call.respond(HttpStatusCode.InternalServerError, "Failed to create feedback discussion")
-            }
+            )
         }
 
-        post("/list-suggestion/{lang}") {
-            val lang = call.parameters["lang"]?.trim()
-
-            if (lang.isNullOrBlank()) {
-                call.respond(HttpStatusCode.BadRequest, "Missing lang parameter")
-                return@post
-            }
-
-            if (!GitHubClient.isAvailable()) {
-                call.respond(HttpStatusCode.ServiceUnavailable, "GitHub token not configured")
-                return@post
-            }
-
-            val json = Json { ignoreUnknownKeys = true }
-            val suggestionRequest = try {
-                json.decodeFromString(
-                    ListSuggestionRequest.serializer(),
-                    call.receiveText()
-                )
-            } catch (_: Exception) {
-                call.respond(HttpStatusCode.BadRequest, "Invalid request body")
-                return@post
-            }
-
-            val comment = suggestionRequest.comment.trim()
-            if (comment.isBlank()) {
-                call.respond(HttpStatusCode.BadRequest, "Missing comment")
-                return@post
-            }
-
-            try {
-                val createdIssue = GitHubClient.createListSuggestionIssue(
-                    lang = lang,
-                    comment = comment,
-                    email = suggestionRequest.email
-                )
-                val response = ListSuggestionResponse(
+        feedbackSubmission(
+            path = "/list-suggestion/{lang}",
+            requiredParams = listOf("lang"),
+            artifactName = "list suggestion issue"
+        ) { params, comment, email ->
+            val createdIssue = GitHubClient.createListSuggestionIssue(
+                lang = params.getValue("lang"),
+                comment = comment,
+                email = email
+            )
+            feedbackJson.encodeToString(
+                GitHubIssueResponse.serializer(),
+                GitHubIssueResponse(
                     issueNumber = createdIssue.number,
                     issueTitle = createdIssue.title,
                     issueUrl = createdIssue.htmlUrl
                 )
-                call.respondText(
-                    text = json.encodeToString(ListSuggestionResponse.serializer(), response),
-                    contentType = ContentType.Application.Json,
-                    status = HttpStatusCode.Created
-                )
-            } catch (e: Exception) {
-                call.application.environment.log.error(
-                    "Failed to create list suggestion issue for $lang: ${e.message}",
-                    e
-                )
-                call.respond(HttpStatusCode.InternalServerError, "Failed to create list suggestion issue")
-            }
+            )
         }
 
-        post("/feedback/{lang}/{word}") {
-            val lang = call.parameters["lang"]?.trim()
-            val word = call.parameters["word"]?.trim()
-
-            if (lang.isNullOrBlank() || word.isNullOrBlank()) {
-                call.respond(HttpStatusCode.BadRequest, "Missing lang or word parameter")
-                return@post
-            }
-
-            if (!GitHubClient.isAvailable()) {
-                call.respond(HttpStatusCode.ServiceUnavailable, "GitHub token not configured")
-                return@post
-            }
-
-            val json = Json { ignoreUnknownKeys = true }
-            val feedbackRequest = try {
-                json.decodeFromString(
-                    FeedbackIssueRequest.serializer(),
-                    call.receiveText()
-                )
-            } catch (_: Exception) {
-                call.respond(HttpStatusCode.BadRequest, "Invalid request body")
-                return@post
-            }
-
-            val comment = feedbackRequest.comment.trim()
-            if (comment.isBlank()) {
-                call.respond(HttpStatusCode.BadRequest, "Missing comment")
-                return@post
-            }
-
-            val translationCodes = parseTranslationCodes(call.request.queryParameters["translations"])
-
-            try {
-                val createdIssue = GitHubClient.createFeedbackIssue(
-                    lang = lang,
-                    word = word,
-                    translationCodes = translationCodes,
-                    comment = comment,
-                    email = feedbackRequest.email
-                )
-                val response = FeedbackIssueResponse(
+        feedbackSubmission(
+            path = "/feedback/{lang}/{word}",
+            requiredParams = listOf("lang", "word"),
+            artifactName = "feedback issue"
+        ) { params, comment, email ->
+            val createdIssue = GitHubClient.createFeedbackIssue(
+                lang = params.getValue("lang"),
+                word = params.getValue("word"),
+                translationCodes = parseTranslationCodes(call.request.queryParameters["translations"]),
+                comment = comment,
+                email = email
+            )
+            feedbackJson.encodeToString(
+                GitHubIssueResponse.serializer(),
+                GitHubIssueResponse(
                     issueNumber = createdIssue.number,
                     issueTitle = createdIssue.title,
                     issueUrl = createdIssue.htmlUrl
                 )
-                call.respondText(
-                    text = json.encodeToString(FeedbackIssueResponse.serializer(), response),
-                    contentType = ContentType.Application.Json,
-                    status = HttpStatusCode.Created
-                )
-            } catch (e: Exception) {
-                call.application.environment.log.error(
-                    "Failed to create feedback issue for $lang/$word: ${e.message}",
-                    e
-                )
-                call.respond(HttpStatusCode.InternalServerError, "Failed to create feedback issue")
-            }
+            )
         }
 
         // Internal endpoint for Cloud Tasks callbacks
@@ -541,6 +422,82 @@ fun Application.module() {
                 call.application.environment.log.error("Failed to update $lang/$word: ${e.message}", e)
                 call.respond(HttpStatusCode.InternalServerError, "Failed to update: ${e.message}")
             }
+        }
+    }
+}
+
+/**
+ * Installs a POST route for one of the feedback-style endpoints, which all turn a comment plus an
+ * optional email into a GitHub artifact and differ only in what they create.
+ *
+ * The shared pipeline, in order: every name in [requiredParams] must be present and non-blank,
+ * a GitHub token must be configured, the body must decode as [FeedbackSubmissionRequest], and the
+ * comment must be non-blank once trimmed. Only then does [createArtifact] run; whatever JSON it
+ * returns is sent back as `201 Created`.
+ *
+ * @param requiredParams Path parameter names to validate, in the order they should be reported.
+ * @param artifactName What the endpoint creates, e.g. "feedback issue". Names the operation in
+ *   both the error log and the 500 response body.
+ * @param createArtifact Creates the artifact and returns the response JSON. Receives the validated
+ *   path parameters, the trimmed comment, and the raw email. Runs with the route's [RoutingContext]
+ *   as receiver so it can still reach `call` for query parameters.
+ */
+private fun Route.feedbackSubmission(
+    path: String,
+    requiredParams: List<String> = emptyList(),
+    artifactName: String,
+    createArtifact: suspend RoutingContext.(
+        params: Map<String, String>,
+        comment: String,
+        email: String?
+    ) -> String
+) {
+    post(path) {
+        val params = LinkedHashMap<String, String>(requiredParams.size)
+        for (name in requiredParams) {
+            val value = call.parameters[name]?.trim()
+            if (value.isNullOrBlank()) {
+                call.respond(HttpStatusCode.BadRequest, "Missing $name parameter")
+                return@post
+            }
+            params[name] = value
+        }
+
+        if (!GitHubClient.isAvailable()) {
+            call.respond(HttpStatusCode.ServiceUnavailable, "GitHub token not configured")
+            return@post
+        }
+
+        val submission = try {
+            feedbackJson.decodeFromString(
+                FeedbackSubmissionRequest.serializer(),
+                call.receiveText()
+            )
+        } catch (_: Exception) {
+            call.respond(HttpStatusCode.BadRequest, "Invalid request body")
+            return@post
+        }
+
+        val comment = submission.comment.trim()
+        if (comment.isBlank()) {
+            call.respond(HttpStatusCode.BadRequest, "Missing comment")
+            return@post
+        }
+
+        try {
+            val responseJson = createArtifact(params, comment, submission.email)
+            call.respondText(
+                text = responseJson,
+                contentType = ContentType.Application.Json,
+                status = HttpStatusCode.Created
+            )
+        } catch (e: Exception) {
+            val context = if (params.isEmpty()) "" else " for ${params.values.joinToString("/")}"
+            call.application.environment.log.error(
+                "Failed to create $artifactName$context: ${e.message}",
+                e
+            )
+            call.respond(HttpStatusCode.InternalServerError, "Failed to create $artifactName")
         }
     }
 }


### PR DESCRIPTION
## Contributor terms

- [x] I have read and agree to the contributor terms in `CONTRIBUTING.md`.
- [x] I have the right to submit these changes under those terms.

## Summary

"Submit a comment to GitHub" existed in three variants — app feedback, word feedback, list suggestion — and each variant was written out again at each of three layers. Nine copies of one feature, so any change to it (a retry, a validation rule, an analytics event) meant nine edits or silent drift.

**Net −130 lines.** Three commits, one per layer, so review can go a layer at a time:

| Commit | Layer | Change |
| --- | --- | --- |
| `75dd271` | `DictionaryClient` | `sendFeedback` / `sendListSuggestion` / `sendGeneralFeedback` → one `postFeedback` envelope |
| `84a98dc` | `Application.kt` | three POST routes → one `Route.feedbackSubmission` pipeline |
| `1b7acba` | three ViewModels | six repeated fields → one shared `FeedbackFormState` |

### Client

The three methods were the same forty lines, differing only in URL, response serializer, and two log strings. Trimming the comment and dropping a blank email move into the envelope so callers stop repeating `takeIf { it.isNotBlank() }`.

### Server

The three routes spelled out the same sequence: validate path params → refuse without a GitHub token → build a `Json` → decode → reject a blank comment → create → 201 → map throws to a logged 500. Validation order is preserved exactly per route.

DTOs that had drifted into copies are consolidated. `FeedbackIssueRequest`, `ListSuggestionRequest` and `GeneralFeedbackRequest` were all `{comment, email?}` — the client posts one shape to all three — and become `FeedbackSubmissionRequest`. `FeedbackIssueResponse` and `ListSuggestionResponse` were both `{issueNumber, issueTitle, issueUrl}` and become `GitHubIssueResponse`. `GeneralFeedbackResponse` keeps its `discussion*` names. **No wire field names change**, so deployed clients are unaffected.

The per-request `Json { ignoreUnknownKeys = true }` in these three handlers becomes one module-level instance. Other handlers still build their own — left for a separate pass rather than widened into this one.

### ViewModels

Settings, Word Details and Search each held `…DialogVisible / …Comment / …Email / …Submitting / …Error / …Url` under their own prefix. They now hold one `FeedbackFormState` driven through named transitions. Each screen keeps its own submission, because which call to make, what must hold first, and what to do with the returned URL genuinely differ. `FeedbackDialog` already took these as parameters, so the UI layer only changed where it reads them from.

## Behaviour changes

Three, all deliberate:

1. **Word Details had a hardcoded English `"Comment is required"`** in `commonMain` — a localization gap. Unifying the error type on `UiText` surfaced it; it now uses the localized resource Settings was already using.
2. **That resource is renamed** `settings_feedback_comment_required` → `feedback_dialog_comment_required` across all 11 resource sets, since two screens now show it. `verifyLocalizationKeys` passes.
3. **`/feedback/{lang}/{word}` answered `"Missing lang or word parameter"` for either**; it now names the parameter actually missing. No test asserts on that text.

## Testing

- `:composeApp:compileKotlinDesktop`, `:server:compileKotlin` — BUILD SUCCESSFUL
- `:composeApp:verifyLocalizationKeys` — BUILD SUCCESSFUL (covers the key rename)
- `:composeApp:desktopTest --tests "*ViewModelTest*" --tests "*StudySession*" --tests "*StatsScreenDataTest*"` — 84 tests, 0 failures
- `:server:test` — 159 tests, 21 failed, **the same 21 that fail on `b4a49f7` with a clean tree** (verified by stashing and re-running; the two failure sets are identical). They are the credential/network-dependent `GitHubClientTest`, `LanguageListsLoaderTest` and word/lists `ApplicationTest` cases.

The two feedback-route tests that *can* run here — `testGeneralFeedback_returnsBadRequestForEmptyComment` and `testGeneralFeedback_returnsBadRequestForInvalidBody` — **pass through the new shared pipeline**. The two that exercise real issue/discussion creation are `@Ignore`d in the suite.

Note for anyone reproducing locally: `:server:test` needs a UTF-8 locale (`LANG=C.UTF-8`), otherwise `processTestResources` fails to hash `pl/kamień.json`. That is environmental and unrelated to this change.

Android and iOS targets were not built locally (no Android SDK in this environment); CI covers those.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FCSWCybtaTofzpkNa5cSpW)_