### PR TITLE
Localize error copy and adopt the AppSpacing scale

### DIFF
--- a/composeApp/src/commonMain/composeResources/values-cs/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-cs/strings.xml
@@ -766,4 +766,14 @@
     <string name="search_add_words">Přidat slova</string>
     <string name="search_add_words_row">Vlož text — vyhledej každé slovo</string>
     <string name="search_add_words_cd">Vlož text a vyhledej každé slovo</string>
+
+    <string name="network_error_offline">Není připojení k internetu. Zkontrolujte připojení a zkuste to znovu.</string>
+    <string name="network_error_timeout">Vypršel časový limit. Zkuste to znovu.</string>
+    <string name="network_error_server_with_code">Chyba serveru (%1$s). Zkuste to znovu.</string>
+    <string name="network_error_server">Chyba serveru. Zkuste to znovu.</string>
+    <string name="network_error_insufficient_storage">Nedostatek volného místa pro stažení.</string>
+    <string name="network_error_unknown">Něco se pokazilo. Zkuste to znovu.</string>
+    <string name="common_loading">Načítání…</string>
+    <string name="common_cancelled">Zrušeno</string>
+    <string name="word_details_load_failed">Slovo se nepodařilo načíst</string>
 </resources>

--- a/composeApp/src/commonMain/composeResources/values-de/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-de/strings.xml
@@ -766,4 +766,14 @@
     <string name="search_add_words">Wörter hinzufügen</string>
     <string name="search_add_words_row">Text einfügen — jedes Wort nachschlagen</string>
     <string name="search_add_words_cd">Text einfügen und jedes Wort nachschlagen</string>
+
+    <string name="network_error_offline">Keine Internetverbindung. Prüfe deine Verbindung und versuche es erneut.</string>
+    <string name="network_error_timeout">Zeitüberschreitung. Bitte versuche es erneut.</string>
+    <string name="network_error_server_with_code">Serverfehler (%1$s). Bitte versuche es erneut.</string>
+    <string name="network_error_server">Serverfehler. Bitte versuche es erneut.</string>
+    <string name="network_error_insufficient_storage">Nicht genug freier Speicher für den Download.</string>
+    <string name="network_error_unknown">Etwas ist schiefgelaufen. Bitte versuche es erneut.</string>
+    <string name="common_loading">Wird geladen…</string>
+    <string name="common_cancelled">Abgebrochen</string>
+    <string name="word_details_load_failed">Wort konnte nicht geladen werden</string>
 </resources>

--- a/composeApp/src/commonMain/composeResources/values-es/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-es/strings.xml
@@ -766,4 +766,14 @@
     <string name="search_add_words">Añadir palabras</string>
     <string name="search_add_words_row">Pega un texto — consulta cada palabra</string>
     <string name="search_add_words_cd">Pega un texto y consulta cada palabra</string>
+
+    <string name="network_error_offline">Sin conexión a internet. Comprueba tu conexión e inténtalo de nuevo.</string>
+    <string name="network_error_timeout">Se agotó el tiempo de espera. Inténtalo de nuevo.</string>
+    <string name="network_error_server_with_code">Error del servidor (%1$s). Inténtalo de nuevo.</string>
+    <string name="network_error_server">Error del servidor. Inténtalo de nuevo.</string>
+    <string name="network_error_insufficient_storage">No hay espacio libre suficiente para la descarga.</string>
+    <string name="network_error_unknown">Algo salió mal. Inténtalo de nuevo.</string>
+    <string name="common_loading">Cargando…</string>
+    <string name="common_cancelled">Cancelado</string>
+    <string name="word_details_load_failed">No se pudo cargar la palabra</string>
 </resources>

--- a/composeApp/src/commonMain/composeResources/values-fr/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-fr/strings.xml
@@ -766,4 +766,14 @@
     <string name="search_add_words">Ajouter des mots</string>
     <string name="search_add_words_row">Colle un texte — cherche chaque mot</string>
     <string name="search_add_words_cd">Colle un texte et cherche chaque mot</string>
+
+    <string name="network_error_offline">Pas de connexion internet. Vérifiez votre connexion et réessayez.</string>
+    <string name="network_error_timeout">Délai d\'attente dépassé. Veuillez réessayer.</string>
+    <string name="network_error_server_with_code">Erreur du serveur (%1$s). Veuillez réessayer.</string>
+    <string name="network_error_server">Erreur du serveur. Veuillez réessayer.</string>
+    <string name="network_error_insufficient_storage">Espace libre insuffisant pour le téléchargement.</string>
+    <string name="network_error_unknown">Une erreur est survenue. Veuillez réessayer.</string>
+    <string name="common_loading">Chargement…</string>
+    <string name="common_cancelled">Annulé</string>
+    <string name="word_details_load_failed">Impossible de charger le mot</string>
 </resources>

--- a/composeApp/src/commonMain/composeResources/values-it/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-it/strings.xml
@@ -766,4 +766,14 @@
     <string name="search_add_words">Aggiungi parole</string>
     <string name="search_add_words_row">Incolla un testo — cerca ogni parola</string>
     <string name="search_add_words_cd">Incolla un testo e cerca ogni parola</string>
+
+    <string name="network_error_offline">Nessuna connessione a internet. Controlla la connessione e riprova.</string>
+    <string name="network_error_timeout">Tempo scaduto. Riprova.</string>
+    <string name="network_error_server_with_code">Errore del server (%1$s). Riprova.</string>
+    <string name="network_error_server">Errore del server. Riprova.</string>
+    <string name="network_error_insufficient_storage">Spazio libero insufficiente per il download.</string>
+    <string name="network_error_unknown">Qualcosa è andato storto. Riprova.</string>
+    <string name="common_loading">Caricamento…</string>
+    <string name="common_cancelled">Annullato</string>
+    <string name="word_details_load_failed">Impossibile caricare la parola</string>
 </resources>

--- a/composeApp/src/commonMain/composeResources/values-nl/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-nl/strings.xml
@@ -766,4 +766,14 @@
     <string name="search_add_words">Woorden toevoegen</string>
     <string name="search_add_words_row">Plak een tekst — zoek elk woord op</string>
     <string name="search_add_words_cd">Plak een tekst en zoek elk woord op</string>
+
+    <string name="network_error_offline">Geen internetverbinding. Controleer je verbinding en probeer het opnieuw.</string>
+    <string name="network_error_timeout">Time-out. Probeer het opnieuw.</string>
+    <string name="network_error_server_with_code">Serverfout (%1$s). Probeer het opnieuw.</string>
+    <string name="network_error_server">Serverfout. Probeer het opnieuw.</string>
+    <string name="network_error_insufficient_storage">Onvoldoende vrije ruimte voor de download.</string>
+    <string name="network_error_unknown">Er is iets misgegaan. Probeer het opnieuw.</string>
+    <string name="common_loading">Laden…</string>
+    <string name="common_cancelled">Geannuleerd</string>
+    <string name="word_details_load_failed">Kan het woord niet laden</string>
 </resources>

--- a/composeApp/src/commonMain/composeResources/values-pl/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-pl/strings.xml
@@ -765,4 +765,14 @@
     <string name="search_add_words">Dodaj słowa</string>
     <string name="search_add_words_row">Wklej tekst — sprawdź każde słowo</string>
     <string name="search_add_words_cd">Wklej tekst i sprawdź każde słowo</string>
+
+    <string name="network_error_offline">Brak połączenia z internetem. Sprawdź połączenie i spróbuj ponownie.</string>
+    <string name="network_error_timeout">Przekroczono czas oczekiwania. Spróbuj ponownie.</string>
+    <string name="network_error_server_with_code">Błąd serwera (%1$s). Spróbuj ponownie.</string>
+    <string name="network_error_server">Błąd serwera. Spróbuj ponownie.</string>
+    <string name="network_error_insufficient_storage">Za mało wolnego miejsca, aby pobrać dane.</string>
+    <string name="network_error_unknown">Coś poszło nie tak. Spróbuj ponownie.</string>
+    <string name="common_loading">Ładowanie…</string>
+    <string name="common_cancelled">Anulowano</string>
+    <string name="word_details_load_failed">Nie udało się wczytać słowa</string>
 </resources>

--- a/composeApp/src/commonMain/composeResources/values-ru/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-ru/strings.xml
@@ -766,4 +766,14 @@
     <string name="search_add_words">Добавить слова</string>
     <string name="search_add_words_row">Вставьте текст — разберите каждое слово</string>
     <string name="search_add_words_cd">Вставьте текст и разберите каждое слово</string>
+
+    <string name="network_error_offline">Нет подключения к интернету. Проверьте соединение и попробуйте снова.</string>
+    <string name="network_error_timeout">Время ожидания истекло. Попробуйте снова.</string>
+    <string name="network_error_server_with_code">Ошибка сервера (%1$s). Попробуйте снова.</string>
+    <string name="network_error_server">Ошибка сервера. Попробуйте снова.</string>
+    <string name="network_error_insufficient_storage">Недостаточно свободного места для загрузки.</string>
+    <string name="network_error_unknown">Что-то пошло не так. Попробуйте снова.</string>
+    <string name="common_loading">Загрузка…</string>
+    <string name="common_cancelled">Отменено</string>
+    <string name="word_details_load_failed">Не удалось загрузить слово</string>
 </resources>

--- a/composeApp/src/commonMain/composeResources/values-tr/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-tr/strings.xml
@@ -766,4 +766,14 @@
     <string name="search_add_words">Kelime ekle</string>
     <string name="search_add_words_row">Metin yapıştır — her kelimeye bak</string>
     <string name="search_add_words_cd">Metin yapıştır ve her kelimeye bak</string>
+
+    <string name="network_error_offline">İnternet bağlantısı yok. Bağlantınızı kontrol edip tekrar deneyin.</string>
+    <string name="network_error_timeout">İstek zaman aşımına uğradı. Lütfen tekrar deneyin.</string>
+    <string name="network_error_server_with_code">Sunucu hatası (%1$s). Lütfen tekrar deneyin.</string>
+    <string name="network_error_server">Sunucu hatası. Lütfen tekrar deneyin.</string>
+    <string name="network_error_insufficient_storage">İndirme için yeterli boş alan yok.</string>
+    <string name="network_error_unknown">Bir şeyler ters gitti. Lütfen tekrar deneyin.</string>
+    <string name="common_loading">Yükleniyor…</string>
+    <string name="common_cancelled">İptal edildi</string>
+    <string name="word_details_load_failed">Kelime yüklenemedi</string>
 </resources>

--- a/composeApp/src/commonMain/composeResources/values-zh/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-zh/strings.xml
@@ -766,4 +766,14 @@
     <string name="search_add_words">添加单词</string>
     <string name="search_add_words_row">粘贴一段文本——查询其中的每个词</string>
     <string name="search_add_words_cd">粘贴一段文本并查询其中的每个词</string>
+
+    <string name="network_error_offline">无网络连接。请检查网络后重试。</string>
+    <string name="network_error_timeout">请求超时，请重试。</string>
+    <string name="network_error_server_with_code">服务器错误（%1$s），请重试。</string>
+    <string name="network_error_server">服务器错误，请重试。</string>
+    <string name="network_error_insufficient_storage">剩余空间不足，无法完成下载。</string>
+    <string name="network_error_unknown">出了点问题，请重试。</string>
+    <string name="common_loading">加载中…</string>
+    <string name="common_cancelled">已取消</string>
+    <string name="word_details_load_failed">无法加载该词</string>
 </resources>

--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -766,4 +766,14 @@
     <string name="search_add_words">Add words</string>
     <string name="search_add_words_row">Paste a text — look up every word</string>
     <string name="search_add_words_cd">Paste a text and look up every word</string>
+
+    <string name="network_error_offline">No internet connection. Check your connection and try again.</string>
+    <string name="network_error_timeout">Request timed out. Please try again.</string>
+    <string name="network_error_server_with_code">Server error (%1$s). Please try again.</string>
+    <string name="network_error_server">Server error. Please try again.</string>
+    <string name="network_error_insufficient_storage">Not enough free space to complete the download.</string>
+    <string name="network_error_unknown">Something went wrong. Please try again.</string>
+    <string name="common_loading">Loading…</string>
+    <string name="common_cancelled">Cancelled</string>
+    <string name="word_details_load_failed">Failed to load word</string>
 </resources>

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/i18n/NetworkErrorUiText.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/i18n/NetworkErrorUiText.kt
@@ -1,0 +1,36 @@
+package com.slovy.slovymovyapp.i18n
+
+import com.slovy.slovymovyapp.data.remote.NetworkError
+import com.slovy.slovymovyapp.data.remote.NetworkErrorClassifier
+import slovymovyapp.composeapp.generated.resources.Res
+import slovymovyapp.composeapp.generated.resources.network_error_insufficient_storage
+import slovymovyapp.composeapp.generated.resources.network_error_offline
+import slovymovyapp.composeapp.generated.resources.network_error_server
+import slovymovyapp.composeapp.generated.resources.network_error_server_with_code
+import slovymovyapp.composeapp.generated.resources.network_error_timeout
+import slovymovyapp.composeapp.generated.resources.network_error_unknown
+
+/**
+ * Localized copy for a classified network failure.
+ *
+ * [NetworkError.userMessage] stays English on purpose: it is what goes into exception messages
+ * and logs. Anything shown to a person goes through here instead, so the five network messages
+ * follow the UI language like the rest of the app.
+ */
+fun NetworkError.toUiText(): UiText = when (this) {
+    is NetworkError.Offline -> UiText.Resource(Res.string.network_error_offline)
+    is NetworkError.Timeout -> UiText.Resource(Res.string.network_error_timeout)
+    is NetworkError.ServerError ->
+        if (statusCode > 0) {
+            UiText.Resource(Res.string.network_error_server_with_code, listOf(statusCode))
+        } else {
+            UiText.Resource(Res.string.network_error_server)
+        }
+
+    is NetworkError.InsufficientStorage -> UiText.Resource(Res.string.network_error_insufficient_storage)
+    is NetworkError.Unknown -> UiText.Resource(Res.string.network_error_unknown)
+}
+
+/** Shorthand for the common `classify(e).toUiText()` pairing at ViewModel catch sites. */
+fun networkErrorUiText(throwable: Throwable): UiText =
+    NetworkErrorClassifier.classify(throwable).toUiText()

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/ErrorScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/ErrorScreen.kt
@@ -22,6 +22,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.ViewModel
+import com.slovy.slovymovyapp.ui.theme.AppSpacing
 import org.jetbrains.compose.resources.stringResource
 import slovymovyapp.composeapp.generated.resources.*
 
@@ -49,7 +50,7 @@ fun ErrorScreenContent(
                 .fillMaxSize()
                 .verticalScroll(rememberScrollState())
                 .padding(innerPadding)
-                .padding(32.dp),
+                .padding(AppSpacing.xxl),
             verticalArrangement = Arrangement.Center,
             horizontalAlignment = Alignment.CenterHorizontally
         ) {

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/FeedbackDialog.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/FeedbackDialog.kt
@@ -14,6 +14,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.dp
 import com.slovy.slovymovyapp.ui.components.SpinningProgressIndicator
+import com.slovy.slovymovyapp.ui.theme.AppSpacing
 import org.jetbrains.compose.resources.stringResource
 import slovymovyapp.composeapp.generated.resources.*
 
@@ -39,7 +40,7 @@ fun FeedbackDialog(
             title = {
                 Row(
                     verticalAlignment = Alignment.CenterVertically,
-                    horizontalArrangement = Arrangement.spacedBy(8.dp)
+                    horizontalArrangement = Arrangement.spacedBy(AppSpacing.sm)
                 ) {
                     Icon(
                         imageVector = Icons.Outlined.CheckCircle,
@@ -56,7 +57,7 @@ fun FeedbackDialog(
                 }
             },
             text = {
-                Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                Column(verticalArrangement = Arrangement.spacedBy(AppSpacing.sm)) {
                     Text(
                         text = stringResource(Res.string.feedback_dialog_sent_message),
                         style = MaterialTheme.typography.bodyMedium
@@ -101,7 +102,7 @@ fun FeedbackDialog(
                     focusedBorderColor = MaterialTheme.colorScheme.onSurfaceVariant,
                     focusedLabelColor = MaterialTheme.colorScheme.onSurfaceVariant
                 )
-                Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                Column(verticalArrangement = Arrangement.spacedBy(AppSpacing.sm)) {
                     OutlinedTextField(
                         value = commentValue,
                         onValueChange = { commentValue = it; onCommentChange(it.text) },

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/components/AppCard.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/components/AppCard.kt
@@ -11,6 +11,7 @@ import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.unit.dp
 import com.slovy.slovymovyapp.ui.ThemePreviewProvider
 import com.slovy.slovymovyapp.ui.ThemedPreview
+import com.slovy.slovymovyapp.ui.theme.AppSpacing
 import com.slovy.slovymovyapp.ui.theme.elevationLevel1
 
 /**
@@ -100,10 +101,10 @@ private fun AppCardPreview(
     @androidx.compose.ui.tooling.preview.PreviewParameter(ThemePreviewProvider::class) isDark: Boolean
 ) {
     ThemedPreview(darkTheme = isDark) {
-        AppCard(modifier = Modifier.padding(16.dp)) {
+        AppCard(modifier = Modifier.padding(AppSpacing.lg)) {
             Text(
                 text = "Sample Card Content",
-                modifier = Modifier.padding(16.dp),
+                modifier = Modifier.padding(AppSpacing.lg),
                 style = MaterialTheme.typography.bodyMedium
             )
         }
@@ -117,12 +118,12 @@ private fun AppCardClickablePreview(
 ) {
     ThemedPreview(darkTheme = isDark) {
         AppCard(
-            modifier = Modifier.padding(16.dp),
+            modifier = Modifier.padding(AppSpacing.lg),
             onClick = {}
         ) {
             Text(
                 text = "Clickable Card",
-                modifier = Modifier.padding(16.dp),
+                modifier = Modifier.padding(AppSpacing.lg),
                 style = MaterialTheme.typography.bodyMedium
             )
         }
@@ -135,10 +136,10 @@ private fun CompactCardPreview(
     @androidx.compose.ui.tooling.preview.PreviewParameter(ThemePreviewProvider::class) isDark: Boolean
 ) {
     ThemedPreview(darkTheme = isDark) {
-        CompactCard(modifier = Modifier.padding(16.dp)) {
+        CompactCard(modifier = Modifier.padding(AppSpacing.lg)) {
             Text(
                 text = "Compact Card",
-                modifier = Modifier.padding(12.dp),
+                modifier = Modifier.padding(AppSpacing.md),
                 style = MaterialTheme.typography.bodySmall
             )
         }

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/components/AppSearchBar.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/components/AppSearchBar.kt
@@ -13,6 +13,7 @@ import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.unit.dp
 import com.slovy.slovymovyapp.ui.ThemePreviewProvider
 import com.slovy.slovymovyapp.ui.ThemedPreview
+import com.slovy.slovymovyapp.ui.theme.AppSpacing
 import com.slovy.slovymovyapp.ui.theme.LocalIsDarkTheme
 import org.jetbrains.compose.resources.stringResource
 import slovymovyapp.composeapp.generated.resources.Res
@@ -135,7 +136,7 @@ private fun AppSearchBarEmptyPreview(
         AppSearchBar(
             query = "",
             onQueryChange = {},
-            modifier = Modifier.padding(16.dp)
+            modifier = Modifier.padding(AppSpacing.lg)
         )
     }
 }
@@ -149,7 +150,7 @@ private fun AppSearchBarWithTextPreview(
         AppSearchBar(
             query = "example search",
             onQueryChange = {},
-            modifier = Modifier.padding(16.dp)
+            modifier = Modifier.padding(AppSpacing.lg)
         )
     }
 }
@@ -164,7 +165,7 @@ private fun AppSearchBarDisabledPreview(
             query = "disabled",
             onQueryChange = {},
             enabled = false,
-            modifier = Modifier.padding(16.dp)
+            modifier = Modifier.padding(AppSpacing.lg)
         )
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/components/FrequencyBadge.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/components/FrequencyBadge.kt
@@ -65,7 +65,7 @@ fun CompactFrequencyBadge(
     ) {
         Text(
             text = stringResource(frequency.label),
-            modifier = Modifier.padding(horizontal = AppSpacing.sm, vertical = 4.dp),
+            modifier = Modifier.padding(horizontal = AppSpacing.sm, vertical = AppSpacing.xs),
             style = MaterialTheme.typography.labelSmall,
             color = textColor
         )
@@ -80,7 +80,7 @@ private fun FrequencyBadgePreview(
 ) {
     ThemedPreview(darkTheme = isDark) {
         Column(
-            modifier = Modifier.padding(16.dp),
+            modifier = Modifier.padding(AppSpacing.lg),
             verticalArrangement = Arrangement.spacedBy(AppSpacing.md)
         ) {
             FrequencyBadge(frequency = SenseFrequency.HIGH)
@@ -98,7 +98,7 @@ private fun CompactFrequencyBadgePreview(
 ) {
     ThemedPreview(darkTheme = isDark) {
         Column(
-            modifier = Modifier.padding(16.dp),
+            modifier = Modifier.padding(AppSpacing.lg),
             verticalArrangement = Arrangement.spacedBy(AppSpacing.sm)
         ) {
             CompactFrequencyBadge(frequency = SenseFrequency.HIGH)

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/components/PartOfSpeechIndicator.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/components/PartOfSpeechIndicator.kt
@@ -16,6 +16,8 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.slovy.slovymovyapp.data.remote.PartOfSpeech
+import com.slovy.slovymovyapp.i18n.UiText
+import com.slovy.slovymovyapp.i18n.resolve
 import com.slovy.slovymovyapp.ui.ThemePreviewProvider
 import com.slovy.slovymovyapp.ui.ThemedPreview
 import com.slovy.slovymovyapp.ui.theme.AppSpacing
@@ -46,7 +48,7 @@ fun PartOfSpeechIndicator(
     modifier: Modifier = Modifier,
     meaningCount: Int? = null,
     cardLoading: Boolean = false,
-    cardError: String? = null
+    cardError: UiText? = null
 ) {
     val color = getPartOfSpeechColor(pos)
     val partOfSpeech = stringResource(pos.displayName)
@@ -97,7 +99,7 @@ fun PartOfSpeechIndicator(
             )
         } else if (cardError != null) {
             Text(
-                text = cardError,
+                text = cardError.resolve(),
                 style = MaterialTheme.typography.titleMedium,
                 color = MaterialTheme.colorScheme.error
             )
@@ -180,7 +182,11 @@ private fun PartOfSpeechIndicatorPreviewLoadingError(
             verticalArrangement = Arrangement.spacedBy(AppSpacing.md)
         ) {
             PartOfSpeechIndicator(pos = PartOfSpeech.VERB, cardLoading = true, cardError = null)
-            PartOfSpeechIndicator(pos = PartOfSpeech.NOUN, cardLoading = false, cardError = "Errors")
+            PartOfSpeechIndicator(
+                pos = PartOfSpeech.NOUN,
+                cardLoading = false,
+                cardError = UiText.Plain("Errors")
+            )
         }
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/components/PartOfSpeechIndicator.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/components/PartOfSpeechIndicator.kt
@@ -158,7 +158,7 @@ private fun PartOfSpeechIndicatorPreview(
 ) {
     ThemedPreview(darkTheme = isDark) {
         Column(
-            modifier = Modifier.padding(16.dp),
+            modifier = Modifier.padding(AppSpacing.lg),
             verticalArrangement = Arrangement.spacedBy(AppSpacing.md)
         ) {
             PartOfSpeechIndicator(pos = PartOfSpeech.VERB, meaningCount = 3)
@@ -178,7 +178,7 @@ private fun PartOfSpeechIndicatorPreviewLoadingError(
 ) {
     ThemedPreview(darkTheme = isDark) {
         Column(
-            modifier = Modifier.padding(16.dp),
+            modifier = Modifier.padding(AppSpacing.lg),
             verticalArrangement = Arrangement.spacedBy(AppSpacing.md)
         ) {
             PartOfSpeechIndicator(pos = PartOfSpeech.VERB, cardLoading = true, cardError = null)
@@ -198,7 +198,7 @@ private fun PartOfSpeechBadgePreview(
 ) {
     ThemedPreview(darkTheme = isDark) {
         Column(
-            modifier = Modifier.padding(16.dp),
+            modifier = Modifier.padding(AppSpacing.lg),
             verticalArrangement = Arrangement.spacedBy(AppSpacing.sm)
         ) {
             Row(

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/components/SpinningProgressIndicator.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/components/SpinningProgressIndicator.kt
@@ -28,6 +28,7 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.slovy.slovymovyapp.ui.ThemePreviewProvider
 import com.slovy.slovymovyapp.ui.ThemedPreview
+import com.slovy.slovymovyapp.ui.theme.AppSpacing
 
 /**
  * Indeterminate spinner used in place of the Material 3 [androidx.compose.material3.CircularProgressIndicator].
@@ -94,8 +95,8 @@ private fun SpinningProgressIndicatorPreview(
 ) {
     ThemedPreview(darkTheme = isDark) {
         Row(
-            modifier = Modifier.padding(16.dp),
-            horizontalArrangement = Arrangement.spacedBy(16.dp),
+            modifier = Modifier.padding(AppSpacing.lg),
+            horizontalArrangement = Arrangement.spacedBy(AppSpacing.lg),
             verticalAlignment = Alignment.CenterVertically,
         ) {
             SpinningProgressIndicator()

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/download/DownloadScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/download/DownloadScreen.kt
@@ -17,6 +17,8 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import com.slovy.slovymovyapp.data.remote.*
+import com.slovy.slovymovyapp.i18n.networkErrorUiText
+import com.slovy.slovymovyapp.i18n.resolve
 import com.slovy.slovymovyapp.ui.components.SpinningProgressIndicator
 import com.slovy.slovymovyapp.ui.icons.DownloadScreenTransparent
 import com.slovy.slovymovyapp.ui.icons.SlovyIcons
@@ -369,9 +371,8 @@ fun DownloadScreenContent(
                 }
 
                 is DownloadUiState.Failed -> {
-                    val classified = NetworkErrorClassifier.classify(state.error)
                     Text(
-                        text = classified.userMessage,
+                        text = networkErrorUiText(state.error).resolve(),
                         style = MaterialTheme.typography.bodyLarge,
                         color = MaterialTheme.colorScheme.error
                     )

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/favorites/FavoriteSenseCard.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/favorites/FavoriteSenseCard.kt
@@ -41,7 +41,7 @@ internal fun FavoriteSenseCard(
             sense = item.sense,
             pos = item.pos,
             loading = item.loading,
-            error = item.error?.resolve(),
+            error = item.error,
             diagnosticInfoOnError = buildDeveloperDiagnosticInfo(item.senseId, item.createdAt)
         ),
         state = senseState,

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/favorites/FavoritesScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/favorites/FavoritesScreen.kt
@@ -45,6 +45,7 @@ import com.slovy.slovymovyapp.ui.components.LanguageFilterDropdown
 import com.slovy.slovymovyapp.ui.icons.NoFavsImage
 import com.slovy.slovymovyapp.ui.icons.SearchOtter
 import com.slovy.slovymovyapp.ui.icons.SlovyIcons
+import com.slovy.slovymovyapp.ui.theme.AppSpacing
 import com.slovy.slovymovyapp.ui.theme.serifFontFamily
 import com.slovy.slovymovyapp.ui.theme.uiItalic
 import com.slovy.slovymovyapp.ui.word.LoadingPlaceholder
@@ -217,8 +218,8 @@ fun FavoritesScreenContent(
                         Row(
                             modifier = Modifier
                                 .fillMaxWidth()
-                                .padding(horizontal = 16.dp),
-                            horizontalArrangement = Arrangement.spacedBy(8.dp),
+                                .padding(horizontal = AppSpacing.lg),
+                            horizontalArrangement = Arrangement.spacedBy(AppSpacing.sm),
                             verticalAlignment = Alignment.CenterVertically
                         ) {
                             AppSearchBar(
@@ -319,7 +320,7 @@ fun FavoritesScreenContent(
                                             },
                                             modifier = Modifier
                                                 .fillMaxWidth()
-                                                .padding(horizontal = 16.dp, vertical = 8.dp),
+                                                .padding(horizontal = AppSpacing.lg, vertical = AppSpacing.sm),
                                         )
                                     } ?: state.studyDone?.let { studyDone ->
                                         StudyDoneCard(
@@ -345,7 +346,7 @@ fun FavoritesScreenContent(
                                             },
                                             modifier = Modifier
                                                 .fillMaxWidth()
-                                                .padding(horizontal = 16.dp, vertical = 8.dp),
+                                                .padding(horizontal = AppSpacing.lg, vertical = AppSpacing.sm),
                                         )
                                     }
                                     Text(
@@ -356,16 +357,20 @@ fun FavoritesScreenContent(
                                         ),
                                         style = MaterialTheme.typography.labelSmall,
                                         color = MaterialTheme.colorScheme.onSurfaceVariant,
-                                        modifier = Modifier.padding(start = 16.dp, top = 8.dp, bottom = 8.dp)
+                                        modifier = Modifier.padding(
+                                            start = AppSpacing.lg,
+                                            top = AppSpacing.sm,
+                                            bottom = AppSpacing.sm,
+                                        )
                                     )
 
                                     LazyColumn(
                                         state = scrollState,
                                         modifier = Modifier
                                             .fillMaxSize()
-                                            .padding(horizontal = 16.dp),
-                                        verticalArrangement = Arrangement.spacedBy(8.dp),
-                                        contentPadding = PaddingValues(bottom = 16.dp)
+                                            .padding(horizontal = AppSpacing.lg),
+                                        verticalArrangement = Arrangement.spacedBy(AppSpacing.sm),
+                                        contentPadding = PaddingValues(bottom = AppSpacing.lg)
                                     ) {
                                         items(
                                             state.senses,
@@ -458,7 +463,7 @@ private fun FavoritesEmptyState(
     Column(
         modifier = modifier
             .fillMaxWidth()
-            .padding(horizontal = 32.dp),
+            .padding(horizontal = AppSpacing.xxl),
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {
         Image(

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/favorites/StudyCards.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/favorites/StudyCards.kt
@@ -27,6 +27,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.slovy.slovymovyapp.data.remote.*
 import com.slovy.slovymovyapp.i18n.resolve
+import com.slovy.slovymovyapp.ui.theme.AppSpacing
 import com.slovy.slovymovyapp.ui.theme.serifFontFamily
 import com.slovy.slovymovyapp.ui.theme.uiItalic
 import kotlinx.coroutines.*
@@ -92,7 +93,7 @@ internal fun StudyDoneCard(
             ) {
                 Column(
                     modifier = Modifier.weight(1f),
-                    verticalArrangement = Arrangement.spacedBy(4.dp),
+                    verticalArrangement = Arrangement.spacedBy(AppSpacing.xs),
                 ) {
                     Text(
                         text = stringResource(Res.string.favorites_study_done_title),
@@ -102,7 +103,7 @@ internal fun StudyDoneCard(
                         color = MaterialTheme.colorScheme.onSurfaceVariant,
                     )
                     Row(
-                        horizontalArrangement = Arrangement.spacedBy(8.dp),
+                        horizontalArrangement = Arrangement.spacedBy(AppSpacing.sm),
                         verticalAlignment = Alignment.Bottom,
                     ) {
                         Text(

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/languagesetup/LanguageSetupScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/languagesetup/LanguageSetupScreen.kt
@@ -100,7 +100,11 @@ fun LanguageSetupScreenContent(
                 verticalArrangement = Arrangement.Center,
                 horizontalAlignment = Alignment.CenterHorizontally
             ) {
-                Text(state.errorMessage, color = MaterialTheme.colorScheme.error, textAlign = TextAlign.Center)
+                Text(
+                    state.errorMessage.resolve(),
+                    color = MaterialTheme.colorScheme.error,
+                    textAlign = TextAlign.Center
+                )
                 Button(onClick = onRetry, modifier = Modifier.padding(top = AppSpacing.lg)) {
                     Text(stringResource(Res.string.common_retry))
                 }

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/languagesetup/LanguageSetupViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/languagesetup/LanguageSetupViewModel.kt
@@ -11,8 +11,8 @@ import com.slovy.slovymovyapp.analytics.AnalyticsEvent
 import com.slovy.slovymovyapp.data.Language
 import com.slovy.slovymovyapp.data.remote.DataDbManager
 import com.slovy.slovymovyapp.data.remote.DictionaryClient
-import com.slovy.slovymovyapp.data.remote.NetworkErrorClassifier
 import com.slovy.slovymovyapp.i18n.UiText
+import com.slovy.slovymovyapp.i18n.networkErrorUiText
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Job
@@ -26,7 +26,7 @@ data class LanguageSetupUiState(
     val learningLanguage: Language? = null,
     val nativeLanguages: Set<Language> = emptySet(),
     val noTranslationSelected: Boolean = false,
-    val errorMessage: String? = null,
+    val errorMessage: UiText? = null,
     val languageRequestDialogVisible: Boolean = false,
     val languageRequestLearnLanguage: String = "",
     val languageRequestTranslateLanguage: String = "",
@@ -78,7 +78,7 @@ class LanguageSetupViewModel(
             } catch (e: Exception) {
                 state = state.copy(
                     isLoading = false,
-                    errorMessage = NetworkErrorClassifier.userMessage(e)
+                    errorMessage = networkErrorUiText(e)
                 )
             }
         }
@@ -185,7 +185,7 @@ class LanguageSetupViewModel(
                 if (isCurrentLanguageRequestJob() && state.languageRequestDialogVisible) {
                     state = state.copy(
                         languageRequestSubmitting = false,
-                        languageRequestError = UiText.Plain(NetworkErrorClassifier.userMessage(e))
+                        languageRequestError = networkErrorUiText(e)
                     )
                 }
             } finally {

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/listdetail/ListDetailScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/listdetail/ListDetailScreen.kt
@@ -316,7 +316,7 @@ private fun ListWordSenseCard(
             pos = item.pos,
             loading = item.loading,
             translationLoading = item.translationLoading,
-            error = item.error?.resolve(),
+            error = item.error,
         ),
         state = SenseUiState(
             senseId = item.senseId,

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/listdetail/ListDetailScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/listdetail/ListDetailScreen.kt
@@ -44,6 +44,7 @@ import com.slovy.slovymovyapp.speech.LemmaAudioControl
 import com.slovy.slovymovyapp.speech.RowAudioActions
 import com.slovy.slovymovyapp.speech.RowAudioUiState
 import com.slovy.slovymovyapp.ui.components.SpinningProgressIndicator
+import com.slovy.slovymovyapp.ui.theme.AppSpacing
 import com.slovy.slovymovyapp.ui.theme.LocalIsDarkTheme
 import com.slovy.slovymovyapp.ui.theme.serifFontFamily
 import com.slovy.slovymovyapp.ui.word.ChapterRule
@@ -124,8 +125,8 @@ internal fun ListDetailErrorScreen(onBack: () -> Unit, onRetry: () -> Unit) {
             modifier = Modifier
                 .fillMaxSize()
                 .padding(innerPadding)
-                .padding(horizontal = 32.dp),
-            verticalArrangement = Arrangement.spacedBy(16.dp, Alignment.CenterVertically),
+                .padding(horizontal = AppSpacing.xxl),
+            verticalArrangement = Arrangement.spacedBy(AppSpacing.lg, Alignment.CenterVertically),
             horizontalAlignment = Alignment.CenterHorizontally,
         ) {
             Text(
@@ -228,14 +229,14 @@ fun ListDetailContent(
             state = scrollState,
             contentPadding = PaddingValues(
                 top = 0.dp,
-                bottom = innerPadding.calculateBottomPadding() + 16.dp,
-                start = 16.dp,
-                end = 16.dp,
+                bottom = innerPadding.calculateBottomPadding() + AppSpacing.lg,
+                start = AppSpacing.lg,
+                end = AppSpacing.lg,
             ),
             modifier = Modifier
                 .fillMaxSize()
                 .padding(top = innerPadding.calculateTopPadding()),
-            verticalArrangement = Arrangement.spacedBy(8.dp),
+            verticalArrangement = Arrangement.spacedBy(AppSpacing.sm),
         ) {
             item {
                 ListDetailHeader(
@@ -258,7 +259,7 @@ fun ListDetailContent(
             if (state.isLoading) {
                 item {
                     Box(
-                        modifier = Modifier.fillMaxWidth().padding(top = 32.dp),
+                        modifier = Modifier.fillMaxWidth().padding(top = AppSpacing.xxl),
                         contentAlignment = Alignment.Center
                     ) {
                         SpinningProgressIndicator()
@@ -271,7 +272,9 @@ fun ListDetailContent(
                         style = MaterialTheme.typography.bodyMedium,
                         color = MaterialTheme.colorScheme.onSurfaceVariant,
                         textAlign = TextAlign.Center,
-                        modifier = Modifier.fillMaxWidth().padding(top = 32.dp, start = 16.dp, end = 16.dp),
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(top = AppSpacing.xxl, start = AppSpacing.lg, end = AppSpacing.lg),
                     )
                 }
             } else {
@@ -359,10 +362,10 @@ private fun ListDetailHeader(
     Column(
         modifier = Modifier
             .fillMaxWidth()
-            .padding(top = 4.dp, bottom = 4.dp),
+            .padding(top = AppSpacing.xs, bottom = AppSpacing.xs),
     ) {
         Row(
-            horizontalArrangement = Arrangement.spacedBy(16.dp),
+            horizontalArrangement = Arrangement.spacedBy(AppSpacing.lg),
             verticalAlignment = Alignment.Top,
             modifier = Modifier.fillMaxWidth(),
         ) {
@@ -404,7 +407,7 @@ private fun ListDetailHeader(
                         fontFamily = MaterialTheme.serifFontFamily,
                         lineHeight = (13.5f * 1.38f).sp,
                         color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        modifier = Modifier.padding(top = 4.dp),
+                        modifier = Modifier.padding(top = AppSpacing.xs),
                     )
                 }
                 val inMyWordsText = stringResource(Res.string.list_detail_in_my_words_count, inMyWordsCount)
@@ -448,14 +451,14 @@ private fun ListDetailHeader(
                             modifier = Modifier.size(14.dp),
                             strokeWidth = 2.dp,
                         )
-                        Spacer(Modifier.width(8.dp))
+                        Spacer(Modifier.width(AppSpacing.sm))
                     } else if (!allInMyWords) {
                         Icon(
                             imageVector = Icons.Default.Add,
                             contentDescription = null,
                             modifier = Modifier.size(18.dp),
                         )
-                        Spacer(Modifier.width(4.dp))
+                        Spacer(Modifier.width(AppSpacing.xs))
                     }
                     Text(
                         text = stringResource(
@@ -468,7 +471,7 @@ private fun ListDetailHeader(
             }
         }
 
-        Spacer(Modifier.height(4.dp))
+        Spacer(Modifier.height(AppSpacing.xs))
         ChapterRule()
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/reader/TextReaderScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/reader/TextReaderScreen.kt
@@ -44,6 +44,7 @@ import com.slovy.slovymovyapp.data.remote.SenseFrequency
 import com.slovy.slovymovyapp.ui.ThemePreviewProvider
 import com.slovy.slovymovyapp.ui.ThemedPreview
 import com.slovy.slovymovyapp.ui.components.SpinningProgressIndicator
+import com.slovy.slovymovyapp.ui.theme.AppSpacing
 import com.slovy.slovymovyapp.ui.theme.serifFontFamily
 import com.slovy.slovymovyapp.ui.theme.uiItalic
 import com.slovy.slovymovyapp.ui.word.ClipboardVector
@@ -349,13 +350,13 @@ private fun InputView(
     Column(
         modifier = modifier
             .fillMaxSize()
-            .padding(start = 16.dp, end = 16.dp, top = 8.dp, bottom = 16.dp),
+            .padding(start = AppSpacing.lg, end = AppSpacing.lg, top = AppSpacing.sm, bottom = AppSpacing.lg),
         verticalArrangement = Arrangement.spacedBy(14.dp)
     ) {
         val dashColor = MaterialTheme.colorScheme.outline.copy(alpha = 0.55f)
         Column(
             horizontalAlignment = Alignment.CenterHorizontally,
-            verticalArrangement = Arrangement.spacedBy(16.dp, Alignment.CenterVertically),
+            verticalArrangement = Arrangement.spacedBy(AppSpacing.lg, Alignment.CenterVertically),
             modifier = Modifier
                 .weight(1f)
                 .fillMaxWidth()
@@ -585,7 +586,7 @@ private fun FrequencyLegend() {
             modifier = Modifier.clearAndSetSemantics {}
         )
         Row(
-            horizontalArrangement = Arrangement.spacedBy(8.dp),
+            horizontalArrangement = Arrangement.spacedBy(AppSpacing.sm),
             verticalAlignment = Alignment.CenterVertically,
             modifier = Modifier.clearAndSetSemantics {}
         ) {

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/search/ListCard.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/search/ListCard.kt
@@ -20,6 +20,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.sp
 import com.slovy.slovymovyapp.data.lists.WordList
 import androidx.compose.ui.unit.dp
+import com.slovy.slovymovyapp.ui.theme.AppSpacing
 import com.slovy.slovymovyapp.ui.theme.serifFontFamily
 import kotlinx.coroutines.flow.*
 import org.jetbrains.compose.resources.pluralStringResource
@@ -76,7 +77,7 @@ internal fun ListCard(
         Row(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(16.dp),
+                .padding(AppSpacing.lg),
             horizontalArrangement = Arrangement.spacedBy(14.dp),
             verticalAlignment = Alignment.CenterVertically,
         ) {

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/search/SearchEmptyStates.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/search/SearchEmptyStates.kt
@@ -33,6 +33,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.sp
 import com.slovy.slovymovyapp.data.lists.WordList
 import com.slovy.slovymovyapp.ui.components.SpinningProgressIndicator
+import com.slovy.slovymovyapp.ui.theme.AppSpacing
 import com.slovy.slovymovyapp.ui.word.ClipboardVector
 import com.slovy.slovymovyapp.ui.word.FavoriteAccentColor
 import androidx.compose.ui.unit.dp
@@ -74,9 +75,9 @@ internal fun EmptySearchState(
         modifier = Modifier
             .fillMaxSize()
             .verticalScroll(rememberScrollState())
-            .padding(horizontal = 16.dp)
-            .padding(top = 4.dp, bottom = 16.dp),
-        verticalArrangement = Arrangement.spacedBy(8.dp)
+            .padding(horizontal = AppSpacing.lg)
+            .padding(top = AppSpacing.xs, bottom = AppSpacing.lg),
+        verticalArrangement = Arrangement.spacedBy(AppSpacing.sm)
     ) {
         if (wordSuggestions.isNotEmpty()) {
             Text(
@@ -93,8 +94,8 @@ internal fun EmptySearchState(
                 modifier = Modifier
                     .fillMaxWidth()
                     .padding(top = 2.dp),
-                horizontalArrangement = Arrangement.spacedBy(8.dp),
-                verticalArrangement = Arrangement.spacedBy(8.dp)
+                horizontalArrangement = Arrangement.spacedBy(AppSpacing.sm),
+                verticalArrangement = Arrangement.spacedBy(AppSpacing.sm)
             ) {
                 wordSuggestions.forEach { lemma ->
                     WordChip(lemma = lemma, onClick = { onWordClick(lemma) })
@@ -154,7 +155,7 @@ internal fun EmptySearchState(
                 onClick = onSuggestListClick,
                 modifier = Modifier
                     .align(Alignment.CenterHorizontally)
-                    .padding(top = 4.dp),
+                    .padding(top = AppSpacing.xs),
                 colors = ButtonDefaults.textButtonColors(
                     contentColor = MaterialTheme.colorScheme.onSurfaceVariant
                 )
@@ -205,7 +206,7 @@ internal fun EmptySearchState(
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(top = 32.dp),
+                    .padding(top = AppSpacing.xxl),
                 textAlign = TextAlign.Center
             )
         }
@@ -225,7 +226,7 @@ private fun ReadSection(onClick: () -> Unit) {
     val shape = RoundedCornerShape(16.dp)
     // Warm but flat: a 16% primary wash over the container, no border, no shadow/glow.
     val rowFill = lerp(MaterialTheme.colorScheme.surfaceContainer, primary, 0.16f)
-    Column(modifier = Modifier.padding(bottom = 4.dp)) {
+    Column(modifier = Modifier.padding(bottom = AppSpacing.xs)) {
         Text(
             text = stringResource(Res.string.search_add_words).uppercase(),
             style = MaterialTheme.typography.labelSmall.copy(
@@ -353,7 +354,7 @@ internal fun NoDictionaryState(
         Column(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(horizontal = 32.dp),
+                .padding(horizontal = AppSpacing.xxl),
             horizontalAlignment = Alignment.CenterHorizontally,
         ) {
             Image(

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/search/SearchScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/search/SearchScreen.kt
@@ -26,6 +26,7 @@ import androidx.compose.ui.semantics.role
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import com.slovy.slovymovyapp.data.lists.WordList
+import com.slovy.slovymovyapp.ui.theme.AppSpacing
 import com.slovy.slovymovyapp.ui.word.DownloadVector
 import androidx.compose.ui.unit.dp
 import com.slovy.slovymovyapp.analytics.Analytics
@@ -180,9 +181,9 @@ fun SearchScreenContent(
                 Row(
                     modifier = Modifier
                         .fillMaxWidth()
-                        .padding(horizontal = 16.dp)
-                        .padding(top = 16.dp),
-                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                        .padding(horizontal = AppSpacing.lg)
+                        .padding(top = AppSpacing.lg),
+                    horizontalArrangement = Arrangement.spacedBy(AppSpacing.sm),
                     verticalAlignment = Alignment.CenterVertically
                 ) {
                     // Search field
@@ -251,8 +252,8 @@ fun SearchScreenContent(
                         else -> {
                             LazyColumn(
                                 modifier = Modifier.fillMaxSize(),
-                                verticalArrangement = Arrangement.spacedBy(8.dp),
-                                contentPadding = PaddingValues(16.dp),
+                                verticalArrangement = Arrangement.spacedBy(AppSpacing.sm),
+                                contentPadding = PaddingValues(AppSpacing.lg),
                                 state = state.scrollState
                             ) {
                                 items(state.results) { item ->
@@ -323,7 +324,7 @@ private fun SearchResultCard(
             )
 
             Row(
-                horizontalArrangement = Arrangement.spacedBy(12.dp),
+                horizontalArrangement = Arrangement.spacedBy(AppSpacing.md),
                 verticalAlignment = Alignment.CenterVertically
             ) {
                 if (showLanguageIndicator) {

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/search/SearchViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/search/SearchViewModel.kt
@@ -19,12 +19,12 @@ import com.slovy.slovymovyapp.analytics.useWithResult
 import com.slovy.slovymovyapp.data.Language
 import com.slovy.slovymovyapp.data.remote.DictionaryClient
 import com.slovy.slovymovyapp.data.remote.DictionaryRepository
-import com.slovy.slovymovyapp.data.remote.NetworkErrorClassifier
 import com.slovy.slovymovyapp.data.settings.Setting
 import com.slovy.slovymovyapp.data.settings.SettingsRepository
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.jsonPrimitive
 import com.slovy.slovymovyapp.i18n.UiText
+import com.slovy.slovymovyapp.i18n.networkErrorUiText
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -270,7 +270,7 @@ class SearchViewModel(
             } catch (e: Exception) {
                 state = state.copy(
                     listSuggestion = state.listSuggestion.submissionFailed(
-                        UiText.Plain(NetworkErrorClassifier.userMessage(e))
+                        networkErrorUiText(e)
                     )
                 )
             }

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/settings/SettingsViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/settings/SettingsViewModel.kt
@@ -16,6 +16,7 @@ import com.slovy.slovymovyapp.data.remote.*
 import com.slovy.slovymovyapp.data.settings.Setting
 import com.slovy.slovymovyapp.data.settings.SettingsRepository
 import com.slovy.slovymovyapp.i18n.UiText
+import com.slovy.slovymovyapp.i18n.networkErrorUiText
 import com.slovy.slovymovyapp.logging.AppLogger
 import com.slovy.slovymovyapp.speech.*
 import kotlinx.coroutines.CancellationException
@@ -319,7 +320,7 @@ class SettingsViewModel(
                 state = state.copy(
                     isLoadingAvailable = false,
                     isLoading = false,
-                    errorMessage = UiText.Plain(NetworkErrorClassifier.userMessage(e))
+                    errorMessage = networkErrorUiText(e)
                 )
             }
         }
@@ -663,7 +664,7 @@ class SettingsViewModel(
                 throw e
             } catch (e: Exception) {
                 state = state.copy(
-                    errorMessage = UiText.Plain(NetworkErrorClassifier.userMessage(e))
+                    errorMessage = networkErrorUiText(e)
                 )
             }
         }
@@ -934,16 +935,22 @@ class SettingsViewModel(
             } catch (e: Exception) {
                 state = state.copy(
                     feedback = state.feedback.submissionFailed(
-                        UiText.Plain(NetworkErrorClassifier.userMessage(e))
+                        networkErrorUiText(e)
                     )
                 )
             }
         }
     }
 
-    private fun messageOrUnknown(throwable: Throwable): String {
+    /**
+     * Reason text for the `..._with_reason` templates. These wrap local storage and settings
+     * failures, where the platform's own message ("database is locked", "permission denied") is
+     * the diagnostic worth showing, so it wins over any generic copy. Only a blank message falls
+     * back, and it falls back to the localized "unknown error" rather than an English sentence.
+     */
+    private suspend fun messageOrUnknown(throwable: Throwable): String {
         val message = throwable.message?.takeIf { it.isNotBlank() }
-        return message ?: NetworkErrorClassifier.userMessage(throwable)
+        return message ?: resolveUiText(UiText.Resource(Res.string.common_unknown_error))
     }
 
     private suspend fun resolveUiText(text: UiText): String = when (text) {
@@ -1028,9 +1035,10 @@ class SettingsViewModel(
 
                         DownloadStatus.Failed -> {
                             downloadCoordinator.clear(downloadKey)
-                            val message =
-                                if (entry.error != null) NetworkErrorClassifier.userMessage(entry.error)
-                                else resolveUiText(UiText.Resource(Res.string.common_unknown_error))
+                            val message = resolveUiText(
+                                if (entry.error != null) networkErrorUiText(entry.error)
+                                else UiText.Resource(Res.string.common_unknown_error)
+                            )
                             state = state.copy(errorMessage = errorMessageBuilder(message))
                             onTerminal()
                             cancel()

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/stats/StatsCalendar.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/stats/StatsCalendar.kt
@@ -19,6 +19,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.slovy.slovymovyapp.data.learning.stats.StatsPracticeDay
 import com.slovy.slovymovyapp.data.learning.stats.StatsYearMonth
+import com.slovy.slovymovyapp.ui.theme.AppSpacing
 import com.slovy.slovymovyapp.ui.theme.serifFontFamily
 import com.slovy.slovymovyapp.ui.theme.uiItalic
 import kotlinx.coroutines.flow.first
@@ -36,7 +37,7 @@ internal fun StreakCard(
         shape = RoundedCornerShape(18.dp),
         padding = PaddingValues(horizontal = 14.dp, vertical = 12.dp),
     ) {
-        Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+        Column(verticalArrangement = Arrangement.spacedBy(AppSpacing.md)) {
             Row(
                 modifier = Modifier.fillMaxWidth(),
                 verticalAlignment = Alignment.Bottom,
@@ -218,7 +219,7 @@ private fun CalendarGrid(
                 today = state.today,
                 onStepMonth = onStepMonth,
             )
-            Row(horizontalArrangement = Arrangement.spacedBy(4.dp)) {
+            Row(horizontalArrangement = Arrangement.spacedBy(AppSpacing.xs)) {
                 weekdays.forEach { day ->
                     Text(
                         text = day,
@@ -234,7 +235,7 @@ private fun CalendarGrid(
                 }
             }
             cells.chunked(7).forEach { week ->
-                Row(horizontalArrangement = Arrangement.spacedBy(4.dp)) {
+                Row(horizontalArrangement = Arrangement.spacedBy(AppSpacing.xs)) {
                     week.forEach { day ->
                         CalendarCell(day = day, state = state, modifier = Modifier.weight(1f))
                     }
@@ -243,7 +244,7 @@ private fun CalendarGrid(
             Row(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(top = 4.dp),
+                    .padding(top = AppSpacing.xs),
                 horizontalArrangement = Arrangement.spacedBy(14.dp, Alignment.CenterHorizontally),
                 verticalAlignment = Alignment.CenterVertically,
             ) {
@@ -389,6 +390,6 @@ internal fun SectionHeader(text: String) {
             letterSpacing = 0.1.sp,
         ),
         color = MaterialTheme.colorScheme.primary,
-        modifier = Modifier.padding(start = 4.dp, top = 4.dp, bottom = 0.dp),
+        modifier = Modifier.padding(start = AppSpacing.xs, top = AppSpacing.xs, bottom = 0.dp),
     )
 }

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/stats/StatsCards.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/stats/StatsCards.kt
@@ -32,6 +32,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.slovy.slovymovyapp.data.learning.stats.StatsPipelineStage
 import com.slovy.slovymovyapp.i18n.ShortDuration
+import com.slovy.slovymovyapp.ui.theme.AppSpacing
 import com.slovy.slovymovyapp.ui.theme.serifFontFamily
 import com.slovy.slovymovyapp.ui.theme.uiItalic
 import org.jetbrains.compose.resources.pluralStringResource
@@ -115,7 +116,7 @@ private fun EffortRow(
             softWrap = false,
             modifier = Modifier
                 .weight(1f)
-                .padding(end = 12.dp),
+                .padding(end = AppSpacing.md),
         )
         CountText(
             text = formatCount(cards, isLoading),
@@ -132,7 +133,7 @@ private fun EffortRow(
             softWrap = false,
             modifier = Modifier
                 .width(layout.cardsUnitWidth)
-                .padding(start = 4.dp),
+                .padding(start = AppSpacing.xs),
         )
         Text(
             // Matches the unit labels' metrics, but deliberately not their font: they use the serif
@@ -372,7 +373,7 @@ private fun PipelineBars(pipeline: List<StatsPipelineStage>, isLoading: Boolean)
     }
     val rows = pipeline.map { stage -> stage to stageLabel(stage.id).uppercase() }
     val labelLayout = rememberPipelineLabelLayout(rows.map { (_, label) -> label })
-    Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+    Column(verticalArrangement = Arrangement.spacedBy(AppSpacing.sm)) {
         rows.forEach { (stage, label) ->
             val pct = if (isLoading) {
                 loadingPipelineWidth(stage.id)

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/stats/StatsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/stats/StatsScreen.kt
@@ -13,6 +13,7 @@ import com.slovy.slovymovyapp.analytics.Analytics
 import com.slovy.slovymovyapp.analytics.AnalyticsEvent
 import com.slovy.slovymovyapp.data.Language
 import com.slovy.slovymovyapp.ui.components.LanguageFilterDropdown
+import com.slovy.slovymovyapp.ui.theme.AppSpacing
 import com.slovy.slovymovyapp.ui.theme.serifFontFamily
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.first
@@ -113,8 +114,8 @@ fun StatsScreenContent(
             Column(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(horizontal = 16.dp)
-                    .padding(top = 4.dp, bottom = 16.dp),
+                    .padding(horizontal = AppSpacing.lg)
+                    .padding(top = AppSpacing.xs, bottom = AppSpacing.lg),
                 verticalArrangement = Arrangement.spacedBy(14.dp),
             ) {
                 StreakCard(state = state, onStepMonth = onStepMonth)
@@ -139,7 +140,7 @@ private fun StatsHeader(
             .padding(horizontal = 20.dp)
             .padding(top = 14.dp, bottom = 10.dp),
         verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.spacedBy(12.dp),
+        horizontalArrangement = Arrangement.spacedBy(AppSpacing.md),
     ) {
         Text(
             text = stringResource(Res.string.stats_title),

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/stats/preview/StatsPreviews.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/stats/preview/StatsPreviews.kt
@@ -23,6 +23,7 @@ import com.slovy.slovymovyapp.data.learning.stats.StatsPipelineStage
 import com.slovy.slovymovyapp.data.learning.stats.StatsPipelineStageId
 import com.slovy.slovymovyapp.data.learning.stats.StatsPracticeDay
 import com.slovy.slovymovyapp.data.learning.stats.StatsYearMonth
+import com.slovy.slovymovyapp.ui.theme.AppSpacing
 import kotlinx.coroutines.flow.first
 import kotlinx.datetime.LocalDate
 import slovymovyapp.composeapp.generated.resources.*
@@ -147,8 +148,8 @@ private fun PipelineStageLabelAutoSizePreview(
         Surface {
             val labelLayout = rememberPipelineLabelLayout(samples)
             Column(
-                modifier = Modifier.padding(16.dp),
-                verticalArrangement = Arrangement.spacedBy(8.dp),
+                modifier = Modifier.padding(AppSpacing.lg),
+                verticalArrangement = Arrangement.spacedBy(AppSpacing.sm),
             ) {
                 samples.forEach { label ->
                     Row(verticalAlignment = Alignment.CenterVertically) {

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/study/PipelineShiftCompleteHero.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/study/PipelineShiftCompleteHero.kt
@@ -55,7 +55,7 @@ internal fun PipelineShiftCompleteHero(
         Column(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(16.dp),
+                .padding(AppSpacing.lg),
             verticalArrangement = Arrangement.spacedBy(AppSpacing.md),
         ) {
             Text(

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/study/StudySessionScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/study/StudySessionScreen.kt
@@ -571,7 +571,7 @@ internal fun StudySessionSnackbarHost(
         hostState = hostState,
         modifier = modifier
             .fillMaxWidth()
-            .padding(12.dp),
+            .padding(AppSpacing.md),
     ) { data ->
         StudySessionSnackbar(data = data)
     }
@@ -606,8 +606,8 @@ private fun StudySessionSnackbar(
             modifier = Modifier
                 .fillMaxWidth()
                 .heightIn(min = 48.dp)
-                .padding(horizontal = AppSpacing.lg, vertical = 8.dp),
-            horizontalArrangement = Arrangement.spacedBy(12.dp),
+                .padding(horizontal = AppSpacing.lg, vertical = AppSpacing.sm),
+            horizontalArrangement = Arrangement.spacedBy(AppSpacing.md),
             verticalAlignment = Alignment.CenterVertically,
         ) {
             Text(
@@ -2101,7 +2101,7 @@ private fun HintRevealPill(
     ) {
         Row(
             verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.spacedBy(8.dp),
+            horizontalArrangement = Arrangement.spacedBy(AppSpacing.sm),
         ) {
             Icon(
                 imageVector = Icons.Filled.VpnKey,

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/word/EntryCard.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/word/EntryCard.kt
@@ -30,6 +30,7 @@ import com.slovy.slovymovyapp.data.remote.FormsSchemeView
 import com.slovy.slovymovyapp.data.remote.LanguageCardPosEntry
 import com.slovy.slovymovyapp.data.remote.LanguageCardResponseSense
 import com.slovy.slovymovyapp.data.remote.RelatedWord
+import com.slovy.slovymovyapp.i18n.UiText
 import com.slovy.slovymovyapp.ui.components.PartOfSpeechIndicator
 import org.jetbrains.compose.resources.stringResource
 import slovymovyapp.composeapp.generated.resources.*
@@ -504,9 +505,9 @@ internal fun EntryCard(
     entry: LanguageCardPosEntry,
     entryState: EntryUiState,
     cardLoading: Boolean = false,
-    cardError: String? = null,
+    cardError: UiText? = null,
     translationLoading: Boolean = false,
-    translationError: String? = null,
+    translationError: UiText? = null,
     onFormsToggle: () -> Unit,
     onFormsViewSelect: (String) -> Unit,
     onSenseToggle: (String) -> Unit,

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/word/EntryCard.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/word/EntryCard.kt
@@ -32,6 +32,7 @@ import com.slovy.slovymovyapp.data.remote.LanguageCardResponseSense
 import com.slovy.slovymovyapp.data.remote.RelatedWord
 import com.slovy.slovymovyapp.i18n.UiText
 import com.slovy.slovymovyapp.ui.components.PartOfSpeechIndicator
+import com.slovy.slovymovyapp.ui.theme.AppSpacing
 import org.jetbrains.compose.resources.stringResource
 import slovymovyapp.composeapp.generated.resources.*
 import kotlin.math.max
@@ -375,7 +376,7 @@ private fun FormsModeSelector(
     val scrollState = rememberScrollState()
     Row(
         modifier = Modifier.horizontalScroll(scrollState),
-        horizontalArrangement = Arrangement.spacedBy(8.dp)
+        horizontalArrangement = Arrangement.spacedBy(AppSpacing.sm)
     ) {
         formsViews.forEach { formsView ->
             val viewId = formsView.view.viewId
@@ -441,7 +442,7 @@ private fun GrammarSection(
     val selectedViewIdResolved = selectedFormsView.view.viewId
     val shape = RoundedCornerShape(14.dp)
 
-    Column(modifier = modifier, verticalArrangement = Arrangement.spacedBy(8.dp)) {
+    Column(modifier = modifier, verticalArrangement = Arrangement.spacedBy(AppSpacing.sm)) {
         if (showToggleButton) Surface(
             modifier = Modifier
                 .clip(shape)
@@ -485,7 +486,7 @@ private fun GrammarSection(
         ) {
             Column(
                 modifier = Modifier.padding(start = 6.dp, top = 2.dp),
-                verticalArrangement = Arrangement.spacedBy(8.dp)
+                verticalArrangement = Arrangement.spacedBy(AppSpacing.sm)
             ) {
                 if (formsViews.size > 1) {
                     FormsModeSelector(
@@ -524,9 +525,9 @@ internal fun EntryCard(
         Row(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(horizontal = 4.dp, vertical = 4.dp),
+                .padding(horizontal = AppSpacing.xs, vertical = AppSpacing.xs),
             verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.spacedBy(12.dp)
+            horizontalArrangement = Arrangement.spacedBy(AppSpacing.md)
         ) {
             PartOfSpeechIndicator(
                 pos = entry.pos,
@@ -581,8 +582,8 @@ internal fun EntryCard(
             Column(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(top = if (entry.formsViews.isEmpty()) 8.dp else 0.dp, bottom = 0.dp),
-                verticalArrangement = Arrangement.spacedBy(8.dp)
+                    .padding(top = if (entry.formsViews.isEmpty()) AppSpacing.sm else 0.dp, bottom = 0.dp),
+                verticalArrangement = Arrangement.spacedBy(AppSpacing.sm)
             ) {
                 // Grammar section - indented under POS header
                 if (entry.formsViews.isNotEmpty()) {
@@ -592,7 +593,7 @@ internal fun EntryCard(
                         expanded = entryState.formsExpanded,
                         onToggle = onFormsToggle,
                         onFormsViewSelect = onFormsViewSelect,
-                        modifier = Modifier.padding(horizontal = 8.dp),
+                        modifier = Modifier.padding(horizontal = AppSpacing.sm),
                         showToggleButton = false
                     )
                 }

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/word/SenseCard.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/word/SenseCard.kt
@@ -38,6 +38,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.em
 import com.slovy.slovymovyapp.data.Language
 import com.slovy.slovymovyapp.data.remote.*
+import com.slovy.slovymovyapp.i18n.UiText
 import com.slovy.slovymovyapp.speech.LemmaAudioControl
 import com.slovy.slovymovyapp.speech.RowAudioPhase
 import com.slovy.slovymovyapp.ui.SpeakerVector
@@ -58,9 +59,9 @@ data class SenseCardData(
     val sense: LanguageCardResponseSense? = null,
     val pos: PartOfSpeech? = null,
     val loading: Boolean = false,
-    val error: String? = null,
+    val error: UiText? = null,
     val translationLoading: Boolean = false,
-    val translationError: String? = null,
+    val translationError: UiText? = null,
     val diagnosticInfoOnError: String? = null,
     val ambiguousTranslations: Set<String> = emptySet(),
     // Summary shown while the full sense is not loaded (e.g. list rows before expansion).

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/word/SenseCard.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/word/SenseCard.kt
@@ -46,6 +46,7 @@ import com.slovy.slovymovyapp.ui.components.SpinningProgressIndicator
 import com.slovy.slovymovyapp.ui.components.appendWithCenteredBullets
 import com.slovy.slovymovyapp.ui.components.appendWithMutedCenteredBullets
 import com.slovy.slovymovyapp.ui.components.centeredBulletInlineContent
+import com.slovy.slovymovyapp.ui.theme.AppSpacing
 import com.slovy.slovymovyapp.ui.theme.LocalIsDarkTheme
 import com.slovy.slovymovyapp.ui.theme.serifFontFamily
 import org.jetbrains.compose.resources.stringResource
@@ -112,7 +113,7 @@ internal fun SenseCard(
             ) {
                 Column(
                     modifier = Modifier.weight(1f),
-                    verticalArrangement = Arrangement.spacedBy(8.dp)
+                    verticalArrangement = Arrangement.spacedBy(AppSpacing.sm)
                 ) {
                     when {
                         data.error != null -> {
@@ -164,7 +165,7 @@ internal fun SenseCard(
 
                         Row(
                             verticalAlignment = Alignment.CenterVertically,
-                            horizontalArrangement = Arrangement.spacedBy(8.dp)
+                            horizontalArrangement = Arrangement.spacedBy(AppSpacing.sm)
                         ) {
                             LevelAndFrequencyRow(
                                 level = sense.learnerLevel,
@@ -197,7 +198,7 @@ internal fun SenseCard(
                 }
 
                 Row(
-                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    horizontalArrangement = Arrangement.spacedBy(AppSpacing.sm),
                     verticalAlignment = Alignment.CenterVertically
                 ) {
                     if (state.showFavoriteToggle) {
@@ -242,11 +243,16 @@ internal fun SenseCard(
                         Column(
                             modifier = Modifier
                                 .fillMaxWidth()
-                                .padding(start = 16.dp, end = 16.dp, top = 8.dp, bottom = 16.dp),
-                            verticalArrangement = Arrangement.spacedBy(16.dp)
+                                .padding(
+                                    start = AppSpacing.lg,
+                                    end = AppSpacing.lg,
+                                    top = AppSpacing.sm,
+                                    bottom = AppSpacing.lg,
+                                ),
+                            verticalArrangement = Arrangement.spacedBy(AppSpacing.lg)
                         ) {
                             if (sense.targetLangDefinitions.isNotEmpty()) {
-                                Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                                Column(verticalArrangement = Arrangement.spacedBy(AppSpacing.sm)) {
                                     SectionLabel(stringResource(Res.string.word_details_definition))
                                     Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
                                         HighlightedText(
@@ -278,7 +284,7 @@ internal fun SenseCard(
                             }
 
                             if (sense.examples.isNotEmpty()) {
-                                Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                                Column(verticalArrangement = Arrangement.spacedBy(AppSpacing.sm)) {
                                     SectionLabel(text = stringResource(Res.string.word_details_examples))
                                     Column(verticalArrangement = Arrangement.spacedBy(20.dp)) {
                                         sense.examples.forEach { ex ->
@@ -333,14 +339,14 @@ internal fun SenseCard(
             ) {
                 Column {
                     HorizontalDivider(
-                        modifier = Modifier.padding(horizontal = 16.dp),
+                        modifier = Modifier.padding(horizontal = AppSpacing.lg),
                         color = MaterialTheme.colorScheme.outlineVariant
                     )
                     Row(
                         modifier = Modifier
                             .fillMaxWidth()
                             .clickable { onViewFullDetails?.invoke() }
-                            .padding(horizontal = 16.dp, vertical = 12.dp),
+                            .padding(horizontal = AppSpacing.lg, vertical = AppSpacing.md),
                         verticalAlignment = Alignment.CenterVertically
                     ) {
                         Text(
@@ -446,14 +452,14 @@ internal fun TraitsList(traits: List<LanguageCardTrait>) {
     if (traits.isEmpty()) return
     Column(
         modifier = Modifier.fillMaxWidth(),
-        verticalArrangement = Arrangement.spacedBy(8.dp)
+        verticalArrangement = Arrangement.spacedBy(AppSpacing.sm)
     ) {
         SectionLabel(stringResource(Res.string.word_details_usage_context))
         Column(
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(start = 11.dp),
-            verticalArrangement = Arrangement.spacedBy(12.dp)
+            verticalArrangement = Arrangement.spacedBy(AppSpacing.md)
         ) {
             traits.forEach { trait ->
                 val traitName = stringResource(trait.traitType.displayName)
@@ -495,7 +501,7 @@ internal fun ExampleItem(
 ) {
     Row(
         modifier = modifier.height(IntrinsicSize.Min),
-        horizontalArrangement = Arrangement.spacedBy(8.dp)
+        horizontalArrangement = Arrangement.spacedBy(AppSpacing.sm)
     ) {
         Box(
             modifier = Modifier
@@ -562,7 +568,7 @@ internal fun LevelAndFrequencyRow(
 ) {
     Row(
         modifier = Modifier.fillMaxWidth(),
-        horizontalArrangement = Arrangement.spacedBy(8.dp),
+        horizontalArrangement = Arrangement.spacedBy(AppSpacing.sm),
         verticalAlignment = Alignment.CenterVertically
     ) {
         val (lc, lcc) = colorsForLevel(level)

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/word/WordDetailsComponents.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/word/WordDetailsComponents.kt
@@ -20,6 +20,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import com.slovy.slovymovyapp.i18n.UiText
 import com.slovy.slovymovyapp.i18n.resolve
+import com.slovy.slovymovyapp.ui.theme.AppSpacing
 import com.slovy.slovymovyapp.ui.theme.serifFontFamily
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.unit.Dp
@@ -51,7 +52,7 @@ internal fun SectionLabel(text: String) {
             letterSpacing = 1.2.sp,
         ),
         color = MaterialTheme.colorScheme.onSurfaceVariant,
-        modifier = Modifier.padding(top = 4.dp)
+        modifier = Modifier.padding(top = AppSpacing.xs)
     )
 }
 
@@ -63,7 +64,7 @@ internal fun LoadingPlaceholder(
 ) {
     Row(
         modifier = modifier,
-        horizontalArrangement = Arrangement.spacedBy(8.dp),
+        horizontalArrangement = Arrangement.spacedBy(AppSpacing.sm),
         verticalAlignment = Alignment.CenterVertically
     ) {
         LoadingIndicator(
@@ -85,7 +86,7 @@ internal fun ErrorPlaceholder(
 ) {
     Row(
         modifier = modifier,
-        horizontalArrangement = Arrangement.spacedBy(8.dp),
+        horizontalArrangement = Arrangement.spacedBy(AppSpacing.sm),
         verticalAlignment = Alignment.CenterVertically
     ) {
         ErrorIcon(Modifier.size(20.dp))
@@ -122,7 +123,7 @@ internal fun EntryList(
     chipSpacing: Dp = 6.dp
 ) {
     if (values.isEmpty()) return
-    Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+    Column(verticalArrangement = Arrangement.spacedBy(AppSpacing.sm)) {
         SectionLabel(label)
         FlowRow(
             modifier = Modifier.fillMaxWidth(),

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/word/WordDetailsComponents.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/word/WordDetailsComponents.kt
@@ -18,6 +18,8 @@ import androidx.compose.ui.text.*
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
+import com.slovy.slovymovyapp.i18n.UiText
+import com.slovy.slovymovyapp.i18n.resolve
 import com.slovy.slovymovyapp.ui.theme.serifFontFamily
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.unit.Dp
@@ -78,7 +80,7 @@ internal fun LoadingPlaceholder(
 
 @Composable
 internal fun ErrorPlaceholder(
-    message: String,
+    message: UiText,
     modifier: Modifier = Modifier
 ) {
     Row(
@@ -88,7 +90,7 @@ internal fun ErrorPlaceholder(
     ) {
         ErrorIcon(Modifier.size(20.dp))
         Text(
-            text = message,
+            text = message.resolve(),
             style = MaterialTheme.typography.bodyMedium,
             color = MaterialTheme.colorScheme.error
         )

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/word/WordDetailsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/word/WordDetailsScreen.kt
@@ -58,6 +58,7 @@ import com.slovy.slovymovyapp.ui.FeedbackFormState
 import com.slovy.slovymovyapp.ui.SpeakerVector
 import com.slovy.slovymovyapp.ui.VoiceSetupBottomSheet
 import com.slovy.slovymovyapp.ui.components.SpinningProgressIndicator
+import com.slovy.slovymovyapp.ui.theme.AppSpacing
 import com.slovy.slovymovyapp.ui.theme.serifFontFamily
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.cancel
@@ -1047,7 +1048,7 @@ fun WordDetailScreenContent(
                         Column(
                             modifier = Modifier.fillMaxSize()
                                 .verticalScroll(rememberScrollState())
-                                .padding(24.dp),
+                                .padding(AppSpacing.xl),
                             horizontalAlignment = Alignment.CenterHorizontally,
                             verticalArrangement = Arrangement.Center
                         ) {
@@ -1056,7 +1057,7 @@ fun WordDetailScreenContent(
                             } else if (state.isError) {
                                 ErrorIcon(Modifier.size(30.dp))
                             }
-                            Spacer(Modifier.height(8.dp))
+                            Spacer(Modifier.height(AppSpacing.sm))
                             Text(
                                 text = state.message.resolve(),
                                 style = MaterialTheme.typography.bodyMedium,
@@ -1140,7 +1141,7 @@ private fun WordDetailContent(
                     .fillMaxWidth()
                     .padding(start = 20.dp, end = 12.dp, top = 8.dp, bottom = 4.dp),
                 verticalAlignment = Alignment.Bottom,
-                horizontalArrangement = Arrangement.spacedBy(8.dp)
+                horizontalArrangement = Arrangement.spacedBy(AppSpacing.sm)
             ) {
                 LemmaHeadlineText(
                     lemma = card.lemma,
@@ -1150,7 +1151,7 @@ private fun WordDetailContent(
                     onClick = { if (isPlaying) onStopWord() else onPlayWord() },
                     enabled = canPlay && !isPreparing,
                     modifier = Modifier
-                        .padding(bottom = 4.dp)
+                        .padding(bottom = AppSpacing.xs)
                         .size(36.dp)
                 ) {
                     when {
@@ -1180,7 +1181,7 @@ private fun WordDetailContent(
         Column(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(start = 16.dp, end = 16.dp, top = 8.dp),
+                .padding(start = AppSpacing.lg, end = AppSpacing.lg, top = AppSpacing.sm),
             verticalArrangement = Arrangement.spacedBy(20.dp),
         ) {
 
@@ -1225,8 +1226,8 @@ private fun WordDetailContent(
                 Column(
                     modifier = Modifier
                         .fillMaxWidth()
-                        .padding(horizontal = 8.dp, vertical = 4.dp),
-                    verticalArrangement = Arrangement.spacedBy(12.dp)
+                        .padding(horizontal = AppSpacing.sm, vertical = AppSpacing.xs),
+                    verticalArrangement = Arrangement.spacedBy(AppSpacing.md)
                 ) {
                     EntryList(
                         label = stringResource(Res.string.word_details_word_family),
@@ -1317,7 +1318,7 @@ internal fun ChapterRule() {
         Icon(
             imageVector = ChapterDiamondVector,
             contentDescription = null,
-            modifier = Modifier.padding(horizontal = 8.dp),
+            modifier = Modifier.padding(horizontal = AppSpacing.sm),
             tint = color
         )
         HorizontalDivider(
@@ -1344,16 +1345,16 @@ private fun LemmaHeadlineAutoSizePreview(
             Column(
                 modifier = Modifier
                     .width(360.dp)
-                    .padding(16.dp),
-                verticalArrangement = Arrangement.spacedBy(12.dp),
+                    .padding(AppSpacing.lg),
+                verticalArrangement = Arrangement.spacedBy(AppSpacing.md),
             ) {
                 samples.forEach { lemma ->
                     Row(
                         modifier = Modifier
                             .fillMaxWidth()
-                            .padding(end = 12.dp),
+                            .padding(end = AppSpacing.md),
                         verticalAlignment = Alignment.Bottom,
-                        horizontalArrangement = Arrangement.spacedBy(8.dp),
+                        horizontalArrangement = Arrangement.spacedBy(AppSpacing.sm),
                     ) {
                         LemmaHeadlineText(
                             lemma = lemma,
@@ -1361,7 +1362,7 @@ private fun LemmaHeadlineAutoSizePreview(
                         )
                         Box(
                             modifier = Modifier
-                                .padding(bottom = 4.dp)
+                                .padding(bottom = AppSpacing.xs)
                                 .size(36.dp)
                                 .clip(RoundedCornerShape(18.dp))
                                 .background(MaterialTheme.colorScheme.surfaceContainerHighest),

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/word/WordDetailsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/word/WordDetailsScreen.kt
@@ -51,6 +51,7 @@ import com.slovy.slovymovyapp.data.remote.*
 import com.slovy.slovymovyapp.logging.AppLogger
 import com.slovy.slovymovyapp.speech.*
 import com.slovy.slovymovyapp.i18n.UiText
+import com.slovy.slovymovyapp.i18n.networkErrorUiText
 import com.slovy.slovymovyapp.i18n.resolve
 import com.slovy.slovymovyapp.ui.AppNavigationBar
 import com.slovy.slovymovyapp.ui.FeedbackFormState
@@ -73,7 +74,7 @@ import kotlin.time.Duration.Companion.milliseconds
 sealed interface WordDetailUiState {
     data class Empty(
         val lemma: String? = null,
-        val message: String = "No entries available.",
+        val message: UiText = UiText.Resource(Res.string.word_details_no_entries),
         val isError: Boolean = false,
         val isLoading: Boolean = false,
         val isRefreshing: Boolean = false
@@ -84,9 +85,9 @@ sealed interface WordDetailUiState {
         val entries: List<EntryUiState>,
         val wordFamilyExpanded: Boolean = false,
         val cardLoading: Boolean = false,
-        val cardError: String? = null,
+        val cardError: UiText? = null,
         val translationLoading: Boolean = false,
-        val translationError: String? = null,
+        val translationError: UiText? = null,
         val feedback: FeedbackFormState = FeedbackFormState(),
         val isRefreshing: Boolean = false
     ) : WordDetailUiState
@@ -114,7 +115,7 @@ data class SenseUiState(
     val pos: PartOfSpeech? = null,
     val showFavoriteToggle: Boolean = expanded,
     val translationLoading: Boolean = false,
-    val translationError: String? = null
+    val translationError: UiText? = null
 )
 
 internal fun LanguageCard.toContentUiState(
@@ -285,7 +286,7 @@ class WordDetailViewModel(
     var state by mutableStateOf<WordDetailUiState>(
         WordDetailUiState.Empty(
             lemma = lemma,
-            message = "Loading...",
+            message = UiText.Resource(Res.string.common_loading),
             isLoading = true
         )
     )
@@ -383,7 +384,7 @@ class WordDetailViewModel(
             // Determine where error occurred based on what was loading before
             val wasWordLoading = current?.cardLoading == true
             val wasTranslationLoading = current?.translationLoading == true
-            val errorMessage = result.error?.message
+            val errorMessage = result.error?.let { networkErrorUiText(it) }
 
             val nextState = card.toContentUiState(
                 targetSenseId = targetSenseId,
@@ -403,7 +404,7 @@ class WordDetailViewModel(
         } else if (result.error != null) {
             state = WordDetailUiState.Empty(
                 lemma = lemma,
-                message = result.error.message ?: "Failed to load word",
+                message = networkErrorUiText(result.error),
                 isError = true
             )
         }
@@ -457,14 +458,21 @@ class WordDetailViewModel(
         }
     }
 
+    /**
+     * Error copy for a section that was still loading when the fetch was cancelled. Returns null
+     * for a section that had already finished, so a completed half of the card keeps its content.
+     */
+    private fun cancelledMarker(wasLoading: Boolean): UiText? =
+        if (wasLoading) UiText.Resource(Res.string.common_cancelled) else null
+
     private fun markCancelled() {
         state = when (val s = state) {
             is WordDetailUiState.Empty -> s.copy(isError = true)
             is WordDetailUiState.Content -> s.copy(
                 cardLoading = false,
                 translationLoading = false,
-                cardError = s.cardError ?: if (s.cardLoading) "Cancelled" else null,
-                translationError = s.translationError ?: if (s.translationLoading) "Cancelled" else null
+                cardError = s.cardError ?: cancelledMarker(s.cardLoading),
+                translationError = s.translationError ?: cancelledMarker(s.translationLoading)
             )
         }
     }
@@ -666,7 +674,7 @@ class WordDetailViewModel(
                 val latest = state as? WordDetailUiState.Content ?: return@launch
                 state = latest.copy(
                     feedback = latest.feedback.submissionFailed(
-                        UiText.Plain(NetworkErrorClassifier.userMessage(e))
+                        networkErrorUiText(e)
                     )
                 )
             }
@@ -1050,7 +1058,7 @@ fun WordDetailScreenContent(
                             }
                             Spacer(Modifier.height(8.dp))
                             Text(
-                                text = state.message,
+                                text = state.message.resolve(),
                                 style = MaterialTheme.typography.bodyMedium,
                                 color = MaterialTheme.colorScheme.onSurfaceVariant,
                                 textAlign = TextAlign.Center
@@ -1095,9 +1103,9 @@ private fun WordDetailContent(
     entryStates: List<EntryUiState>,
     modifier: Modifier = Modifier,
     cardLoading: Boolean = false,
-    cardError: String? = null,
+    cardError: UiText? = null,
     translationLoading: Boolean = false,
-    translationError: String? = null,
+    translationError: UiText? = null,
     isPlaying: Boolean = false,
     isPreparing: Boolean = false,
     canPlay: Boolean = false,

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/word/preview/SenseCardSpeakerPreview.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/word/preview/SenseCardSpeakerPreview.kt
@@ -8,11 +8,11 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
-import androidx.compose.ui.unit.dp
 import com.slovy.slovymovyapp.speech.LemmaAudioControl
 import com.slovy.slovymovyapp.speech.RowAudioPhase
 import com.slovy.slovymovyapp.ui.ThemePreviewProvider
 import com.slovy.slovymovyapp.ui.ThemedPreview
+import com.slovy.slovymovyapp.ui.theme.AppSpacing
 import com.slovy.slovymovyapp.ui.word.SenseCard
 import com.slovy.slovymovyapp.ui.word.SenseCardData
 import com.slovy.slovymovyapp.ui.word.SenseUiState
@@ -39,8 +39,8 @@ private fun SenseCardSpeakerStatesPreview(
 ) {
     ThemedPreview(darkTheme = isDark) {
         Column(
-            modifier = Modifier.fillMaxWidth().padding(16.dp),
-            verticalArrangement = Arrangement.spacedBy(8.dp),
+            modifier = Modifier.fillMaxWidth().padding(AppSpacing.lg),
+            verticalArrangement = Arrangement.spacedBy(AppSpacing.sm),
         ) {
             // Idle / preparing / playing speaker states on a normal-length lemma.
             SenseCard(
@@ -72,8 +72,8 @@ private fun SenseCardSpeakerLongWordsPreview(
 ) {
     ThemedPreview(darkTheme = isDark) {
         Column(
-            modifier = Modifier.fillMaxWidth().padding(16.dp),
-            verticalArrangement = Arrangement.spacedBy(8.dp),
+            modifier = Modifier.fillMaxWidth().padding(AppSpacing.lg),
+            verticalArrangement = Arrangement.spacedBy(AppSpacing.sm),
         ) {
             // Spec §3: the lemma is never truncated; the speaker follows the last fragment.
             SenseCard(

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/word/preview/WordDetailsPreview_Basic.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/word/preview/WordDetailsPreview_Basic.kt
@@ -1,6 +1,7 @@
 package com.slovy.slovymovyapp.ui.word.preview
 
 import androidx.compose.runtime.Composable
+import com.slovy.slovymovyapp.i18n.UiText
 import com.slovy.slovymovyapp.ui.ThemePreviewProvider
 import com.slovy.slovymovyapp.ui.ThemedPreview
 import com.slovy.slovymovyapp.ui.word.WordDetailScreenContent
@@ -52,7 +53,7 @@ private fun WordDetailScreenPreviewLoading(
             state = WordDetailUiState.Empty(
                 lemma = "Word",
                 isLoading = true,
-                message = "Loading..."
+                message = UiText.Plain("Loading...")
             )
         )
     }
@@ -68,7 +69,7 @@ private fun WordDetailScreenPreviewError(
             state = WordDetailUiState.Empty(
                 lemma = "Word",
                 isError = true,
-                message = "No such word found"
+                message = UiText.Plain("No such word found")
             )
         )
     }

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/word/preview/WordDetailsPreview_LoadingError.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/word/preview/WordDetailsPreview_LoadingError.kt
@@ -2,6 +2,7 @@ package com.slovy.slovymovyapp.ui.word.preview
 
 import androidx.compose.runtime.Composable
 import com.slovy.slovymovyapp.data.remote.PartOfSpeech
+import com.slovy.slovymovyapp.i18n.UiText
 import com.slovy.slovymovyapp.ui.ThemePreviewProvider
 import com.slovy.slovymovyapp.ui.ThemedPreview
 import com.slovy.slovymovyapp.ui.word.WordDetailScreenContent
@@ -84,7 +85,7 @@ private fun WordDetailScreenPreviewCardError(
             state = WordDetailUiState.Content(
                 card = loadingCard,
                 entries = emptyList(),
-                cardError = "Failed to load card data"
+                cardError = UiText.Plain("Failed to load card data")
             )
         )
     }
@@ -101,7 +102,7 @@ private fun WordDetailScreenPreviewCardErrorMultiPos(
             state = WordDetailUiState.Content(
                 card = loadingCard,
                 entries = emptyList(),
-                cardError = "Network error: Unable to connect"
+                cardError = UiText.Plain("Network error: Unable to connect")
             )
         )
     }
@@ -117,7 +118,7 @@ private fun WordDetailScreenPreviewSenseTranslationError(
         val entriesWithError = base.entries.mapIndexed { idx, entry ->
             if (idx == 0) {
                 entry.copy(senses = entry.senses.mapIndexed { sIdx, sense ->
-                    if (sIdx == 0) sense.copy(translationError = "Failed to translate", expanded = true) else sense
+                    if (sIdx == 0) sense.copy(translationError = UiText.Plain("Failed to translate"), expanded = true) else sense
                 })
             } else entry
         }


### PR DESCRIPTION
## Contributor terms

- [x] I have read and agree to the contributor terms in `CONTRIBUTING.md`.
- [x] I have the right to submit these changes under those terms.

## Summary

Two independent cleanups, one commit each.

### 1. Localize user-facing network and word-detail error copy

`NetworkErrorClassifier` returned hardcoded English for its five error categories, and those strings went straight into snackbars, error screens and card placeholders — so a Russian or Polish user hit *"Something went wrong. Please try again."* in the middle of an otherwise translated app.

Word Details went further and rendered raw exception text: `cardError` and `translationError` were set from `result.error?.message`, which surfaces things like `Raw data for 'foo' (en) not found locally` and `Server error 502: <html>…` as the user-visible copy for a part-of-speech row.

`NetworkError.userMessage` stays English on purpose — it is what lands in exception messages and logs, and `LemmaRecovery` still classifies against it. Anything shown to a person now goes through a new `NetworkError.toUiText()` / `networkErrorUiText(throwable)` pair in `i18n/`.

Converted to `UiText` end to end:

- `WordDetailUiState.Empty.message`, `Content.cardError` / `translationError`
- `SenseUiState.translationError`, `SenseCardData.error` / `translationError`
- `LanguageSetupUiState.errorMessage`
- `ErrorPlaceholder` and `PartOfSpeechIndicator` parameters

Favorites and List Detail already held `UiText` errors and resolved them just to fit `SenseCardData`'s `String` field; those `.resolve()` calls are gone.

The `…_with_reason` templates in Settings keep the platform's own message (`database is locked`) because that is the diagnostic worth showing for a local storage failure. Only the blank-message fallback changed, from an English sentence to the localized "unknown error".

New keys in all 11 locale sets: six `network_error_*`, plus `common_loading`, `common_cancelled` and `word_details_load_failed`. **The non-English translations are machine-authored and worth a native-speaker pass** — particularly CS, TR and ZH.

I did not add the `LoadableUiState` interface the audit suggested. The UI states are genuinely heterogeneous — Download, Word Details and Favorites are sealed hierarchies while Settings, Language Setup, List Detail and Stats are flat data classes — and nothing would consume such an interface polymorphically. It would be abstraction without a caller.

### 2. Use the AppSpacing scale for on-grid padding and gaps

`AppSpacing` has documented a 4dp grid since it was added, but only 29 of 110 UI files used it; everywhere else the same values were spelled as raw `dp` literals, so nothing tied a screen's padding to the scale and drift was invisible in review.

146 literals replaced across 25 files, in spacing positions only: `padding()`, `PaddingValues()`, `Arrangement.spacedBy()`, and `Spacer()` whose modifier is a bare `height()` / `width()`. Sizes, corner radii, borders and elevations keep their literals — a 16dp icon is not "large padding", and rewriting those would assert a relationship that does not exist.

A call is converted only when **every** dp value in it is on the grid. `.padding(start = 22.dp, top = 22.dp, end = 22.dp, bottom = 24.dp)` stays untouched: half-converting it would make a deliberately hand-tuned set look like a scale value next to three strays. `0.dp` does not block a call, since it means "none" and reads fine as-is.

`AppSpacing` now appears in 50 files. Of the 153 grid-valued literals left in `ui/`, 38 are `size()`, 14 `RoundedCornerShape()` and the rest widths, heights and clips — none of them spacing.

I left `AppElevation` alone. 17 of its 27 candidate sites are `defaultElevation = 0.dp`, where the literal is already clearer than `AppElevation.level0`, and one site uses `2.dp`, which is not on that scale at all (`level2` is 3dp). Worth a separate look at whether the elevation scale reflects what the app actually does.

## Testing

- `./gradlew :composeApp:compileKotlinDesktop` — passes
- `./gradlew :composeApp:verifyLocalizationKeys` — passes, all 11 sets at parity
- `./gradlew :composeApp:desktopTest` — 460/465

The 5 failures are `DictionaryClientTest.getWord_*`. They reproduce on a clean baseline in this container with the branch stashed, so they are pre-existing: those tests reach live GitHub and AI backends that this environment has no credentials for.

The spacing rewrite is mechanically proven value-preserving: substituting each `AppSpacing` token back for its dp value reproduces all 25 files byte for byte, the added imports aside.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FCSWCybtaTofzpkNa5cSpW)_