### PR TITLE
Extend the spacing scale to the app's real rhythm and snap the strays

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/components/FrequencyBadge.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/components/FrequencyBadge.kt
@@ -40,7 +40,7 @@ fun FrequencyBadge(
     ) {
         Text(
             text = stringResource(frequency.label),
-            modifier = Modifier.padding(horizontal = AppSpacing.md, vertical = 6.dp),
+            modifier = Modifier.padding(horizontal = AppSpacing.md, vertical = AppSpacing.xsPlus),
             style = MaterialTheme.typography.labelSmall,
             color = textColor
         )

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/components/PartOfSpeechIndicator.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/components/PartOfSpeechIndicator.kt
@@ -140,7 +140,7 @@ fun PartOfSpeechBadge(
                 color = color.copy(alpha = 0.1f),
                 shape = MaterialTheme.shapes.small
             )
-            .padding(horizontal = AppSpacing.md, vertical = 6.dp)
+            .padding(horizontal = AppSpacing.md, vertical = AppSpacing.xsPlus)
     ) {
         Text(
             text = label.replaceFirstChar { it.uppercase() },

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/developer/DeveloperTerminalOverlay.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/developer/DeveloperTerminalOverlay.kt
@@ -133,7 +133,7 @@ fun DeveloperTerminalOverlay(
             modifier = Modifier
                 .align(Alignment.BottomEnd)
                 .navigationBarsPadding()
-                .padding(end = 16.dp, bottom = 88.dp),
+                .padding(end = AppSpacing.lg, bottom = 88.dp),
             onOpen = {
                 syncTerminalLogs()
                 isTerminalOpen = true

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/favorites/FavoritesScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/favorites/FavoritesScreen.kt
@@ -283,7 +283,7 @@ fun FavoritesScreenContent(
                                                     containerColor = MaterialTheme.colorScheme.primary,
                                                     contentColor = MaterialTheme.colorScheme.onPrimary,
                                                 ),
-                                                contentPadding = PaddingValues(horizontal = 28.dp),
+                                                contentPadding = PaddingValues(horizontal = AppSpacing.xlPlus),
                                                 modifier = Modifier
                                                     .height(56.dp)
                                                     .widthIn(min = 220.dp)
@@ -510,7 +510,7 @@ private fun FavoritesEmptyState(
                 containerColor = MaterialTheme.colorScheme.primary,
                 contentColor = MaterialTheme.colorScheme.onPrimary,
             ),
-            contentPadding = PaddingValues(horizontal = 28.dp),
+            contentPadding = PaddingValues(horizontal = AppSpacing.xlPlus),
             modifier = Modifier
                 .height(56.dp)
                 .widthIn(min = 220.dp)

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/favorites/StudyCards.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/favorites/StudyCards.kt
@@ -85,7 +85,7 @@ internal fun StudyDoneCard(
         border = BorderStroke(0.5.dp, MaterialTheme.colorScheme.onSurface.copy(alpha = 0.09f)),
     ) {
         Column(
-            modifier = Modifier.padding(horizontal = 18.dp, vertical = 16.dp),
+            modifier = Modifier.padding(AppSpacing.lg),
         ) {
             Row(
                 modifier = Modifier.fillMaxWidth(),
@@ -151,7 +151,7 @@ internal fun StudyDoneCard(
             }
             if (continueLabel != null) {
                 HorizontalDivider(
-                    modifier = Modifier.padding(top = 13.dp, bottom = 11.dp),
+                    modifier = Modifier.padding(top = AppSpacing.md, bottom = AppSpacing.smPlus),
                     thickness = 0.5.dp,
                     color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.10f),
                 )
@@ -205,12 +205,12 @@ internal fun StudyDueCard(
         Row(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(horizontal = 18.dp, vertical = 16.dp),
+                .padding(AppSpacing.lg),
             verticalAlignment = Alignment.CenterVertically,
         ) {
             Column(
                 modifier = Modifier.weight(1f),
-                verticalArrangement = Arrangement.spacedBy(2.dp),
+                verticalArrangement = Arrangement.spacedBy(AppSpacing.xxs),
             ) {
                 Text(
                     text = stringResource(Res.string.favorites_study_due_title),
@@ -219,7 +219,7 @@ internal fun StudyDueCard(
                     letterSpacing = 1.4.sp,
                     color = MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.7f),
                 )
-                Row(horizontalArrangement = Arrangement.spacedBy(10.dp)) {
+                Row(horizontalArrangement = Arrangement.spacedBy(AppSpacing.smPlus)) {
                     Text(
                         text = pluralStringResource(
                             Res.plurals.favorites_study_due_count,

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/languagesetup/LanguageSetupComponents.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/languagesetup/LanguageSetupComponents.kt
@@ -326,7 +326,7 @@ private fun LanguageSetupOptionRow(
 
                 Spacer(Modifier.width(AppSpacing.md))
 
-                Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
+                Column(verticalArrangement = Arrangement.spacedBy(AppSpacing.xxs)) {
                     Text(
                         text = title,
                         style = MaterialTheme.typography.bodyLarge.copy(

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/listdetail/ListDetailScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/listdetail/ListDetailScreen.kt
@@ -432,7 +432,7 @@ private fun ListDetailHeader(
                     fontSize = 12.sp,
                     fontWeight = FontWeight.Medium,
                     color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.8f),
-                    modifier = Modifier.padding(top = 6.dp),
+                    modifier = Modifier.padding(top = AppSpacing.xsPlus),
                 )
             }
         }

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/reader/TextReaderScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/reader/TextReaderScreen.kt
@@ -351,7 +351,7 @@ private fun InputView(
         modifier = modifier
             .fillMaxSize()
             .padding(start = AppSpacing.lg, end = AppSpacing.lg, top = AppSpacing.sm, bottom = AppSpacing.lg),
-        verticalArrangement = Arrangement.spacedBy(14.dp)
+        verticalArrangement = Arrangement.spacedBy(AppSpacing.mdPlus)
     ) {
         val dashColor = MaterialTheme.colorScheme.outline.copy(alpha = 0.55f)
         Column(
@@ -378,7 +378,7 @@ private fun InputView(
                     onClickLabel = stringResource(Res.string.reader_paste_from_clipboard),
                     role = Role.Button
                 ) { onPaste() }
-                .padding(horizontal = 22.dp, vertical = 24.dp)
+                .padding(horizontal = AppSpacing.lgPlus, vertical = AppSpacing.xl)
                 .semantics(mergeDescendants = true) {}
         ) {
             if (isAnalyzing) {
@@ -485,9 +485,14 @@ private fun ResultView(
             modifier = Modifier
                 .weight(1f)
                 .verticalScroll(scrollState)
-                .padding(start = 20.dp, end = 20.dp, top = 4.dp, bottom = 16.dp),
+                .padding(
+                    start = AppSpacing.lgPlus,
+                    end = AppSpacing.lgPlus,
+                    top = AppSpacing.xs,
+                    bottom = AppSpacing.lg,
+                ),
             horizontalArrangement = Arrangement.spacedBy(1.dp),
-            verticalArrangement = Arrangement.spacedBy(6.dp)
+            verticalArrangement = Arrangement.spacedBy(AppSpacing.xsPlus)
         ) {
             val groups = remember(state.tokens) { groupTokensForRendering(state.tokens) }
             groups.forEach { group ->
@@ -543,13 +548,13 @@ private fun HighlightedWord(
     val semanticDescription = listOfNotNull(savedWord, bandLabelText).joinToString(", ")
     Row(
         verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.spacedBy(3.dp),
+        horizontalArrangement = Arrangement.spacedBy(AppSpacing.xxs),
         modifier = Modifier
             .semantics { contentDescription = semanticDescription }
             .clip(RoundedCornerShape(4.dp))
             .then(if (bandBackground != null) Modifier.background(bandBackground) else Modifier)
             .clickable(onClickLabel = lookUpLabel, role = Role.Button) { onClick() }
-            .padding(horizontal = 4.dp, vertical = 1.dp)
+            .padding(horizontal = AppSpacing.xs, vertical = 1.dp)
     ) {
         if (isFavorite) {
             Text(
@@ -570,9 +575,14 @@ private fun FrequencyLegend() {
     Row(
         modifier = Modifier
             .fillMaxWidth()
-            .padding(start = 20.dp, end = 20.dp, top = 6.dp, bottom = 11.dp)
+            .padding(
+                start = AppSpacing.lgPlus,
+                end = AppSpacing.lgPlus,
+                top = AppSpacing.xsPlus,
+                bottom = AppSpacing.smPlus,
+            )
             .semantics { contentDescription = legendLabel },
-        horizontalArrangement = Arrangement.spacedBy(14.dp),
+        horizontalArrangement = Arrangement.spacedBy(AppSpacing.mdPlus),
         verticalAlignment = Alignment.CenterVertically
     ) {
         Text(
@@ -605,7 +615,7 @@ private fun FrequencyLegend() {
                     modifier = Modifier
                         .clip(RoundedCornerShape(4.dp))
                         .background(bg)
-                        .padding(horizontal = 6.dp, vertical = 2.dp)
+                        .padding(horizontal = AppSpacing.xsPlus, vertical = AppSpacing.xxs)
                 )
             }
         }

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/search/ListCard.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/search/ListCard.kt
@@ -78,12 +78,12 @@ internal fun ListCard(
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(AppSpacing.lg),
-            horizontalArrangement = Arrangement.spacedBy(14.dp),
+            horizontalArrangement = Arrangement.spacedBy(AppSpacing.mdPlus),
             verticalAlignment = Alignment.CenterVertically,
         ) {
             Column(
                 modifier = Modifier.weight(1f),
-                verticalArrangement = Arrangement.spacedBy(6.dp),
+                verticalArrangement = Arrangement.spacedBy(AppSpacing.xsPlus),
             ) {
                 if (badge != null) {
                     Box(
@@ -91,7 +91,7 @@ internal fun ListCard(
                             .clip(RoundedCornerShape(6.dp))
                             .background(hue.copy(alpha = 0.14f))
                             .border(0.5.dp, hue.copy(alpha = 0.35f), RoundedCornerShape(6.dp))
-                            .padding(horizontal = 9.dp, vertical = 3.dp)
+                            .padding(horizontal = AppSpacing.sm, vertical = AppSpacing.xxs)
                     ) {
                         Text(
                             text = badge.uppercase(),
@@ -127,7 +127,7 @@ internal fun ListCard(
                     fontSize = 11.5.sp,
                     fontWeight = FontWeight.Medium,
                     color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.85f),
-                    modifier = Modifier.padding(top = 2.dp),
+                    modifier = Modifier.padding(top = AppSpacing.xxs),
                 )
             }
 

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/search/SearchEmptyStates.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/search/SearchEmptyStates.kt
@@ -88,12 +88,12 @@ internal fun EmptySearchState(
                     fontSize = 10.5.sp,
                 ),
                 color = MaterialTheme.colorScheme.primary,
-                modifier = Modifier.padding(top = 8.dp, bottom = 2.dp)
+                modifier = Modifier.padding(top = AppSpacing.sm, bottom = AppSpacing.xxs)
             )
             FlowRow(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(top = 2.dp),
+                    .padding(top = AppSpacing.xxs),
                 horizontalArrangement = Arrangement.spacedBy(AppSpacing.sm),
                 verticalArrangement = Arrangement.spacedBy(AppSpacing.sm)
             ) {
@@ -104,8 +104,8 @@ internal fun EmptySearchState(
             Row(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(top = 6.dp),
-                horizontalArrangement = Arrangement.spacedBy(7.dp, Alignment.CenterHorizontally),
+                    .padding(top = AppSpacing.xsPlus),
+                horizontalArrangement = Arrangement.spacedBy(AppSpacing.xsPlus, Alignment.CenterHorizontally),
                 verticalAlignment = Alignment.CenterVertically
             ) {
                 Icon(
@@ -139,8 +139,8 @@ internal fun EmptySearchState(
                 ),
                 color = MaterialTheme.colorScheme.primary,
                 modifier = Modifier.padding(
-                    top = if (wordSuggestions.isNotEmpty()) 12.dp else 8.dp,
-                    bottom = 2.dp
+                    top = if (wordSuggestions.isNotEmpty()) AppSpacing.md else AppSpacing.sm,
+                    bottom = AppSpacing.xxs
                 )
             )
             curatedLists.forEachIndexed { index, list ->
@@ -175,9 +175,12 @@ internal fun EmptySearchState(
             Row(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(top = if (wordSuggestions.isNotEmpty()) 12.dp else 8.dp, bottom = 2.dp),
+                    .padding(
+                        top = if (wordSuggestions.isNotEmpty()) AppSpacing.md else AppSpacing.sm,
+                        bottom = AppSpacing.xxs,
+                    ),
                 verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.spacedBy(6.dp)
+                horizontalArrangement = Arrangement.spacedBy(AppSpacing.xsPlus)
             ) {
                 Icon(
                     imageVector = Icons.Filled.Favorite,
@@ -235,7 +238,7 @@ private fun ReadSection(onClick: () -> Unit) {
                 fontSize = 10.5.sp,
             ),
             color = primary,
-            modifier = Modifier.padding(top = 8.dp, bottom = 10.dp)
+            modifier = Modifier.padding(top = AppSpacing.sm, bottom = AppSpacing.smPlus)
         )
         // Min height + real vertical padding so the row grows when a localized label wraps
         // to two lines (e.g. German) instead of crowding or clipping on a fixed height.
@@ -246,8 +249,8 @@ private fun ReadSection(onClick: () -> Unit) {
                 .clip(shape)
                 .background(rowFill)
                 .clickable(onClickLabel = stringResource(Res.string.search_add_words_cd), role = Role.Button) { onClick() }
-                .padding(start = 12.dp, end = 14.dp, top = 12.dp, bottom = 12.dp),
-            horizontalArrangement = Arrangement.spacedBy(13.dp),
+                .padding(start = AppSpacing.md, end = AppSpacing.mdPlus, top = AppSpacing.md, bottom = AppSpacing.md),
+            horizontalArrangement = Arrangement.spacedBy(AppSpacing.md),
             verticalAlignment = Alignment.Top
         ) {
             Box(
@@ -275,7 +278,7 @@ private fun ReadSection(onClick: () -> Unit) {
                 color = MaterialTheme.colorScheme.onSurface,
                 // Centers the first text line (19sp line height) on the 34dp icon tile, so the
                 // icon stays anchored to line one instead of floating mid-gap on two-line copy.
-                modifier = Modifier.weight(1f).padding(top = 7.dp)
+                modifier = Modifier.weight(1f).padding(top = AppSpacing.xsPlus)
             )
         }
     }
@@ -301,7 +304,7 @@ private fun WordChip(lemma: String, onClick: () -> Unit) {
             )
             // Taller vertical padding lifts the tap target without the empty centering gap
             // that a reserved 48dp slot leaves between wrapped rows.
-            .padding(horizontal = 12.dp, vertical = 10.dp)
+            .padding(horizontal = AppSpacing.md, vertical = AppSpacing.smPlus)
     ) {
         Text(
             text = lemma,
@@ -338,7 +341,7 @@ private fun SuggestionCard(lemma: String, onClick: () -> Unit) {
             color = MaterialTheme.colorScheme.onSurface,
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(horizontal = 16.dp, vertical = 14.dp)
+                .padding(horizontal = AppSpacing.lg, vertical = AppSpacing.mdPlus)
         )
     }
 }
@@ -400,7 +403,7 @@ internal fun NoDictionaryState(
                     containerColor = MaterialTheme.colorScheme.primary,
                     contentColor = MaterialTheme.colorScheme.onPrimary,
                 ),
-                contentPadding = PaddingValues(horizontal = 28.dp),
+                contentPadding = PaddingValues(horizontal = AppSpacing.xlPlus),
                 modifier = Modifier
                     .height(56.dp)
                     .widthIn(min = 220.dp)

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/search/SearchScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/search/SearchScreen.kt
@@ -310,7 +310,7 @@ private fun SearchResultCard(
         Row(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(horizontal = 16.dp, vertical = 20.dp),
+                .padding(horizontal = AppSpacing.lg, vertical = AppSpacing.lgPlus),
             verticalAlignment = Alignment.CenterVertically
         ) {
             Text(

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/settings/VoiceSection.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/settings/VoiceSection.kt
@@ -356,7 +356,7 @@ fun VoiceItem(
                         },
                         style = MaterialTheme.typography.labelSmall,
                         color = qualityColor,
-                        modifier = Modifier.padding(horizontal = AppSpacing.sm, vertical = 2.dp)
+                        modifier = Modifier.padding(horizontal = AppSpacing.sm, vertical = AppSpacing.xxs)
                     )
                 }
                 if (voice.networkConnectionRequired) {
@@ -368,7 +368,7 @@ fun VoiceItem(
                             text = stringResource(Res.string.voice_network_online),
                             style = MaterialTheme.typography.labelSmall,
                             color = MaterialTheme.colorScheme.error,
-                            modifier = Modifier.padding(horizontal = AppSpacing.sm, vertical = 2.dp)
+                            modifier = Modifier.padding(horizontal = AppSpacing.sm, vertical = AppSpacing.xxs)
                         )
                     }
                 }

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/stats/StatsCalendar.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/stats/StatsCalendar.kt
@@ -35,7 +35,7 @@ internal fun StreakCard(
 ) {
     StatsCard(
         shape = RoundedCornerShape(18.dp),
-        padding = PaddingValues(horizontal = 14.dp, vertical = 12.dp),
+        padding = PaddingValues(horizontal = AppSpacing.mdPlus, vertical = AppSpacing.md),
     ) {
         Column(verticalArrangement = Arrangement.spacedBy(AppSpacing.md)) {
             Row(
@@ -212,7 +212,7 @@ private fun CalendarGrid(
             modifier = Modifier
                 .widthIn(max = 280.dp)
                 .fillMaxWidth(),
-            verticalArrangement = Arrangement.spacedBy(6.dp),
+            verticalArrangement = Arrangement.spacedBy(AppSpacing.xsPlus),
         ) {
             MonthStepper(
                 viewMonth = state.viewMonth,
@@ -245,7 +245,7 @@ private fun CalendarGrid(
                 modifier = Modifier
                     .fillMaxWidth()
                     .padding(top = AppSpacing.xs),
-                horizontalArrangement = Arrangement.spacedBy(14.dp, Alignment.CenterHorizontally),
+                horizontalArrangement = Arrangement.spacedBy(AppSpacing.mdPlus, Alignment.CenterHorizontally),
                 verticalAlignment = Alignment.CenterVertically,
             ) {
                 LegendDot(
@@ -354,7 +354,7 @@ private fun CalendarCell(
 private fun LegendDot(color: Color, label: String, borderStroke: BorderStroke) {
     val shape = RoundedCornerShape(3.dp)
     Row(
-        horizontalArrangement = Arrangement.spacedBy(5.dp),
+        horizontalArrangement = Arrangement.spacedBy(AppSpacing.xs),
         verticalAlignment = Alignment.CenterVertically,
     ) {
         Box(

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/stats/StatsCards.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/stats/StatsCards.kt
@@ -64,11 +64,11 @@ internal fun EffortCard(state: StatsUiState) {
     )
     StatsCard(
         shape = RoundedCornerShape(16.dp),
-        padding = PaddingValues(horizontal = 16.dp, vertical = 14.dp),
+        padding = PaddingValues(horizontal = AppSpacing.lg, vertical = AppSpacing.mdPlus),
     ) {
         Column(
             modifier = Modifier.fillMaxWidth(),
-            verticalArrangement = Arrangement.spacedBy(13.dp),
+            verticalArrangement = Arrangement.spacedBy(AppSpacing.md),
         ) {
             EffortRow(
                 label = stringResource(Res.string.stats_today_label),
@@ -302,10 +302,10 @@ private fun AnnotatedString.Builder.appendDurationPart(
 internal fun LibraryCard(state: StatsUiState) {
     StatsCard(
         shape = RoundedCornerShape(16.dp),
-        padding = PaddingValues(horizontal = 16.dp, vertical = 14.dp),
+        padding = PaddingValues(horizontal = AppSpacing.lg, vertical = AppSpacing.mdPlus),
     ) {
-        Column(verticalArrangement = Arrangement.spacedBy(14.dp)) {
-            Row(horizontalArrangement = Arrangement.spacedBy(14.dp)) {
+        Column(verticalArrangement = Arrangement.spacedBy(AppSpacing.mdPlus)) {
+            Row(horizontalArrangement = Arrangement.spacedBy(AppSpacing.mdPlus)) {
                 LibraryMetric(
                     value = state.wordsTotal,
                     label = pluralStringResource(Res.plurals.stats_words_label, state.wordsTotal),
@@ -338,7 +338,7 @@ private fun LibraryMetric(
     isLoading: Boolean,
     modifier: Modifier = Modifier,
 ) {
-    Column(modifier = modifier, verticalArrangement = Arrangement.spacedBy(2.dp)) {
+    Column(modifier = modifier, verticalArrangement = Arrangement.spacedBy(AppSpacing.xxs)) {
         CountText(
             text = formatCount(value, isLoading),
             style = MaterialTheme.typography.headlineMedium.copy(
@@ -397,7 +397,7 @@ private fun PipelineBars(pipeline: List<StatsPipelineStage>, isLoading: Boolean)
             )
             Row(
                 verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.spacedBy(10.dp),
+                horizontalArrangement = Arrangement.spacedBy(AppSpacing.smPlus),
             ) {
                 PipelineStageLabel(label = label, layout = labelLayout)
                 Box(
@@ -548,7 +548,7 @@ private fun PipelineCaption() {
             lineHeight = 17.sp,
         ),
         color = MaterialTheme.colorScheme.onSurfaceVariant,
-        modifier = Modifier.padding(top = 2.dp),
+        modifier = Modifier.padding(top = AppSpacing.xxs),
     )
 }
 

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/stats/StatsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/stats/StatsScreen.kt
@@ -116,7 +116,7 @@ fun StatsScreenContent(
                     .fillMaxWidth()
                     .padding(horizontal = AppSpacing.lg)
                     .padding(top = AppSpacing.xs, bottom = AppSpacing.lg),
-                verticalArrangement = Arrangement.spacedBy(14.dp),
+                verticalArrangement = Arrangement.spacedBy(AppSpacing.mdPlus),
             ) {
                 StreakCard(state = state, onStepMonth = onStepMonth)
                 SectionHeader(text = stringResource(Res.string.stats_effort_section))
@@ -137,8 +137,8 @@ private fun StatsHeader(
     Row(
         modifier = Modifier
             .fillMaxWidth()
-            .padding(horizontal = 20.dp)
-            .padding(top = 14.dp, bottom = 10.dp),
+            .padding(horizontal = AppSpacing.lgPlus)
+            .padding(top = AppSpacing.mdPlus, bottom = AppSpacing.smPlus),
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(AppSpacing.md),
     ) {

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/stats/preview/StatsPreviews.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/stats/preview/StatsPreviews.kt
@@ -156,7 +156,7 @@ private fun PipelineStageLabelAutoSizePreview(
                         PipelineStageLabel(label = label, layout = labelLayout)
                         Box(
                             modifier = Modifier
-                                .padding(start = 10.dp)
+                                .padding(start = AppSpacing.smPlus)
                                 .weight(1f)
                                 .height(10.dp)
                                 .clip(RoundedCornerShape(5.dp))

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/study/MilestoneHeroCard.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/study/MilestoneHeroCard.kt
@@ -70,7 +70,12 @@ internal fun MilestoneHeroCard(
             verticalArrangement = Arrangement.spacedBy(AppSpacing.md),
             modifier = Modifier
                 .align(Alignment.Center)
-                .padding(start = 22.dp, top = 22.dp, end = 22.dp, bottom = 24.dp),
+                .padding(
+                    start = AppSpacing.lgPlus,
+                    top = AppSpacing.lgPlus,
+                    end = AppSpacing.lgPlus,
+                    bottom = AppSpacing.xl,
+                ),
         ) {
             val medallionCount by rememberCountUp(
                 target = medallionTarget,

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/study/PipelineShiftCompleteHero.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/study/PipelineShiftCompleteHero.kt
@@ -70,7 +70,7 @@ internal fun PipelineShiftCompleteHero(
                 color = MaterialTheme.colorScheme.onSurface,
                 modifier = Modifier.fillMaxWidth(),
             )
-            Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
+            Column(verticalArrangement = Arrangement.spacedBy(AppSpacing.smPlus)) {
                 stages.forEachIndexed { index, stage ->
                     PipelineShiftRow(
                         stage = stage,
@@ -111,7 +111,7 @@ private fun PipelineShiftRow(
 
     Row(
         verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.spacedBy(10.dp),
+        horizontalArrangement = Arrangement.spacedBy(AppSpacing.smPlus),
         modifier = Modifier.fillMaxWidth(),
     ) {
         Text(

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/study/StudySessionScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/study/StudySessionScreen.kt
@@ -697,7 +697,7 @@ private fun StudySessionProgressLabel(
                 modifier = Modifier.size(14.dp),
                 tint = MaterialTheme.colorScheme.primary,
             )
-            Spacer(Modifier.width(6.dp))
+            Spacer(Modifier.width(AppSpacing.xsPlus))
         }
         Text(
             text = stringResource(
@@ -897,7 +897,7 @@ private fun StudyOverflowMenuItem(
                 }
             }
             Column(
-                verticalArrangement = Arrangement.spacedBy(2.dp),
+                verticalArrangement = Arrangement.spacedBy(AppSpacing.xxs),
             ) {
                 Text(
                     text = label,
@@ -1430,9 +1430,9 @@ private fun CantListenNowButton(
         modifier = modifier
             .clip(RoundedCornerShape(6.dp))
             .clickable(role = Role.Button, onClick = onClick)
-            .padding(horizontal = 10.dp, vertical = 6.dp),
+            .padding(horizontal = AppSpacing.smPlus, vertical = AppSpacing.xsPlus),
         verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.spacedBy(5.dp),
+        horizontalArrangement = Arrangement.spacedBy(AppSpacing.xs),
     ) {
         Icon(
             imageVector = SpeakerOffVector,
@@ -1520,7 +1520,7 @@ private fun StudyCardBackContent(
         verticalArrangement = Arrangement.spacedBy(AppSpacing.md),
     ) {
         back.cloze?.let { cloze ->
-            Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
+            Column(verticalArrangement = Arrangement.spacedBy(AppSpacing.xsPlus)) {
                 StudyClozeText(
                     cloze = cloze,
                     style = MaterialTheme.typography.headlineSmall.copy(
@@ -1583,7 +1583,7 @@ private fun StudyCardBackContent(
         }
 
         back.definition?.let { definition ->
-            Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
+            Column(verticalArrangement = Arrangement.spacedBy(AppSpacing.xsPlus)) {
                 StudyTaggedText(
                     text = definition,
                     style = MaterialTheme.typography.bodyLarge.copy(
@@ -1665,7 +1665,7 @@ private fun StudySynonymsRow(
 
     Column(
         modifier = modifier.fillMaxWidth(),
-        verticalArrangement = Arrangement.spacedBy(6.dp),
+        verticalArrangement = Arrangement.spacedBy(AppSpacing.xsPlus),
     ) {
         Text(
             text = stringResource(Res.string.word_details_synonyms).uppercase(),
@@ -1716,7 +1716,7 @@ private fun SenseDotRow(
 ) {
     Row(
         modifier = modifier,
-        horizontalArrangement = Arrangement.spacedBy(6.dp),
+        horizontalArrangement = Arrangement.spacedBy(AppSpacing.xsPlus),
         verticalAlignment = Alignment.CenterVertically,
     ) {
         repeat(count) { index ->
@@ -1830,7 +1830,7 @@ private fun StudyExampleBlock(
         )
         Column(
             modifier = Modifier.weight(1f),
-            verticalArrangement = Arrangement.spacedBy(6.dp),
+            verticalArrangement = Arrangement.spacedBy(AppSpacing.xsPlus),
         ) {
             StudyExampleText(
                 text = example.text,
@@ -2096,7 +2096,7 @@ private fun HintRevealPill(
                 this.contentDescription = contentDescription
             }
             .clickable(role = Role.Button, onClickLabel = contentDescription) { onReveal() }
-            .padding(horizontal = 14.dp),
+            .padding(horizontal = AppSpacing.mdPlus),
         contentAlignment = Alignment.Center,
     ) {
         Row(
@@ -2156,9 +2156,9 @@ private fun FirstLetterHintView(
         Row(
             modifier = Modifier
                 .fillMaxHeight()
-                .padding(horizontal = 14.dp),
+                .padding(horizontal = AppSpacing.mdPlus),
             verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.spacedBy(6.dp),
+            horizontalArrangement = Arrangement.spacedBy(AppSpacing.xsPlus),
         ) {
             Text(
                 text = hint.letter.toString(),

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/theme/Spacing.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/theme/Spacing.kt
@@ -4,23 +4,41 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 
 /**
- * Consistent spacing scale for layout and padding.
+ * Spacing scale for layout, padding and gaps.
  *
- * Based on 4dp grid system:
- * - xs (4dp): Minimal spacing, tight elements
- * - sm (8dp): Small spacing, compact layouts
- * - md (12dp): Medium spacing, related items
- * - lg (16dp): Large spacing, default padding
- * - xl (24dp): Extra large, section spacing
+ * The scale is a 2dp rhythm in the tight range and a 4dp rhythm from [lg] up, which is what the
+ * screens were already built on. The `…Plus` tokens are the intermediate steps: each one sits
+ * between the token it is named after and the next one up.
+ *
+ * - xxs (2dp): hairline separation inside a component — badge insets, tight vertical gaps
+ * - xs (4dp): minimal spacing, tight elements
+ * - xsPlus (6dp): between xs and sm
+ * - sm (8dp): small spacing, compact layouts
+ * - smPlus (10dp): between sm and md
+ * - md (12dp): medium spacing, related items
+ * - mdPlus (14dp): between md and lg
+ * - lg (16dp): large spacing, default padding
+ * - lgPlus (20dp): between lg and xl
+ * - xl (24dp): extra large, section spacing
+ * - xlPlus (28dp): between xl and xxl
  * - xxl (32dp): XX large, major sections
  * - xxxl (48dp): XXX large, screen padding
+ *
+ * Reach for the nearest step rather than a literal. A raw `dp` value in a padding or gap is a
+ * claim that no step fits, so it should be able to survive the question "why not the neighbour?".
  */
 object AppSpacing {
+    val xxs: Dp = 2.dp
     val xs: Dp = 4.dp
+    val xsPlus: Dp = 6.dp
     val sm: Dp = 8.dp
+    val smPlus: Dp = 10.dp
     val md: Dp = 12.dp
+    val mdPlus: Dp = 14.dp
     val lg: Dp = 16.dp
+    val lgPlus: Dp = 20.dp
     val xl: Dp = 24.dp
+    val xlPlus: Dp = 28.dp
     val xxl: Dp = 32.dp
     val xxxl: Dp = 48.dp
 }

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/word/EntryCard.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/word/EntryCard.kt
@@ -147,7 +147,7 @@ private fun FormsGridCell(cell: GridCell, value: String?) {
                 drawLine(color, Offset(0f, size.height), Offset(size.width, size.height), stroke)
                 drawLine(color, Offset(size.width, 0f), Offset(size.width, size.height), stroke)
             }
-            .padding(horizontal = 8.dp, vertical = 5.dp),
+            .padding(horizontal = AppSpacing.sm, vertical = AppSpacing.xs),
         contentAlignment = contentAlignment
     ) {
         if (text.isNotEmpty()) {
@@ -451,9 +451,9 @@ private fun GrammarSection(
             shape = shape
         ) {
             Row(
-                modifier = Modifier.padding(horizontal = 10.dp, vertical = 6.dp),
+                modifier = Modifier.padding(horizontal = AppSpacing.smPlus, vertical = AppSpacing.xsPlus),
                 verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.spacedBy(5.dp)
+                horizontalArrangement = Arrangement.spacedBy(AppSpacing.xs)
             ) {
                 Icon(
                     imageVector = Icons.AutoMirrored.Outlined.LibraryBooks,
@@ -485,7 +485,7 @@ private fun GrammarSection(
             exit = shrinkVertically() + fadeOut()
         ) {
             Column(
-                modifier = Modifier.padding(start = 6.dp, top = 2.dp),
+                modifier = Modifier.padding(start = AppSpacing.xsPlus, top = AppSpacing.xxs),
                 verticalArrangement = Arrangement.spacedBy(AppSpacing.sm)
             ) {
                 if (formsViews.size > 1) {
@@ -547,10 +547,15 @@ internal fun EntryCard(
                                 RoundedCornerShape(50)
                             )
                             .clickable(role = Role.Button) { onFormsToggle() }
-                            .padding(top = 4.dp, bottom = 4.dp, start = 9.dp, end = 10.dp)
+                            .padding(
+                                top = AppSpacing.xs,
+                                bottom = AppSpacing.xs,
+                                start = AppSpacing.sm,
+                                end = AppSpacing.smPlus,
+                            )
                     ) {
                         Row(
-                            horizontalArrangement = Arrangement.spacedBy(6.dp),
+                            horizontalArrangement = Arrangement.spacedBy(AppSpacing.xsPlus),
                             verticalAlignment = Alignment.CenterVertically
                         ) {
                             Icon(

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/word/SenseCard.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/word/SenseCard.kt
@@ -108,7 +108,7 @@ internal fun SenseCard(
                     .fillMaxWidth()
                     .clip(MaterialTheme.shapes.small)
                     .clickable(onClick = onToggle)
-                    .padding(horizontal = 16.dp, vertical = 14.dp),
+                    .padding(horizontal = AppSpacing.lg, vertical = AppSpacing.mdPlus),
                 verticalAlignment = Alignment.CenterVertically
             ) {
                 Column(
@@ -254,7 +254,7 @@ internal fun SenseCard(
                             if (sense.targetLangDefinitions.isNotEmpty()) {
                                 Column(verticalArrangement = Arrangement.spacedBy(AppSpacing.sm)) {
                                     SectionLabel(stringResource(Res.string.word_details_definition))
-                                    Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
+                                    Column(verticalArrangement = Arrangement.spacedBy(AppSpacing.xsPlus)) {
                                         HighlightedText(
                                             text = sense.targetLangDefinitions.map { definition ->
                                                 definition.value.replaceFirstChar { if (it.isUpperCase()) it.lowercase() else it.toString() }
@@ -286,7 +286,7 @@ internal fun SenseCard(
                             if (sense.examples.isNotEmpty()) {
                                 Column(verticalArrangement = Arrangement.spacedBy(AppSpacing.sm)) {
                                     SectionLabel(text = stringResource(Res.string.word_details_examples))
-                                    Column(verticalArrangement = Arrangement.spacedBy(20.dp)) {
+                                    Column(verticalArrangement = Arrangement.spacedBy(AppSpacing.lgPlus)) {
                                         sense.examples.forEach { ex ->
                                             ExampleItem(
                                                 example = ex,
@@ -458,7 +458,7 @@ internal fun TraitsList(traits: List<LanguageCardTrait>) {
         Column(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(start = 11.dp),
+                .padding(start = AppSpacing.smPlus),
             verticalArrangement = Arrangement.spacedBy(AppSpacing.md)
         ) {
             traits.forEach { trait ->
@@ -511,7 +511,7 @@ internal fun ExampleItem(
                 .background(MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.6f))
         )
         Column(
-            verticalArrangement = Arrangement.spacedBy(6.dp),
+            verticalArrangement = Arrangement.spacedBy(AppSpacing.xsPlus),
             modifier = Modifier.weight(1f)
         ) {
             ExampleText(

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/word/WordDetailsComponents.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/word/WordDetailsComponents.kt
@@ -249,13 +249,15 @@ internal fun Badge(
         } else Modifier
     ) {
         Row(
-            horizontalArrangement = Arrangement.spacedBy(6.dp),
+            horizontalArrangement = Arrangement.spacedBy(AppSpacing.xsPlus),
             verticalAlignment = Alignment.CenterVertically,
             modifier = Modifier.padding(
-                start = if (isClickable && isFavorite) 9.dp else if (isClickable) 11.dp else 12.dp,
-                end = if (isClickable) 8.dp else 12.dp,
-                top = 5.dp,
-                bottom = 5.dp
+                start = if (isClickable && isFavorite) AppSpacing.sm
+                else if (isClickable) AppSpacing.smPlus
+                else AppSpacing.md,
+                end = if (isClickable) AppSpacing.sm else AppSpacing.md,
+                top = AppSpacing.xs,
+                bottom = AppSpacing.xs
             )
         ) {
             if (isFavorite) {
@@ -293,7 +295,7 @@ internal fun MetaBadge(
     Box(
         modifier = Modifier
             .background(containerColor, RoundedCornerShape(4.dp))
-            .padding(horizontal = 8.dp, vertical = 3.dp)
+            .padding(horizontal = AppSpacing.sm, vertical = AppSpacing.xxs)
     ) {
         Text(
             text = text,

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/word/WordDetailsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/ui/word/WordDetailsScreen.kt
@@ -1020,7 +1020,7 @@ fun WordDetailScreenContent(
                         modifier = Modifier
                             .fillMaxSize()
                             .verticalScroll(scrollState)
-                            .padding(bottom = 20.dp),
+                            .padding(bottom = AppSpacing.lgPlus),
                         cardLoading = state.cardLoading,
                         cardError = state.cardError,
                         translationLoading = state.translationLoading,
@@ -1139,7 +1139,12 @@ private fun WordDetailContent(
             Row(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(start = 20.dp, end = 12.dp, top = 8.dp, bottom = 4.dp),
+                    .padding(
+                        start = AppSpacing.lgPlus,
+                        end = AppSpacing.md,
+                        top = AppSpacing.sm,
+                        bottom = AppSpacing.xs,
+                    ),
                 verticalAlignment = Alignment.Bottom,
                 horizontalArrangement = Arrangement.spacedBy(AppSpacing.sm)
             ) {
@@ -1182,7 +1187,7 @@ private fun WordDetailContent(
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(start = AppSpacing.lg, end = AppSpacing.lg, top = AppSpacing.sm),
-            verticalArrangement = Arrangement.spacedBy(20.dp),
+            verticalArrangement = Arrangement.spacedBy(AppSpacing.lgPlus),
         ) {
 
             if (card.entries.isEmpty()) {
@@ -1308,7 +1313,7 @@ internal fun ChapterRule() {
     Row(
         modifier = Modifier
             .fillMaxWidth()
-            .padding(start = 40.dp, end = 40.dp, top = 2.dp, bottom = 4.dp),
+            .padding(start = 40.dp, end = 40.dp, top = AppSpacing.xxs, bottom = AppSpacing.xs),
         verticalAlignment = Alignment.CenterVertically
     ) {
         HorizontalDivider(


### PR DESCRIPTION
## Contributor terms

- [x] I have read and agree to the contributor terms in `CONTRIBUTING.md`.
- [x] I have the right to submit these changes under those terms.

## Summary

Follow-up to #866, which converted only the padding that already sat on the documented 4dp grid. That left 114 `dp` literals in spacing positions, and looking at them changed the diagnosis.

**They were not noise.** `6.dp` appears at 24 call sites across five files, `14.dp` at 16, `2.dp` at 15, `10.dp` at 11 — and 14 of the `6.dp` uses are gaps in `spacedBy()`. That is a deliberate 2dp rhythm in the tight range that the scale had no word for, so every one of those sites had to write a number. The scale was incomplete; the screens were not wrong.

### Extended the scale

Every existing token keeps its name and value. The new ones fill the gaps between them, so `<name>Plus` always reads as one notch above `<name>`:

```
xxs 2, xs 4, xsPlus 6, sm 8, smPlus 10, md 12, mdPlus 14,
lg 16, lgPlus 20, xl 24, xlPlus 28, xxl 32, xxxl 48
```

### Snapped the strays

27 literals sit off even that rhythm. Each moved to the nearest step, ties resolved downward because tighter never overflows a layout:

| from | to | sites |
| --- | --- | --- |
| 3 | 2 | 3 |
| 5 | 4 | 6 |
| 7 | 6 | 2 |
| 9 | 8 | 3 |
| 11 | 10 | 4 |
| 13 | 12 | 3 |
| 18 | 16 | 2 |
| 22 | 20 | 4 |

Every move is 1dp except `18→16` and `22→20`. The optical compensation in `WordDetailsComponents` becomes 8/10/12 instead of 9/11/12, which makes its steps even.

### Four values stay literal on purpose

- **`1.dp`** — a hairline, not a spacing step. Three of its four sites are `spacedBy(1.dp)` for `StatsCalendar` heatmap cells and `TextReader` word gaps, where 2dp visibly thins the calendar and breaks up the prose. This is the one place I did not follow "fix all the spacing", and it is deliberate.
- **`0.dp`** — "none" reads better as the number.
- **`40.dp`** — the `ChapterRule` side inset, one call site.
- **`88.dp`** — clears a bottom bar; component-local, not a scale value.

Spacing positions in `commonMain` are now fully covered: `padding()`, `PaddingValues()`, `spacedBy()` and bare `Spacer()` sizes hold a token or one of those four. Other source sets have no Compose spacing to convert. Sizes, radii, borders and elevations are untouched, as in #866.

Two padding calls in `StudyCards` became `horizontal = lg, vertical = lg` once 18 snapped to 16; collapsed those to `padding(lg)`.

## Testing

- `./gradlew :composeApp:compileKotlinDesktop` — passes
- `./gradlew :composeApp:verifyLocalizationKeys` — passes
- `./gradlew :composeApp:desktopTest` — 460/465

The 5 failures are the known `DictionaryClientTest.getWord_*` cases that need live GitHub and AI backends; they reproduce on a clean baseline in this container and passed in CI on #866.

The diff was checked mechanically: applying the 27 snaps to the previous files and then substituting each token back for its dp value reproduces all 23 files exactly, so nothing moved beyond the snaps listed above.

**This one changes pixels.** 27 spacing values shift by 1–2dp across Study cards, Search empty states, Stats, Word Details, the reader and the milestone hero. Worth a look on a device before merging.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FCSWCybtaTofzpkNa5cSpW)_