### PR TITLE
Extract the app-scoped object graph, and name the server's JSON configurations

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,8 @@ Important namespaces and entry points:
 - Android application ID: `com.slovy.slovymovyapp`; Android app namespace: `com.slovy.slovymovyapp.androidApp`.
 - Shared Compose/library namespace: `com.slovy.slovymovyapp`.
 - Server main class: `com.slovy.slovymovyapp.ApplicationKt`.
-- Shared UI navigation and dependency wiring: `composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/App.kt`.
+- Shared UI navigation: `composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/App.kt`; its typed destinations
+  are in `AppDestination.kt` and the app-scoped object graph in `AppContainer.kt`, both alongside it.
 - Versions: `gradle/libs.versions.toml`. The root build derives `versionCode` from the git commit count and
   `versionName` as `1.3.<commit-count>`.
 
@@ -170,7 +171,7 @@ fun Screen(viewModel: ScreenViewModel) {
 - Map domain objects to UI models outside the rendering composable when the mapping contains decisions.
 - Add previews for meaningful content/loading/error/empty states.
 
-`App.kt` uses typed destinations (`AppDestination`) with Compose Navigation. Screen ViewModels are normally created
+`App.kt` uses typed destinations (`AppDestination.kt`) with Compose Navigation. Screen ViewModels are normally created
 with `viewModel(viewModelStoreOwner = backStackEntry) { ... }` so their lifetime matches the navigation entry. The
 current intentional exceptions are app-scoped Favorites/Settings ViewModels and the bounded Word Details ViewModel
 cache. Do not accidentally change those lifetimes when refactoring navigation.
@@ -229,9 +230,12 @@ cannot use Valkyrie; `WordListIcon` renders them through the app's singleton Coi
 
 ## Application services and platform wiring
 
-`App.kt` creates the app/session-level repositories and services, including dictionary/list clients, local/downloaded
-database managers, `WordFetchManager`, lemma recovery, intake/session/stats services, downloads, TTS, and export. Keep
-expensive managers stable across recompositions; do not recreate caches or coordinators in screen content.
+`AppContainer` holds the app/session-level repositories and services, including dictionary/list clients,
+local/downloaded database managers, `WordFetchManager`, lemma recovery, intake/session/stats services, downloads,
+TTS, and export. `rememberAppContainer` builds it and closes `LemmaRecoveryController` and `DownloadCoordinator`
+when the composition leaves. Each service keeps its own `remember` keys, so one is recreated when its own inputs
+change and not when a sibling's do. Take what a screen needs from the container; do not recreate caches or
+coordinators in screen content, and do not add a member to the container until something outside it needs one.
 
 Platform services use expect/actual or injectable interfaces:
 
@@ -379,8 +383,8 @@ explicit `LOADING`/`READY`/`ERROR` states and load-error reasons so UI can disti
 
 `StatsService` owns queue/global/screen snapshots, streak/practice data, and the pipeline stages `QUEUE`, `NEW`,
 `FRESH`, `MIDDLE`, `STRONG`, and `LEARNED`. Its retrievability function is reused in session priority.
-`FavoritesReviewCoordinator` caches a full intake refresh for five minutes per language; `refreshDueCountsOnly` must
-not rerun intake. It also avoids intake during a data-version mismatch.
+`FavoritesReviewCoordinator` (in `data/learning/review`) caches a full intake refresh for five minutes per language;
+`refreshDueCountsOnly` must not rerun intake. It also avoids intake during a data-version mismatch.
 
 ## Curated word lists
 

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/App.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/App.kt
@@ -19,23 +19,12 @@ import coil3.svg.SvgDecoder
 import com.slovy.slovymovyapp.analytics.*
 import com.slovy.slovymovyapp.analytics.Analytics.logEvent
 import com.slovy.slovymovyapp.data.Language
-import com.slovy.slovymovyapp.data.export.AppDataExporter
-import com.slovy.slovymovyapp.data.favorites.FavoritesRepository
-import com.slovy.slovymovyapp.data.learning.fsrs.FsrsDefaults
-import com.slovy.slovymovyapp.data.learning.fsrs.FsrsScheduler
-import com.slovy.slovymovyapp.data.learning.intake.IntakeService
-import com.slovy.slovymovyapp.data.learning.intake.LearningIntake
-import com.slovy.slovymovyapp.data.learning.session.ExamplePicker
-import com.slovy.slovymovyapp.data.learning.session.SessionService
-import com.slovy.slovymovyapp.data.learning.stats.ReviewQueueStats
-import com.slovy.slovymovyapp.data.learning.stats.StatsService
-import com.slovy.slovymovyapp.data.local.LocalDbManager
+import com.slovy.slovymovyapp.data.learning.review.FavoritesReviewCoordinator
+import com.slovy.slovymovyapp.data.learning.review.FavoritesReviewState
 import com.slovy.slovymovyapp.data.remote.*
 import com.slovy.slovymovyapp.data.settings.Setting
 import com.slovy.slovymovyapp.data.settings.SettingsRepository
 import com.slovy.slovymovyapp.logging.AppLogger
-import com.slovy.slovymovyapp.speech.TextToSpeechManager
-import com.slovy.slovymovyapp.speech.VoiceFilterHelper
 import com.slovy.slovymovyapp.ui.*
 import com.slovy.slovymovyapp.ui.favorites.*
 import com.slovy.slovymovyapp.ui.settings.*
@@ -45,9 +34,6 @@ import com.slovy.slovymovyapp.ui.stats.*
 import com.slovy.slovymovyapp.ui.listdetail.*
 import com.slovy.slovymovyapp.ui.languagesetup.*
 import com.slovy.slovymovyapp.ui.download.*
-import com.slovy.slovymovyapp.data.lists.ListsService
-import com.slovy.slovymovyapp.data.lists.WordListsRepository
-import com.slovy.slovymovyapp.data.recovery.RecoverableSense
 import com.slovy.slovymovyapp.ui.study.StudySessionScreen
 import com.slovy.slovymovyapp.ui.study.StudySessionViewModel
 import com.slovy.slovymovyapp.ui.reader.TextReaderScreen
@@ -56,153 +42,15 @@ import com.slovy.slovymovyapp.ui.theme.AppTheme
 import com.slovy.slovymovyapp.ui.word.WordDetailScreen
 import com.slovy.slovymovyapp.ui.word.WordDetailViewModel
 import kotlinx.coroutines.*
-import kotlinx.coroutines.sync.Mutex
-import kotlinx.coroutines.sync.withLock
-import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.jsonPrimitive
 import org.jetbrains.compose.resources.stringResource
 import slovymovyapp.composeapp.generated.resources.Res
 import slovymovyapp.composeapp.generated.resources.download_item_dictionary_name
 import slovymovyapp.composeapp.generated.resources.download_title_downloading
-import kotlin.concurrent.Volatile
 import kotlin.time.Clock
 import kotlin.time.Duration.Companion.milliseconds
-import kotlin.time.Duration.Companion.minutes
 import kotlin.time.ExperimentalTime
-import kotlin.time.Instant
-
-internal data class FavoritesReviewState(
-    val reviewByLanguage: Map<Language, FavoriteLanguageReviewState>,
-) {
-    val hasDueCards: Boolean get() = reviewByLanguage.values.any { it.dueCount > 0 }
-}
-
-internal data class FavoriteLanguageReviewState(
-    val dueCount: Int,
-    val activeCardCount: Int,
-    val delayedDueLemmaCount: Int,
-    val delayedDueCardCount: Int,
-    val pendingFavoriteLemmaCount: Int,
-    val canStudyPendingFavoritesNow: Boolean,
-    val nextReviewAtEpochMs: Long?,
-)
-
-@OptIn(ExperimentalTime::class)
-internal class FavoritesReviewCoordinator(
-    private val clock: Clock = Clock.System,
-) {
-    private val refreshMutex = Mutex()
-    private var lastIntakeAtByLanguage: Map<Language, Instant> = emptyMap()
-
-    // Intake reads the local dictionary DB. The data-version-mismatch flow wipes that DB
-    // (LocalDbManager.deleteAll closes the driver), so we must keep the coordinator disabled
-    // until the routing layer has confirmed we're past that check.
-    @Volatile
-    var enabled: Boolean = false
-
-    suspend fun refresh(
-        favoritesRepository: FavoritesRepository,
-        intakeService: LearningIntake,
-        statsService: StatsService,
-    ): FavoritesReviewState = refreshMutex.withLock {
-        if (!enabled) return@withLock FavoritesReviewState(emptyMap())
-        computeFavoritesReviewState(favoritesRepository, intakeService, statsService)
-    }
-
-    /**
-     * Re-reads review queue state without running intake. Cheap enough to call right after a
-     * favorite toggle: remove/add already mutate `card.suspended` synchronously, so
-     * due and delayed-card metadata are accurate. Skipping intake here avoids serializing the dictionary-DB
-     * driver against the screen's own queries on iOS.
-     */
-    suspend fun refreshDueCountsOnly(
-        favoritesRepository: FavoritesRepository,
-        intakeService: LearningIntake,
-        statsService: StatsService,
-    ): FavoritesReviewState = refreshMutex.withLock {
-        if (!enabled) return@withLock FavoritesReviewState(emptyMap())
-        PerformanceMonitoring.startTrace("favorites_review_due_counts").useWithResult {
-            withContext(Dispatchers.Default) {
-                val languages = favoritesRepository.getAllGroupedByLangAndLemma()
-                    .map { it.language }
-                    .distinct()
-                putMetric("languages", languages.size.toLong())
-                val reviewByLanguage = languages.associateWith { language ->
-                    statsService.reviewQueueStats(language.code)
-                        .toFavoriteLanguageReviewState(language, intakeService)
-                }
-                putReviewStateMetrics(reviewByLanguage)
-                FavoritesReviewState(reviewByLanguage = reviewByLanguage)
-            }
-        }
-    }
-
-    fun invalidateIntakeCacheForLanguage(language: Language) {
-        lastIntakeAtByLanguage = lastIntakeAtByLanguage - language
-    }
-
-    fun invalidateAllIntakeCache() {
-        lastIntakeAtByLanguage = emptyMap()
-    }
-
-    private suspend fun computeFavoritesReviewState(
-        favoritesRepository: FavoritesRepository,
-        intakeService: LearningIntake,
-        statsService: StatsService,
-    ): FavoritesReviewState = PerformanceMonitoring.startTrace("favorites_review_compute_state").useWithResult {
-        withContext(Dispatchers.Default) {
-            val favorites = favoritesRepository.getAllGroupedByLangAndLemma()
-            val languages = favorites
-                .map { it.language }
-                .distinct()
-            putMetric("favorites", favorites.size.toLong())
-            putMetric("languages", languages.size.toLong())
-            var intakeRuns = 0L
-            languages.forEach { language ->
-                if (shouldRunIntake(language)) {
-                    intakeService.runIntake(language.code)
-                    markIntakeRun(language)
-                    intakeRuns += 1
-                }
-            }
-            putMetric("intake_runs", intakeRuns)
-            val reviewByLanguage = languages.associateWith { language ->
-                statsService.reviewQueueStats(language.code)
-                    .toFavoriteLanguageReviewState(language, intakeService)
-            }
-            putReviewStateMetrics(reviewByLanguage)
-            FavoritesReviewState(reviewByLanguage = reviewByLanguage)
-        }
-    }
-
-    private fun ReviewQueueStats.toFavoriteLanguageReviewState(
-        language: Language,
-        intakeService: LearningIntake,
-    ) =
-        FavoriteLanguageReviewState(
-            dueCount = dueToday,
-            activeCardCount = activeCardCount,
-            delayedDueLemmaCount = delayedDueLemmaCount,
-            delayedDueCardCount = delayedDueCardCount,
-            pendingFavoriteLemmaCount = pendingFavoriteLemmaCount,
-            canStudyPendingFavoritesNow = intakeService.canContinueWithPendingFavoritesNow(language.code),
-            nextReviewAtEpochMs = nextReviewAtEpochMs,
-        )
-
-    internal fun shouldRunIntake(language: Language): Boolean {
-        val lastRunAt = lastIntakeAtByLanguage[language] ?: return true
-        return clock.now() - lastRunAt >= INTAKE_CACHE_TTL
-    }
-
-    internal fun markIntakeRun(language: Language) {
-        lastIntakeAtByLanguage += language to clock.now()
-    }
-
-    private companion object {
-        val INTAKE_CACHE_TTL = 5.minutes
-    }
-}
 
 private fun FavoritesReviewState.toFavoriteLanguageReviewUiState(): Map<Language, FavoriteLanguageReviewUiState> =
     reviewByLanguage.mapValues { (_, reviewState) ->
@@ -216,74 +64,6 @@ private fun FavoritesReviewState.toFavoriteLanguageReviewUiState(): Map<Language
             nextReviewAtEpochMs = reviewState.nextReviewAtEpochMs,
         )
     }
-
-private fun PerformanceTrace.putReviewStateMetrics(reviewByLanguage: Map<Language, FavoriteLanguageReviewState>) {
-    putMetric("due_cards", reviewByLanguage.values.sumOf { it.dueCount }.toLong())
-    putMetric("active_cards", reviewByLanguage.values.sumOf { it.activeCardCount }.toLong())
-    putMetric("delayed_due_lemmas", reviewByLanguage.values.sumOf { it.delayedDueLemmaCount }.toLong())
-    putMetric("delayed_due_cards", reviewByLanguage.values.sumOf { it.delayedDueCardCount }.toLong())
-    putMetric("pending_favorite_lemmas", reviewByLanguage.values.sumOf { it.pendingFavoriteLemmaCount }.toLong())
-}
-
-@Serializable
-private sealed interface AppDestination {
-    @Serializable
-    data object Welcome : AppDestination
-
-    @Serializable
-    data object DownloadSetup : AppDestination
-
-    @Serializable
-    data object SetupLanguages : AppDestination
-
-    @Serializable
-    data object Search : AppDestination
-
-    @Serializable
-    data object Favorites : AppDestination
-
-    @Serializable
-    data object Stats : AppDestination
-
-    @Serializable
-    data class StudySession(
-        val langCode: String,
-    ) : AppDestination
-
-    @Serializable
-    data class WordDetail(
-        @Deprecated("temporal hack, looks like IOS can't handle enums here")
-        val dictionaryLanguageCode: String,
-        val lemma: String,
-        val targetSenseId: String? = null,
-        val translationLanguageCodes: List<String>? = null,
-    ) : AppDestination {
-        @Suppress("DEPRECATION")
-        val dictionaryLanguage: Language
-            get() = Language.fromCode(dictionaryLanguageCode)
-
-        val translationLanguages: List<Language>?
-            get() = translationLanguageCodes?.mapNotNull { Language.fromCodeOrNull(it) }
-    }
-
-    @Serializable
-    data object Settings : AppDestination
-
-    @Serializable
-    data object Developer : AppDestination
-
-    @Serializable
-    data class TextReader(val languageCode: String) : AppDestination
-
-    @Serializable
-    data class Error(val message: String) : AppDestination
-
-    @Serializable
-    data object DataVersionMismatch : AppDestination
-
-    @Serializable
-    data class ListDetail(val languageCode: String, val listId: String) : AppDestination
-}
 
 @OptIn(ExperimentalTime::class)
 @Composable
@@ -304,91 +84,12 @@ fun App(
     var pendingSearchQuery by remember { mutableStateOf<String?>(null) }
     var nativeLanguages by remember { mutableStateOf<List<Language>>(emptyList()) }
     var dictionaryLanguage by remember { mutableStateOf<Language?>(null) }
-    val appDatabase = remember(platform) {
-        DataDbManager.openAppDatabase(platform)
-    }
-    val favoritesRepository = remember(appDatabase) {
-        FavoritesRepository(appDatabase)
-    }
-    val localDbManager = remember(platform) { LocalDbManager(platform) }
-    val dictionaryRepository =
-        remember(dataManager, localDbManager, favoritesRepository, settingsRepository) {
-            DictionaryRepository(dataManager, localDbManager, favoritesRepository, settingsRepository)
-        }
-    val dictionaryClient = remember(platform, dictionaryRepository, localDbManager, dataManager) {
-        DictionaryClient(platform, dictionaryRepository, localDbManager, dataManager)
-    }
-    val listsClient = remember(platform) { ListsClient(platform) }
-    val wordListsRepository = remember(appDatabase) { WordListsRepository(appDatabase) }
-    val listsService = remember(wordListsRepository, listsClient) {
-        ListsService(wordListsRepository, listsClient)
-    }
-    val wordFetchManager = remember(dictionaryClient) {
-        WordFetchManager(dictionaryClient)
-    }
-    val lemmaRecovery = remember(
-        favoritesRepository,
-        wordListsRepository,
-        dataManager,
-        dictionaryRepository,
-        wordFetchManager,
-    ) {
-        LemmaRecovery(
-            itemsProvider = {
-                // Recover favorites and curated word-list senses in one combined pass; both
-                // implement RecoverableSense, and recover() dedups by (language, lemma).
-                val favorites: List<RecoverableSense> = favoritesRepository.getAll()
-                favorites + wordListsRepository.getAllSenses()
-            },
-            dataDbManager = dataManager,
-            dictionaryRepository = dictionaryRepository,
-            wordFetchManager = wordFetchManager,
-        )
-    }
-    val lemmaRecoveryController = remember(lemmaRecovery, platform) {
-        LemmaRecoveryController(lemmaRecovery, platform)
-    }
-    DisposableEffect(lemmaRecoveryController) {
-        onDispose { lemmaRecoveryController.close() }
-    }
-    val fsrsConfig = remember { FsrsDefaults.config() }
-    val fsrsScheduler = remember(fsrsConfig) {
-        FsrsScheduler(
-            retention = fsrsConfig.requestRetention,
-            weights = fsrsConfig.weights,
-            maximumInterval = fsrsConfig.maximumInterval,
-            enableFuzz = fsrsConfig.enableFuzz,
-        )
-    }
-    val intakeService = remember(appDatabase, dictionaryRepository, fsrsConfig) {
-        IntakeService(
-            learning = appDatabase.favoritesQueries,
-            dictionary = dictionaryRepository,
-            config = fsrsConfig,
-            clock = Clock.System,
-        )
-    }
-    val sessionService = remember(appDatabase, wordFetchManager, fsrsScheduler, fsrsConfig, dictionaryRepository) {
-        SessionService(
-            learning = appDatabase.favoritesQueries,
-            wordFetchManager = wordFetchManager,
-            scheduler = fsrsScheduler,
-            examplePicker = ExamplePicker(appDatabase.favoritesQueries),
-            config = fsrsConfig,
-            clock = Clock.System,
-            translationTargets = dictionaryRepository::defaultTranslationTargets,
-        )
-    }
-    val statsService = remember(appDatabase, fsrsConfig) {
-        StatsService(
-            learning = appDatabase.favoritesQueries,
-            clock = Clock.System,
-        )
-    }
-    val downloadCoordinator = remember { DownloadCoordinator() }
-    val ttsManager = remember(androidContext) { TextToSpeechManager(androidContext) }
-    val appDataExporter = remember(androidContext) { AppDataExporter(androidContext) }
-    val voiceFilterHelper = remember(settingsRepository) { VoiceFilterHelper(settingsRepository) }
+    val container = rememberAppContainer(
+        settingsRepository = settingsRepository,
+        dataManager = dataManager,
+        platform = platform,
+        androidContext = androidContext,
+    )
 
     val navController = rememberNavController()
     val navBackStackEntry by navController.currentBackStackEntryAsState()
@@ -401,20 +102,20 @@ fun App(
     // Shared ViewModel for Favorites screen to preserve state across navigation
     val favoritesViewModel = remember {
         FavoritesViewModel(
-            favoritesRepository = favoritesRepository,
-            dictionaryRepository = dictionaryRepository,
+            favoritesRepository = container.favoritesRepository,
+            dictionaryRepository = container.dictionaryRepository,
             settingsRepository = settingsRepository,
-            speechPlayer = ttsManager,
-            voiceFilterHelper = voiceFilterHelper,
+            speechPlayer = container.ttsManager,
+            voiceFilterHelper = container.voiceFilterHelper,
             clock = Clock.System,
         ).also { it.start() }
     }
 
     suspend fun refreshFavoritesReviewState() {
         val reviewState = favoritesReviewCoordinator.refresh(
-            favoritesRepository = favoritesRepository,
-            intakeService = intakeService,
-            statsService = statsService,
+            favoritesRepository = container.favoritesRepository,
+            intakeService = container.intakeService,
+            statsService = container.statsService,
         )
         favoritesViewModel.updateReviewState(reviewState.toFavoriteLanguageReviewUiState())
         hasFavoritesToReview = reviewState.hasDueCards
@@ -422,9 +123,9 @@ fun App(
 
     suspend fun refreshFavoritesDueCountsOnly() {
         val reviewState = favoritesReviewCoordinator.refreshDueCountsOnly(
-            favoritesRepository = favoritesRepository,
-            intakeService = intakeService,
-            statsService = statsService,
+            favoritesRepository = container.favoritesRepository,
+            intakeService = container.intakeService,
+            statsService = container.statsService,
         )
         favoritesViewModel.updateReviewState(reviewState.toFavoriteLanguageReviewUiState())
         hasFavoritesToReview = reviewState.hasDueCards
@@ -441,20 +142,20 @@ fun App(
     val settingsViewModel =
         remember {
             SettingsViewModel(
-                ttsManager,
-                voiceFilterHelper,
+                container.ttsManager,
+                container.voiceFilterHelper,
                 dataManager,
-                downloadCoordinator,
-                dictionaryClient,
-                appDataExporter,
+                container.downloadCoordinator,
+                container.dictionaryClient,
+                container.appDataExporter,
                 settingsRepository,
                 platform,
                 buildConfig,
                 onDictionaryDataChanged = { recoverFavorites ->
                     favoritesReviewCoordinator.invalidateAllIntakeCache()
-                    dictionaryRepository.clearSenseCache()
+                    container.dictionaryRepository.clearSenseCache()
                     if (recoverFavorites) {
-                        lemmaRecoveryController.ensureStarted()
+                        container.lemmaRecoveryController.ensureStarted()
                     }
                     favoritesViewModel.dropCachedFavoriteDetails()
                 },
@@ -462,9 +163,6 @@ fun App(
         }
     LaunchedEffect(settingsViewModel) {
         settingsViewModel.migrateLegacyDefaultVoiceSelectionsAfterAppStart()
-    }
-    DisposableEffect(Unit) {
-        onDispose { downloadCoordinator.close() }
     }
 
     // Update the badge/due counts immediately from current SR state so the bottom-nav dot
@@ -517,7 +215,7 @@ fun App(
 
         // Check if data version is current (before welcome, so existing users see mismatch).
         // The coordinator defaults to disabled, so returning DataVersionMismatch here keeps
-        // intake off — the redownload flow calls localDbManager.deleteAll(), and any concurrent
+        // intake off — the redownload flow calls container.localDbManager.deleteAll(), and any concurrent
         // intake query against the cached driver would crash.
         if (!dataManager.hasRequiredVersion()) {
             val savedVersion = settingsRepository.getById(Setting.Name.DATA_VERSION)?.value?.jsonPrimitive?.content
@@ -622,7 +320,7 @@ fun App(
                     ) {
                         LanguageSetupViewModel(
                             dataManager,
-                            dictionaryClient,
+                            container.dictionaryClient,
                             initialLearningLanguage = dictionaryLanguage,
                             initialNativeLanguages = nativeLanguages.toSet()
                         )
@@ -671,7 +369,7 @@ fun App(
                             viewModelStoreOwner = backStackEntry
                         ) {
                             DownloadViewModel(
-                                downloadCoordinator = downloadCoordinator,
+                                downloadCoordinator = container.downloadCoordinator,
                                 downloadKey = "setup_${dictLang.code}",
                                 analyticsParams = mapOf(
                                     "kind" to "setup",
@@ -711,16 +409,16 @@ fun App(
                                 },
                                 finalize = { onRecoveryProgress, onWordListsSync ->
                                     favoritesReviewCoordinator.invalidateAllIntakeCache()
-                                    dictionaryRepository.clearSenseCache()
+                                    container.dictionaryRepository.clearSenseCache()
                                     // Bring the curated lists for the freshly downloaded language
                                     // up to date while the finalizing screen is visible.
                                     onWordListsSync(true)
-                                    listsService.sync(dictLang)
+                                    container.listsService.sync(dictLang)
                                     onWordListsSync(false)
-                                    val recoveryJob = lemmaRecoveryController.ensureStarted()
+                                    val recoveryJob = container.lemmaRecoveryController.ensureStarted()
                                     coroutineScope {
                                         val observerJob = launch {
-                                            lemmaRecoveryController.progress.collect { progress ->
+                                            container.lemmaRecoveryController.progress.collect { progress ->
                                                 if (progress != null) {
                                                     onRecoveryProgress(progress)
                                                 }
@@ -812,7 +510,7 @@ fun App(
                     val viewModel = viewModel(
                         viewModelStoreOwner = backStackEntry
                     ) {
-                        SearchViewModel(dictionaryRepository, settingsRepository, listsService, dictionaryClient)
+                        SearchViewModel(container.dictionaryRepository, settingsRepository, container.listsService, container.dictionaryClient)
                     }
 
                     LaunchedEffect(pendingSearchQuery) {
@@ -883,12 +581,12 @@ fun App(
                         ListDetailViewModel(
                             listId = args.listId,
                             language = lang,
-                            repository = dictionaryRepository,
-                            favoritesRepository = favoritesRepository,
-                            listsService = listsService,
-                            lemmaRecovery = lemmaRecovery,
-                            speechPlayer = ttsManager,
-                            voiceFilterHelper = voiceFilterHelper,
+                            repository = container.dictionaryRepository,
+                            favoritesRepository = container.favoritesRepository,
+                            listsService = container.listsService,
+                            lemmaRecovery = container.lemmaRecovery,
+                            speechPlayer = container.ttsManager,
+                            voiceFilterHelper = container.voiceFilterHelper,
                             onFavoriteChanged = { _ ->
                                 favoritesReviewCoordinator.invalidateIntakeCacheForLanguage(lang)
                                 appCoroutineScope.launch { refreshFavoritesDueCountsOnly() }
@@ -952,12 +650,12 @@ fun App(
                             appCoroutineScope.launch {
                                 val shouldStartStudy = when (action) {
                                     FavoritesStudyDoneAction.REVIEW_MORE -> {
-                                        sessionService.continueDelayedCardsNow(language.code)
+                                        container.sessionService.continueDelayedCardsNow(language.code)
                                         true
                                     }
 
                                     FavoritesStudyDoneAction.STUDY_NEW ->
-                                        intakeService.continueWithPendingFavoritesNow(language.code).cardsCreated > 0
+                                        container.intakeService.continueWithPendingFavoritesNow(language.code).cardsCreated > 0
                                 }
                                 refreshFavoritesDueCountsOnly()
                                 if (shouldStartStudy) {
@@ -983,7 +681,7 @@ fun App(
                     val viewModel = viewModel(
                         viewModelStoreOwner = backStackEntry
                     ) {
-                        StatsViewModel(learningLanguagesForStats, statsService, settingsRepository, Clock.System)
+                        StatsViewModel(learningLanguagesForStats, container.statsService, settingsRepository, Clock.System)
                     }
 
                     StatsScreen(
@@ -1011,13 +709,13 @@ fun App(
                     ) {
                         StudySessionViewModel(
                             langCode = args.langCode,
-                            favoritesRepository = favoritesRepository,
-                            intakeService = intakeService,
-                            sessionService = sessionService,
-                            statsService = statsService,
+                            favoritesRepository = container.favoritesRepository,
+                            intakeService = container.intakeService,
+                            sessionService = container.sessionService,
+                            statsService = container.statsService,
                             clock = Clock.System,
-                            ttsManager = ttsManager,
-                            voiceFilterHelper = voiceFilterHelper,
+                            ttsManager = container.ttsManager,
+                            voiceFilterHelper = container.voiceFilterHelper,
                             onReviewSubmitted = {
                                 Language.fromCodeOrNull(args.langCode)?.let { lang ->
                                     favoritesReviewCoordinator.invalidateIntakeCacheForLanguage(lang)
@@ -1073,9 +771,9 @@ fun App(
                 composable<AppDestination.Developer> { backStackEntry ->
                     val viewModel = viewModel(viewModelStoreOwner = backStackEntry) {
                         DeveloperViewModel(
-                            favoritesRepository = favoritesRepository,
-                            intake = intakeService,
-                            listsService = listsService,
+                            favoritesRepository = container.favoritesRepository,
+                            intake = container.intakeService,
+                            listsService = container.listsService,
                             learningLanguagesProvider = {
                                 dataManager.listDownloadedDatabases()
                                     .filterIsInstance<DatabaseFileInfo.Dictionary>()
@@ -1112,12 +810,12 @@ fun App(
                             }
                         }
                         WordDetailViewModel(
-                            dictionaryRepository,
-                            dictionaryClient,
-                            wordFetchManager,
-                            favoritesRepository,
-                            ttsManager,
-                            voiceFilterHelper,
+                            container.dictionaryRepository,
+                            container.dictionaryClient,
+                            container.wordFetchManager,
+                            container.favoritesRepository,
+                            container.ttsManager,
+                            container.voiceFilterHelper,
                             args.dictionaryLanguage,
                             args.lemma,
                             args.targetSenseId,
@@ -1137,7 +835,6 @@ fun App(
                             wordDetailViewModels[args] = created
                         }
                     }
-
 
                     // Reload favorites and voices when navigating to this screen
                     LaunchedEffect(Unit) {
@@ -1186,7 +883,7 @@ fun App(
                         return@composable
                     }
                     val viewModel = viewModel(viewModelStoreOwner = backStackEntry) {
-                        TextReaderViewModel(dictionaryRepository, favoritesRepository, language)
+                        TextReaderViewModel(container.dictionaryRepository, container.favoritesRepository, language)
                     }
                     TextReaderScreen(
                         viewModel = viewModel,
@@ -1209,8 +906,8 @@ fun App(
                             coroutineScope.launch {
                                 try {
                                     dataManager.deleteAllDownloadedData()
-                                    localDbManager.deleteAll()
-                                    dictionaryRepository.clearSenseCache()
+                                    container.localDbManager.deleteAll()
+                                    container.dictionaryRepository.clearSenseCache()
                                     favoritesReviewCoordinator.invalidateAllIntakeCache()
                                     favoritesViewModel.dropCachedFavoriteDetails()
                                     val target = selectInitialDestination()
@@ -1256,7 +953,7 @@ fun App(
                 enabled = settingsState.developerModeEnabled,
                 onShiftLearningTime = { duration ->
                     withContext(Dispatchers.IO) {
-                        favoritesRepository.shiftLearningTimestampsBack(duration)
+                        container.favoritesRepository.shiftLearningTimestampsBack(duration)
                     }
                     refreshFavoritesDueCountsOnly()
                 },

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/AppContainer.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/AppContainer.kt
@@ -1,0 +1,195 @@
+package com.slovy.slovymovyapp
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.remember
+import com.slovy.slovymovyapp.data.export.AppDataExporter
+import com.slovy.slovymovyapp.data.favorites.FavoritesRepository
+import com.slovy.slovymovyapp.data.learning.fsrs.FsrsDefaults
+import com.slovy.slovymovyapp.data.learning.fsrs.FsrsScheduler
+import com.slovy.slovymovyapp.data.learning.intake.IntakeService
+import com.slovy.slovymovyapp.data.learning.session.ExamplePicker
+import com.slovy.slovymovyapp.data.learning.session.SessionService
+import com.slovy.slovymovyapp.data.learning.stats.StatsService
+import com.slovy.slovymovyapp.data.lists.ListsService
+import com.slovy.slovymovyapp.data.lists.WordListsRepository
+import com.slovy.slovymovyapp.data.local.LocalDbManager
+import com.slovy.slovymovyapp.data.recovery.RecoverableSense
+import com.slovy.slovymovyapp.data.remote.*
+import com.slovy.slovymovyapp.data.settings.SettingsRepository
+import com.slovy.slovymovyapp.speech.TextToSpeechManager
+import com.slovy.slovymovyapp.speech.VoiceFilterHelper
+import kotlin.time.Clock
+import kotlin.time.ExperimentalTime
+
+/**
+ * The app-scoped object graph: the databases, repositories, clients, managers and services that
+ * outlive any single screen.
+ *
+ * These used to be twenty `remember` calls at the top of [App], where the wiring sat between the
+ * navigation graph and the startup routing and was hard to read past. Keeping them together also
+ * makes the rule explicit: everything here is created once for the session, so a screen must take
+ * what it needs from the container rather than build its own — a second [WordFetchManager] or
+ * [DownloadCoordinator] would quietly split the state they exist to share.
+ *
+ * Build it with [rememberAppContainer], which preserves each object's original `remember` keys, so
+ * a service is still recreated exactly when its own inputs change and not when a sibling's do.
+ */
+@Stable
+internal class AppContainer(
+    val favoritesRepository: FavoritesRepository,
+    val localDbManager: LocalDbManager,
+    val dictionaryRepository: DictionaryRepository,
+    val dictionaryClient: DictionaryClient,
+    val listsService: ListsService,
+    val wordFetchManager: WordFetchManager,
+    val lemmaRecovery: LemmaRecovery,
+    val lemmaRecoveryController: LemmaRecoveryController,
+    val intakeService: IntakeService,
+    val sessionService: SessionService,
+    val statsService: StatsService,
+    val downloadCoordinator: DownloadCoordinator,
+    val ttsManager: TextToSpeechManager,
+    val appDataExporter: AppDataExporter,
+    val voiceFilterHelper: VoiceFilterHelper,
+)
+
+/**
+ * Creates the app-scoped graph and ties the two objects that own resources to the composition:
+ * [LemmaRecoveryController] and [DownloadCoordinator] are closed when it leaves.
+ */
+@OptIn(ExperimentalTime::class)
+@Composable
+internal fun rememberAppContainer(
+    settingsRepository: SettingsRepository,
+    dataManager: DataDbManager,
+    platform: PlatformDbSupport,
+    androidContext: Any?,
+): AppContainer {
+    val appDatabase = remember(platform) {
+        DataDbManager.openAppDatabase(platform)
+    }
+    val favoritesRepository = remember(appDatabase) {
+        FavoritesRepository(appDatabase)
+    }
+    val localDbManager = remember(platform) { LocalDbManager(platform) }
+    val dictionaryRepository =
+        remember(dataManager, localDbManager, favoritesRepository, settingsRepository) {
+            DictionaryRepository(dataManager, localDbManager, favoritesRepository, settingsRepository)
+        }
+    val dictionaryClient = remember(platform, dictionaryRepository, localDbManager, dataManager) {
+        DictionaryClient(platform, dictionaryRepository, localDbManager, dataManager)
+    }
+    val listsClient = remember(platform) { ListsClient(platform) }
+    val wordListsRepository = remember(appDatabase) { WordListsRepository(appDatabase) }
+    val listsService = remember(wordListsRepository, listsClient) {
+        ListsService(wordListsRepository, listsClient)
+    }
+    val wordFetchManager = remember(dictionaryClient) {
+        WordFetchManager(dictionaryClient)
+    }
+    val lemmaRecovery = remember(
+        favoritesRepository,
+        wordListsRepository,
+        dataManager,
+        dictionaryRepository,
+        wordFetchManager,
+    ) {
+        LemmaRecovery(
+            itemsProvider = {
+                // Recover favorites and curated word-list senses in one combined pass; both
+                // implement RecoverableSense, and recover() dedups by (language, lemma).
+                val favorites: List<RecoverableSense> = favoritesRepository.getAll()
+                favorites + wordListsRepository.getAllSenses()
+            },
+            dataDbManager = dataManager,
+            dictionaryRepository = dictionaryRepository,
+            wordFetchManager = wordFetchManager,
+        )
+    }
+    val lemmaRecoveryController = remember(lemmaRecovery, platform) {
+        LemmaRecoveryController(lemmaRecovery, platform)
+    }
+    val fsrsConfig = remember { FsrsDefaults.config() }
+    val fsrsScheduler = remember(fsrsConfig) {
+        FsrsScheduler(
+            retention = fsrsConfig.requestRetention,
+            weights = fsrsConfig.weights,
+            maximumInterval = fsrsConfig.maximumInterval,
+            enableFuzz = fsrsConfig.enableFuzz,
+        )
+    }
+    val intakeService = remember(appDatabase, dictionaryRepository, fsrsConfig) {
+        IntakeService(
+            learning = appDatabase.favoritesQueries,
+            dictionary = dictionaryRepository,
+            config = fsrsConfig,
+            clock = Clock.System,
+        )
+    }
+    val sessionService = remember(appDatabase, wordFetchManager, fsrsScheduler, fsrsConfig, dictionaryRepository) {
+        SessionService(
+            learning = appDatabase.favoritesQueries,
+            wordFetchManager = wordFetchManager,
+            scheduler = fsrsScheduler,
+            examplePicker = ExamplePicker(appDatabase.favoritesQueries),
+            config = fsrsConfig,
+            clock = Clock.System,
+            translationTargets = dictionaryRepository::defaultTranslationTargets,
+        )
+    }
+    val statsService = remember(appDatabase, fsrsConfig) {
+        StatsService(
+            learning = appDatabase.favoritesQueries,
+            clock = Clock.System,
+        )
+    }
+    val downloadCoordinator = remember { DownloadCoordinator() }
+    val ttsManager = remember(androidContext) { TextToSpeechManager(androidContext) }
+    val appDataExporter = remember(androidContext) { AppDataExporter(androidContext) }
+    val voiceFilterHelper = remember(settingsRepository) { VoiceFilterHelper(settingsRepository) }
+    DisposableEffect(lemmaRecoveryController) {
+        onDispose { lemmaRecoveryController.close() }
+    }
+    DisposableEffect(downloadCoordinator) {
+        onDispose { downloadCoordinator.close() }
+    }
+
+    return remember(
+        favoritesRepository,
+        localDbManager,
+        dictionaryRepository,
+        dictionaryClient,
+        wordListsRepository,
+        listsService,
+        wordFetchManager,
+        lemmaRecovery,
+        lemmaRecoveryController,
+        intakeService,
+        sessionService,
+        statsService,
+        downloadCoordinator,
+        ttsManager,
+        appDataExporter,
+        voiceFilterHelper,
+    ) {
+        AppContainer(
+            favoritesRepository = favoritesRepository,
+            localDbManager = localDbManager,
+            dictionaryRepository = dictionaryRepository,
+            dictionaryClient = dictionaryClient,
+            listsService = listsService,
+            wordFetchManager = wordFetchManager,
+            lemmaRecovery = lemmaRecovery,
+            lemmaRecoveryController = lemmaRecoveryController,
+            intakeService = intakeService,
+            sessionService = sessionService,
+            statsService = statsService,
+            downloadCoordinator = downloadCoordinator,
+            ttsManager = ttsManager,
+            appDataExporter = appDataExporter,
+            voiceFilterHelper = voiceFilterHelper,
+        )
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/AppDestination.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/AppDestination.kt
@@ -1,0 +1,71 @@
+package com.slovy.slovymovyapp
+
+import com.slovy.slovymovyapp.data.Language
+import kotlinx.serialization.Serializable
+
+/**
+ * Typed navigation destinations for the app's single [androidx.navigation.compose.NavHost].
+ *
+ * Route arguments are plain strings rather than [Language] values: the Kotlin/Native side of
+ * Compose Navigation cannot round-trip an enum through a route, so each destination stores the
+ * language code and exposes the parsed value as a property.
+ */
+@Serializable
+internal sealed interface AppDestination {
+    @Serializable
+    data object Welcome : AppDestination
+
+    @Serializable
+    data object DownloadSetup : AppDestination
+
+    @Serializable
+    data object SetupLanguages : AppDestination
+
+    @Serializable
+    data object Search : AppDestination
+
+    @Serializable
+    data object Favorites : AppDestination
+
+    @Serializable
+    data object Stats : AppDestination
+
+    @Serializable
+    data class StudySession(
+        val langCode: String,
+    ) : AppDestination
+
+    @Serializable
+    data class WordDetail(
+        @Deprecated("temporal hack, looks like IOS can't handle enums here")
+        val dictionaryLanguageCode: String,
+        val lemma: String,
+        val targetSenseId: String? = null,
+        val translationLanguageCodes: List<String>? = null,
+    ) : AppDestination {
+        @Suppress("DEPRECATION")
+        val dictionaryLanguage: Language
+            get() = Language.fromCode(dictionaryLanguageCode)
+
+        val translationLanguages: List<Language>?
+            get() = translationLanguageCodes?.mapNotNull { Language.fromCodeOrNull(it) }
+    }
+
+    @Serializable
+    data object Settings : AppDestination
+
+    @Serializable
+    data object Developer : AppDestination
+
+    @Serializable
+    data class TextReader(val languageCode: String) : AppDestination
+
+    @Serializable
+    data class Error(val message: String) : AppDestination
+
+    @Serializable
+    data object DataVersionMismatch : AppDestination
+
+    @Serializable
+    data class ListDetail(val languageCode: String, val listId: String) : AppDestination
+}

--- a/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/data/learning/review/FavoritesReviewCoordinator.kt
+++ b/composeApp/src/commonMain/kotlin/com/slovy/slovymovyapp/data/learning/review/FavoritesReviewCoordinator.kt
@@ -1,0 +1,159 @@
+package com.slovy.slovymovyapp.data.learning.review
+
+import com.slovy.slovymovyapp.analytics.PerformanceMonitoring
+import com.slovy.slovymovyapp.analytics.PerformanceTrace
+import com.slovy.slovymovyapp.analytics.useWithResult
+import com.slovy.slovymovyapp.data.Language
+import com.slovy.slovymovyapp.data.favorites.FavoritesRepository
+import com.slovy.slovymovyapp.data.learning.intake.LearningIntake
+import com.slovy.slovymovyapp.data.learning.stats.ReviewQueueStats
+import com.slovy.slovymovyapp.data.learning.stats.StatsService
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
+import kotlin.concurrent.Volatile
+import kotlin.time.Clock
+import kotlin.time.Duration.Companion.minutes
+import kotlin.time.ExperimentalTime
+import kotlin.time.Instant
+
+internal data class FavoritesReviewState(
+    val reviewByLanguage: Map<Language, FavoriteLanguageReviewState>,
+) {
+    val hasDueCards: Boolean get() = reviewByLanguage.values.any { it.dueCount > 0 }
+}
+
+internal data class FavoriteLanguageReviewState(
+    val dueCount: Int,
+    val activeCardCount: Int,
+    val delayedDueLemmaCount: Int,
+    val delayedDueCardCount: Int,
+    val pendingFavoriteLemmaCount: Int,
+    val canStudyPendingFavoritesNow: Boolean,
+    val nextReviewAtEpochMs: Long?,
+)
+
+@OptIn(ExperimentalTime::class)
+internal class FavoritesReviewCoordinator(
+    private val clock: Clock = Clock.System,
+) {
+    private val refreshMutex = Mutex()
+    private var lastIntakeAtByLanguage: Map<Language, Instant> = emptyMap()
+
+    // Intake reads the local dictionary DB. The data-version-mismatch flow wipes that DB
+    // (LocalDbManager.deleteAll closes the driver), so we must keep the coordinator disabled
+    // until the routing layer has confirmed we're past that check.
+    @Volatile
+    var enabled: Boolean = false
+
+    suspend fun refresh(
+        favoritesRepository: FavoritesRepository,
+        intakeService: LearningIntake,
+        statsService: StatsService,
+    ): FavoritesReviewState = refreshMutex.withLock {
+        if (!enabled) return@withLock FavoritesReviewState(emptyMap())
+        computeFavoritesReviewState(favoritesRepository, intakeService, statsService)
+    }
+
+    /**
+     * Re-reads review queue state without running intake. Cheap enough to call right after a
+     * favorite toggle: remove/add already mutate `card.suspended` synchronously, so
+     * due and delayed-card metadata are accurate. Skipping intake here avoids serializing the dictionary-DB
+     * driver against the screen's own queries on iOS.
+     */
+    suspend fun refreshDueCountsOnly(
+        favoritesRepository: FavoritesRepository,
+        intakeService: LearningIntake,
+        statsService: StatsService,
+    ): FavoritesReviewState = refreshMutex.withLock {
+        if (!enabled) return@withLock FavoritesReviewState(emptyMap())
+        PerformanceMonitoring.startTrace("favorites_review_due_counts").useWithResult {
+            withContext(Dispatchers.Default) {
+                val languages = favoritesRepository.getAllGroupedByLangAndLemma()
+                    .map { it.language }
+                    .distinct()
+                putMetric("languages", languages.size.toLong())
+                val reviewByLanguage = languages.associateWith { language ->
+                    statsService.reviewQueueStats(language.code)
+                        .toFavoriteLanguageReviewState(language, intakeService)
+                }
+                putReviewStateMetrics(reviewByLanguage)
+                FavoritesReviewState(reviewByLanguage = reviewByLanguage)
+            }
+        }
+    }
+
+    fun invalidateIntakeCacheForLanguage(language: Language) {
+        lastIntakeAtByLanguage = lastIntakeAtByLanguage - language
+    }
+
+    fun invalidateAllIntakeCache() {
+        lastIntakeAtByLanguage = emptyMap()
+    }
+
+    private suspend fun computeFavoritesReviewState(
+        favoritesRepository: FavoritesRepository,
+        intakeService: LearningIntake,
+        statsService: StatsService,
+    ): FavoritesReviewState = PerformanceMonitoring.startTrace("favorites_review_compute_state").useWithResult {
+        withContext(Dispatchers.Default) {
+            val favorites = favoritesRepository.getAllGroupedByLangAndLemma()
+            val languages = favorites
+                .map { it.language }
+                .distinct()
+            putMetric("favorites", favorites.size.toLong())
+            putMetric("languages", languages.size.toLong())
+            var intakeRuns = 0L
+            languages.forEach { language ->
+                if (shouldRunIntake(language)) {
+                    intakeService.runIntake(language.code)
+                    markIntakeRun(language)
+                    intakeRuns += 1
+                }
+            }
+            putMetric("intake_runs", intakeRuns)
+            val reviewByLanguage = languages.associateWith { language ->
+                statsService.reviewQueueStats(language.code)
+                    .toFavoriteLanguageReviewState(language, intakeService)
+            }
+            putReviewStateMetrics(reviewByLanguage)
+            FavoritesReviewState(reviewByLanguage = reviewByLanguage)
+        }
+    }
+
+    private fun ReviewQueueStats.toFavoriteLanguageReviewState(
+        language: Language,
+        intakeService: LearningIntake,
+    ) =
+        FavoriteLanguageReviewState(
+            dueCount = dueToday,
+            activeCardCount = activeCardCount,
+            delayedDueLemmaCount = delayedDueLemmaCount,
+            delayedDueCardCount = delayedDueCardCount,
+            pendingFavoriteLemmaCount = pendingFavoriteLemmaCount,
+            canStudyPendingFavoritesNow = intakeService.canContinueWithPendingFavoritesNow(language.code),
+            nextReviewAtEpochMs = nextReviewAtEpochMs,
+        )
+
+    internal fun shouldRunIntake(language: Language): Boolean {
+        val lastRunAt = lastIntakeAtByLanguage[language] ?: return true
+        return clock.now() - lastRunAt >= INTAKE_CACHE_TTL
+    }
+
+    internal fun markIntakeRun(language: Language) {
+        lastIntakeAtByLanguage += language to clock.now()
+    }
+
+    private companion object {
+        val INTAKE_CACHE_TTL = 5.minutes
+    }
+}
+
+private fun PerformanceTrace.putReviewStateMetrics(reviewByLanguage: Map<Language, FavoriteLanguageReviewState>) {
+    putMetric("due_cards", reviewByLanguage.values.sumOf { it.dueCount }.toLong())
+    putMetric("active_cards", reviewByLanguage.values.sumOf { it.activeCardCount }.toLong())
+    putMetric("delayed_due_lemmas", reviewByLanguage.values.sumOf { it.delayedDueLemmaCount }.toLong())
+    putMetric("delayed_due_cards", reviewByLanguage.values.sumOf { it.delayedDueCardCount }.toLong())
+    putMetric("pending_favorite_lemmas", reviewByLanguage.values.sumOf { it.pendingFavoriteLemmaCount }.toLong())
+}

--- a/composeApp/src/commonTest/kotlin/com/slovy/slovymovyapp/data/learning/review/FavoritesReviewCoordinatorTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/slovy/slovymovyapp/data/learning/review/FavoritesReviewCoordinatorTest.kt
@@ -1,4 +1,4 @@
-package com.slovy.slovymovyapp
+package com.slovy.slovymovyapp.data.learning.review
 
 import com.slovy.slovymovyapp.data.Language
 import kotlin.test.Test

--- a/server/src/main/kotlin/com/slovy/slovymovyapp/Application.kt
+++ b/server/src/main/kotlin/com/slovy/slovymovyapp/Application.kt
@@ -9,6 +9,7 @@ import com.slovy.slovymovyapp.data.settings.SettingsRepository
 import com.slovy.slovymovyapp.db.AppDatabase
 import com.slovy.slovymovyapp.ingestion.ExtractedWordData
 import com.slovy.slovymovyapp.ingestion.LanguageCardResponse
+import com.slovy.slovymovyapp.server.ServerJson
 import com.slovy.slovymovyapp.server.ai.GEMINI_3_1_FLASH_LITE
 import com.slovy.slovymovyapp.server.ai.GeminiProvider
 import com.slovy.slovymovyapp.server.ai.OpenAIProvider
@@ -35,7 +36,6 @@ import io.ktor.util.logging.*
 import kotlinx.coroutines.*
 import kotlinx.coroutines.selects.select
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.jsonPrimitive
 import org.kohsuke.github.GHFileNotFoundException
 import org.kohsuke.github.HttpException
@@ -70,7 +70,6 @@ private data class GeneralFeedbackResponse(
     val discussionUrl: String
 )
 
-private val feedbackJson = Json { ignoreUnknownKeys = true }
 
 fun main() {
     val port = System.getenv(SERVER_PORT_ENV)?.toIntOrNull() ?: SERVER_PORT
@@ -118,14 +117,16 @@ fun Application.module() {
                     call.respond(HttpStatusCode.ServiceUnavailable, "GitHub token not configured")
                     return@get
                 }
-                val json = Json { ignoreUnknownKeys = true }
                 try {
                     // Prefer a fresh bundle's version (zero extra GitHub calls). Fall back to the
                     // dedicated version cache, which only does the cheap tree-walk and is unaffected
                     // by malformed list JSON or icon download failures.
                     val version = bundleCache.peekFresh(lang)?.version ?: versionCache.get(lang)
                     call.respondText(
-                        json.encodeToString(ListsVersionResponse.serializer(), ListsVersionResponse(version)),
+                        ServerJson.lenient.encodeToString(
+                            ListsVersionResponse.serializer(),
+                            ListsVersionResponse(version)
+                        ),
                         ContentType.Application.Json
                     )
                 } catch (_: GHFileNotFoundException) {
@@ -146,12 +147,11 @@ fun Application.module() {
                     call.respond(HttpStatusCode.ServiceUnavailable, "GitHub token not configured")
                     return@get
                 }
-                val json = Json { ignoreUnknownKeys = true }
                 try {
                     val bundle = bundleCache.get(lang)
                     val response = LanguageListsResponse(version = bundle.version, lists = bundle.lists)
                     call.respondText(
-                        json.encodeToString(LanguageListsResponse.serializer(), response),
+                        ServerJson.lenient.encodeToString(LanguageListsResponse.serializer(), response),
                         ContentType.Application.Json
                     )
                 } catch (_: GHFileNotFoundException) {
@@ -203,11 +203,9 @@ fun Application.module() {
                 return@get
             }
 
-            val json = Json { ignoreUnknownKeys = true }
-
             try {
                 // Step 1: Prepare base data before starting the stream so we can still return errors
-                val baseResult = loadBaseWordData(lang, word, json, logger = call.application.environment.log)
+                val baseResult = loadBaseWordData(lang, word, logger = call.application.environment.log)
 
                 // Step 2: Stream results as NDJSON (base, then translated if available)
                 //
@@ -225,7 +223,7 @@ fun Application.module() {
                         // Send filtered base response to client (always filter based on requested codes)
                         val baseResponseToClient = filterTranslations(baseResult.response, requestedLangCodes)
                         val baseChunk = WordStreamChunk(WordStreamStage.BASE, baseResponseToClient)
-                        write(json.encodeToString(WordStreamChunk.serializer(), baseChunk))
+                        write(ServerJson.lenient.encodeToString(WordStreamChunk.serializer(), baseChunk))
                         write("\n")
                         flush()
 
@@ -239,7 +237,6 @@ fun Application.module() {
                                 lang = lang,
                                 word = word,
                                 requestedLangCodes = requestedLangCodes,
-                                json = json,
                                 logger = streamLogger
                             )
 
@@ -250,7 +247,7 @@ fun Application.module() {
                                 val translatedResponseToClient = filterTranslations(fullResponse, requestedLangCodes)
                                 val translatedChunk =
                                     WordStreamChunk(WordStreamStage.TRANSLATED, translatedResponseToClient)
-                                write(json.encodeToString(WordStreamChunk.serializer(), translatedChunk))
+                                write(ServerJson.lenient.encodeToString(WordStreamChunk.serializer(), translatedChunk))
                                 write("\n")
                                 flush()
                             }
@@ -259,7 +256,7 @@ fun Application.module() {
                         // Step 3: Queue Cloud Tasks update if requested (only if something was processed)
                         // IMPORTANT: Use fullResponse (unfiltered) to ensure nothing is lost in repo
                         if (!push.isNullOrBlank() && wasProcessed) {
-                            val responseJson = json.encodeToString(
+                            val responseJson = ServerJson.lenient.encodeToString(
                                 LanguageCardResponse.serializer(),
                                 fullResponse
                             )
@@ -287,7 +284,7 @@ fun Application.module() {
             artifactName = "feedback discussion"
         ) { _, comment, email ->
             val discussion = GitHubClient.createFeedbackDiscussion(comment = comment, email = email)
-            feedbackJson.encodeToString(
+            ServerJson.lenient.encodeToString(
                 GeneralFeedbackResponse.serializer(),
                 GeneralFeedbackResponse(
                     discussionNumber = discussion.number,
@@ -307,7 +304,7 @@ fun Application.module() {
                 comment = comment,
                 email = email
             )
-            feedbackJson.encodeToString(
+            ServerJson.lenient.encodeToString(
                 GitHubIssueResponse.serializer(),
                 GitHubIssueResponse(
                     issueNumber = createdIssue.number,
@@ -329,7 +326,7 @@ fun Application.module() {
                 comment = comment,
                 email = email
             )
-            feedbackJson.encodeToString(
+            ServerJson.lenient.encodeToString(
                 GitHubIssueResponse.serializer(),
                 GitHubIssueResponse(
                     issueNumber = createdIssue.number,
@@ -360,12 +357,9 @@ fun Application.module() {
                 return@post
             }
 
-            val jsonDecoder = Json { ignoreUnknownKeys = false }
-            val jsonEncoder = Json { prettyPrint = true }
-
             try {
                 val responseJson = call.receiveText()
-                val incoming = jsonDecoder.decodeFromString(
+                val incoming = ServerJson.strict.decodeFromString(
                     LanguageCardResponse.serializer(),
                     responseJson
                 )
@@ -377,18 +371,18 @@ fun Application.module() {
                 // Check if file exists and handle accordingly
                 try {
                     val (existingContent, sha) = GitHubClient.loadWordsContentFromPushBranch(lang, word)
-                    val existing = jsonDecoder.decodeFromString(
+                    val existing = ServerJson.strict.decodeFromString(
                         LanguageCardResponse.serializer(),
                         existingContent
                     )
                     val merged = WordDataMerger.merge(existing, incoming)
-                    val mergedJson = jsonEncoder.encodeToString(
+                    val mergedJson = ServerJson.pretty.encodeToString(
                         LanguageCardResponse.serializer(),
                         merged
                     )
 
                     // Skip commit if content is identical
-                    val existingPretty = jsonEncoder.encodeToString(
+                    val existingPretty = ServerJson.pretty.encodeToString(
                         LanguageCardResponse.serializer(),
                         existing
                     )
@@ -400,7 +394,7 @@ fun Application.module() {
                     }
                 } catch (_: GHFileNotFoundException) {
                     // File doesn't exist - create it
-                    val prettyJson = jsonEncoder.encodeToString(
+                    val prettyJson = ServerJson.pretty.encodeToString(
                         LanguageCardResponse.serializer(),
                         incoming
                     )
@@ -469,7 +463,7 @@ private fun Route.feedbackSubmission(
         }
 
         val submission = try {
-            feedbackJson.decodeFromString(
+            ServerJson.lenient.decodeFromString(
                 FeedbackSubmissionRequest.serializer(),
                 call.receiveText()
             )
@@ -611,14 +605,13 @@ internal suspend fun <T> raceWithFallback(
 private suspend fun enhanceWithAI(
     lang: String,
     word: String,
-    json: Json,
     logger: Logger
 ): LanguageCardResponse {
     val geminiProvider = GeminiProvider()
     val openAIProvider = OpenAIProvider()
 
     val content = GitHubClient.loadDbExtractContent(lang, "$word.json")
-    val extractedData = json.decodeFromString(ExtractedWordData.serializer(), content)
+    val extractedData = ServerJson.lenient.decodeFromString(ExtractedWordData.serializer(), content)
     val request = DbExtractEnhancerUtils.createLanguageCardRequest(extractedData)
         ?: throw IllegalArgumentException("No entries found for word '$word' in language '$lang'")
 
@@ -672,20 +665,20 @@ private data class EnhancedTranslations(
     val mergedLangCodes: List<String>
 )
 
-private suspend fun loadBaseWordData(lang: String, word: String, json: Json, logger: Logger): WordProcessResult {
+private suspend fun loadBaseWordData(lang: String, word: String, logger: Logger): WordProcessResult {
     var wasProcessed = false
     val response = try {
         // Try push branch first (contains latest updates)
         val (content, _) = GitHubClient.loadWordsContentFromPushBranch(lang, word)
-        json.decodeFromString(LanguageCardResponse.serializer(), content)
+        ServerJson.lenient.decodeFromString(LanguageCardResponse.serializer(), content)
     } catch (_: GHFileNotFoundException) {
         // Fall back to main branch
         try {
             val content = GitHubClient.loadWordsContent(lang, word)
-            json.decodeFromString(LanguageCardResponse.serializer(), content)
+            ServerJson.lenient.decodeFromString(LanguageCardResponse.serializer(), content)
         } catch (_: GHFileNotFoundException) {
             wasProcessed = true
-            enhanceWithAI(lang, word, json, logger = logger)
+            enhanceWithAI(lang, word, logger = logger)
         }
     }
     return WordProcessResult(response = response, wasProcessed = wasProcessed)
@@ -721,7 +714,6 @@ private suspend fun addMissingTranslations(
     lang: String,
     word: String,
     requestedLangCodes: List<String>,
-    json: Json,
     logger: Logger
 ): TranslationResult {
     if (requestedLangCodes.isEmpty()) return TranslationResult(response, updated = false)
@@ -748,7 +740,7 @@ private suspend fun addMissingTranslations(
 
     val extractedData = try {
         val content = GitHubClient.loadDbExtractContent(lang, "$word.json")
-        json.decodeFromString(ExtractedWordData.serializer(), content)
+        ServerJson.lenient.decodeFromString(ExtractedWordData.serializer(), content)
     } catch (_: GHFileNotFoundException) {
         logger.warn("No db-extract for $lang/$word; cannot translate it into $missingLangCodes")
         return TranslationResult(response, updated = false)

--- a/server/src/main/kotlin/com/slovy/slovymovyapp/server/ServerJson.kt
+++ b/server/src/main/kotlin/com/slovy/slovymovyapp/server/ServerJson.kt
@@ -1,0 +1,30 @@
+package com.slovy.slovymovyapp.server
+
+import kotlinx.serialization.json.Json
+
+/**
+ * The JSON configurations this server uses, named by what each one is for.
+ *
+ * `Json { … }` builds a fresh configuration and serializers module, so a route handler that
+ * declares its own pays that cost on every request. The bigger problem is drift: the same
+ * three settings were spelled out at nine call sites, and whether two of them agreed was a
+ * matter of luck rather than intent.
+ */
+object ServerJson {
+    /**
+     * Payloads from GitHub, the AI providers, and this server's own clients. Unknown keys are
+     * expected — the words repo and provider responses both carry fields the server does not
+     * model — so decoding must tolerate them rather than fail.
+     */
+    val lenient: Json = Json { ignoreUnknownKeys = true }
+
+    /**
+     * The `/internal/update-repo` callback. An unknown key there means the caller and this
+     * server disagree about the schema, and a repo write is the wrong place to find that out
+     * quietly, so the payload is rejected instead.
+     */
+    val strict: Json = Json { ignoreUnknownKeys = false }
+
+    /** Content written to disk or committed to the words repo, where a human reads the diff. */
+    val pretty: Json = Json { prettyPrint = true }
+}

--- a/server/src/main/kotlin/com/slovy/slovymovyapp/server/ai/Gemini.kt
+++ b/server/src/main/kotlin/com/slovy/slovymovyapp/server/ai/Gemini.kt
@@ -2,9 +2,9 @@ package com.slovy.slovymovyapp.server.ai
 
 import com.google.genai.Client
 import com.google.genai.types.*
+import com.slovy.slovymovyapp.server.ServerJson
 import io.ktor.util.logging.*
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.json.Json
 import java.io.File
 
 @Serializable
@@ -97,7 +97,6 @@ object Gemini {
  * Gemini AI provider implementation.
  */
 class GeminiProvider : AIProvider {
-    private val cacheJson = Json { prettyPrint = true }
 
     override fun complete(parameters: AIParameters, cache: AICache, retryStrategy: RetryStrategy): String {
         val clientProvider = Gemini.clientProvider()
@@ -128,7 +127,7 @@ class GeminiProvider : AIProvider {
         )
 
         // Check cache
-        val parametersJson = cacheJson.encodeToString(geminiParams)
+        val parametersJson = ServerJson.pretty.encodeToString(geminiParams)
         val cachedResponse = cache.get(parametersJson)
         if (cachedResponse != null) {
             return cachedResponse

--- a/server/src/main/kotlin/com/slovy/slovymovyapp/server/ai/OpenAI.kt
+++ b/server/src/main/kotlin/com/slovy/slovymovyapp/server/ai/OpenAI.kt
@@ -14,6 +14,7 @@ import com.openai.models.chat.completions.ChatCompletionCreateParams.Verbosity
 import com.openai.models.chat.completions.ChatCompletionMessageParam
 import com.openai.models.chat.completions.ChatCompletionSystemMessageParam
 import com.openai.models.chat.completions.ChatCompletionUserMessageParam
+import com.slovy.slovymovyapp.server.ServerJson
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.*
 import java.io.File
@@ -162,7 +163,6 @@ object OpenAI {
  */
 class OpenAIProvider : AIProvider {
 
-    private val cacheJson = Json { prettyPrint = true }
     private val encodingRegistry = Encodings.newDefaultEncodingRegistry()
 
     override fun complete(parameters: AIParameters, cache: AICache, retryStrategy: RetryStrategy): String {
@@ -187,7 +187,7 @@ class OpenAIProvider : AIProvider {
         )
 
         // Check cache
-        val parametersJson = cacheJson.encodeToString(openAIParams)
+        val parametersJson = ServerJson.pretty.encodeToString(openAIParams)
         val cachedResponse = cache.get(parametersJson)
         if (cachedResponse != null) {
             return cachedResponse
@@ -363,8 +363,7 @@ object SchemaConverter {
      * @return OpenAI compatible JSON Schema as a JsonObject
      */
     fun geminiToOpenAI(geminiSchema: String): JsonObject {
-        val json = Json { ignoreUnknownKeys = true }
-        val geminiJsonObject = json.parseToJsonElement(geminiSchema).jsonObject
+        val geminiJsonObject = ServerJson.lenient.parseToJsonElement(geminiSchema).jsonObject
 
         return convertJsonObjectToOpenAI(geminiJsonObject)
     }

--- a/server/src/main/kotlin/com/slovy/slovymovyapp/server/ai/enhancer/DbExtractEnhancerUtils.kt
+++ b/server/src/main/kotlin/com/slovy/slovymovyapp/server/ai/enhancer/DbExtractEnhancerUtils.kt
@@ -2,7 +2,7 @@ package com.slovy.slovymovyapp.server.ai.enhancer
 
 import com.slovy.slovymovyapp.data.Language
 import com.slovy.slovymovyapp.ingestion.*
-import kotlinx.serialization.json.Json
+import com.slovy.slovymovyapp.server.ServerJson
 import java.io.File
 import kotlin.uuid.ExperimentalUuidApi
 
@@ -12,8 +12,6 @@ import kotlin.uuid.ExperimentalUuidApi
  */
 @OptIn(ExperimentalUuidApi::class)
 object DbExtractEnhancerUtils {
-    private val json = Json { ignoreUnknownKeys = true }
-
     fun loadExtractedWordData(
         word: String,
         langCode: String,
@@ -23,7 +21,7 @@ object DbExtractEnhancerUtils {
         val cl = Thread.currentThread().contextClassLoader
         val url = cl.getResource(path) ?: error("Resource not found: $path")
         val file = File(url.toURI())
-        return json.decodeFromString(ExtractedWordData.serializer(), file.readText())
+        return ServerJson.lenient.decodeFromString(ExtractedWordData.serializer(), file.readText())
     }
 
     fun createLanguageCardRequest(extractedData: ExtractedWordData): LanguageCardRequest? {

--- a/server/src/main/kotlin/com/slovy/slovymovyapp/server/lists/ListsFolderDecoder.kt
+++ b/server/src/main/kotlin/com/slovy/slovymovyapp/server/lists/ListsFolderDecoder.kt
@@ -1,6 +1,6 @@
 package com.slovy.slovymovyapp.server.lists
 
-import kotlinx.serialization.json.Json
+import com.slovy.slovymovyapp.server.ServerJson
 import org.slf4j.LoggerFactory
 
 /**
@@ -12,8 +12,6 @@ import org.slf4j.LoggerFactory
 internal object ListsFolderDecoder {
 
     private val log = LoggerFactory.getLogger("ListsFolderDecoder")
-
-    private val json = Json { ignoreUnknownKeys = true }
 
     /** UI locale every list should provide; clients fall back to it for unknown locales. */
     private const val BASE_LOCALE = "en"
@@ -35,7 +33,7 @@ internal object ListsFolderDecoder {
         text: String,
         iconsByName: Map<String, String>,
     ): ListContent {
-        val raw = json.decodeFromString(RawListFile.serializer(), text)
+        val raw = ServerJson.lenient.decodeFromString(RawListFile.serializer(), text)
         // Prefer the new {senseId, lemma} shape; fall back to the legacy sense-ids-only shape
         // for files not yet re-exported. Legacy senses get an empty lemma, so clients cannot
         // fetch them when they are missing from the local dictionary until the file is updated.

--- a/server/src/test/kotlin/com/slovy/slovymovyapp/ApplicationTest.kt
+++ b/server/src/test/kotlin/com/slovy/slovymovyapp/ApplicationTest.kt
@@ -1,5 +1,6 @@
 package com.slovy.slovymovyapp
 
+import com.slovy.slovymovyapp.server.ServerJson
 import com.slovy.slovymovyapp.server.ai.GeminiProvider
 import com.slovy.slovymovyapp.server.github.GitHubClient
 import io.ktor.client.request.*
@@ -8,7 +9,6 @@ import io.ktor.http.*
 import io.ktor.server.testing.*
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
-import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
@@ -65,8 +65,7 @@ class ApplicationTest {
         if (response.status == HttpStatusCode.NotFound) return@testApplication
         assertEquals(HttpStatusCode.OK, response.status)
         assertEquals(ContentType.Application.Json, response.contentType()?.withoutParameters())
-        val json = Json { ignoreUnknownKeys = true }
-        val version = json.parseToJsonElement(response.bodyAsText())
+        val version = ServerJson.lenient.parseToJsonElement(response.bodyAsText())
             .jsonObject["version"]?.jsonPrimitive?.content
         assertNotNull(version, "Response must contain 'version'")
         assertEquals(40, version.length, "Version must be a 40-char tree SHA")
@@ -83,8 +82,7 @@ class ApplicationTest {
         if (response.status == HttpStatusCode.NotFound) return@testApplication
         assertEquals(HttpStatusCode.OK, response.status)
         assertEquals(ContentType.Application.Json, response.contentType()?.withoutParameters())
-        val json = Json { ignoreUnknownKeys = true }
-        val body = json.parseToJsonElement(response.bodyAsText()).jsonObject
+        val body = ServerJson.lenient.parseToJsonElement(response.bodyAsText()).jsonObject
         val version = body["version"]?.jsonPrimitive?.content
         assertNotNull(version, "Response must contain 'version'")
         assertEquals(40, version.length)
@@ -117,8 +115,7 @@ class ApplicationTest {
         val body = response.bodyAsText()
         assertTrue(body.isNotBlank(), "Response body should not be blank")
 
-        val json = Json { ignoreUnknownKeys = true }
-        val chunks = parseNdjson(body, json)
+        val chunks = parseNdjson(body)
         assertTrue(chunks.isNotEmpty(), "NDJSON stream should contain at least one chunk")
         val baseChunk = chunks.first()
         assertEquals("base", baseChunk["stage"]?.jsonPrimitive?.content)
@@ -161,8 +158,7 @@ class ApplicationTest {
         assertEquals(ContentType.parse("application/x-ndjson"), response.contentType()?.withoutParameters())
 
         val body = response.bodyAsText()
-        val json = Json { ignoreUnknownKeys = true }
-        val chunks = parseNdjson(body, json)
+        val chunks = parseNdjson(body)
         assertTrue(chunks.isNotEmpty(), "NDJSON stream should contain at least one chunk")
         val lastPayload = chunks.last()["payload"]?.jsonObject
         val entries = lastPayload?.get("entries")?.jsonArray
@@ -194,8 +190,7 @@ class ApplicationTest {
         assertEquals(ContentType.parse("application/x-ndjson"), response.contentType()?.withoutParameters())
 
         val body = response.bodyAsText()
-        val json = Json { ignoreUnknownKeys = true }
-        val chunks = parseNdjson(body, json)
+        val chunks = parseNdjson(body)
         assertTrue(chunks.isNotEmpty(), "NDJSON stream should contain at least one chunk")
         val entries = chunks.last()["payload"]?.jsonObject?.get("entries")?.jsonArray
         assertNotNull(entries, "Response should contain 'entries' field")
@@ -223,8 +218,7 @@ class ApplicationTest {
         assertEquals(ContentType.parse("application/x-ndjson"), response.contentType()?.withoutParameters())
 
         val body = response.bodyAsText()
-        val json = Json { ignoreUnknownKeys = true }
-        val chunks = parseNdjson(body, json)
+        val chunks = parseNdjson(body)
         assertEquals(1, chunks.size, "Self-translation request should not produce a translated stage")
         assertEquals("base", chunks.first()["stage"]?.jsonPrimitive?.content)
     }
@@ -248,8 +242,7 @@ class ApplicationTest {
             assertEquals(HttpStatusCode.Created, response.status)
             assertEquals(ContentType.Application.Json, response.contentType()?.withoutParameters())
 
-            val json = Json { ignoreUnknownKeys = true }
-            val responseJson = json.parseToJsonElement(response.bodyAsText()).jsonObject
+            val responseJson = ServerJson.lenient.parseToJsonElement(response.bodyAsText()).jsonObject
             issueNumber = responseJson["issueNumber"]?.jsonPrimitive?.content?.toIntOrNull()
             assertNotNull(issueNumber, "Issue number should be present in response")
             val createdIssueNumber = issueNumber
@@ -296,8 +289,7 @@ class ApplicationTest {
         assertEquals(HttpStatusCode.Created, response.status)
         assertEquals(ContentType.Application.Json, response.contentType()?.withoutParameters())
 
-        val json = Json { ignoreUnknownKeys = true }
-        val responseJson = json.parseToJsonElement(response.bodyAsText()).jsonObject
+        val responseJson = ServerJson.lenient.parseToJsonElement(response.bodyAsText()).jsonObject
         val discussionNumber = responseJson["discussionNumber"]?.jsonPrimitive?.content?.toIntOrNull()
         assertNotNull(discussionNumber, "Discussion number should be present in response")
         assertTrue(discussionNumber > 0, "Discussion number should be positive")
@@ -335,11 +327,11 @@ class ApplicationTest {
         assertEquals(HttpStatusCode.BadRequest, response.status)
     }
 
-    private fun parseNdjson(body: String, json: Json) =
+    private fun parseNdjson(body: String) =
         body
             .lineSequence()
             .filter { it.isNotBlank() }
-            .map { json.parseToJsonElement(it).jsonObject }
+            .map { ServerJson.lenient.parseToJsonElement(it).jsonObject }
             .toList()
 }
 


### PR DESCRIPTION
## Contributor terms

- [x] I have read and agree to the contributor terms in `CONTRIBUTING.md`.
- [x] I have the right to submit these changes under those terms.

## Summary

The last two items from the audit, one commit each.

### 1. Name the server's JSON configurations

Three settings were spelled out at seventeen call sites, and whether any two agreed was luck rather than intent. Three of them sat *inside* route handlers — `/lists/{lang}`, `/lists/{lang}/version` and `/word` — so every request built a fresh configuration and serializers module before doing any work.

`ServerJson` names the three by what they are for:

| | setting | for |
| --- | --- | --- |
| `lenient` | `ignoreUnknownKeys = true` | payloads from GitHub, the AI providers and our own clients, which carry fields the server does not model |
| `strict` | `ignoreUnknownKeys = false` | the `/internal/update-repo` callback, where an unknown key means the caller and this server disagree about the schema |
| `pretty` | `prettyPrint = true` | content written to disk or committed to the words repo, where a human reads the diff |

Each call site kept the configuration it already had, so nothing about parsing or output changed. `loadBaseWordData`, `enhanceWithAI` and `addMissingTranslations` took a `json: Json` parameter that existed only to hand them the route's local instance; they always received the same one, so it is gone.

Left alone on purpose: `TestApplication`'s decoder also sets `explicitNulls = false` so test payloads may omit nullable fields — a real difference with a stated reason. The builder tests use `ignoreUnknownKeys = false` with `isLenient` and `allowTrailingComma` off, mirroring `JsonIngestionBuilder`; folding them into `ServerJson.strict` would drop two settings and weaken what they assert.

### 2. Extract the app-scoped object graph out of `App.kt`

`App.kt` was 1266 lines holding four unrelated things: the object graph, the navigation graph, startup routing, and the favorites-review domain. The graph was the worst — twenty `remember` calls between the imports and the first screen, so reading how a destination is wired meant scrolling past every service the app owns.

Three moves, all verbatim:

- **`AppContainer.kt`** — the graph, built by `rememberAppContainer()`. Each object keeps the exact `remember` keys it had, so a service is still recreated when its own inputs change and not when a sibling's do. Collapsing them into one keyed `remember` would have tied, for example, the app database's lifetime to `androidContext`, which it never had. The two objects that own resources are closed there too, next to where they are made.
- **`data/learning/review/FavoritesReviewCoordinator.kt`** — the coordinator with `FavoritesReviewState` and `FavoriteLanguageReviewState`. It reads favorites, runs intake and computes queue stats; none of that is UI entry-point work. Its test moves with it.
- **`AppDestination.kt`** — the destinations, now `internal` rather than `private` since they are read from `App.kt`.

`toFavoriteLanguageReviewUiState` stays in `App.kt`: it maps to a UI type and belongs on the UI side of the boundary.

The container exposes **fourteen** members, not eighteen. `appDatabase`, `listsClient`, `wordListsRepository` and `fsrsConfig` exist only to build the others and nothing outside the graph asks for them, so they stay local to `rememberAppContainer`. Publishing them would invite a screen to reach past a service to what it was built from.

`App.kt` is now 967 lines. `CLAUDE.md` described it as where services are created; updated to match.

#### ViewModel lifetimes are unchanged

This is what the refactor most risked, since `CLAUDE.md` calls the exceptions out explicitly. Verified against the previous revision:

- 10 screens still use `viewModel(viewModelStoreOwner = backStackEntry)` — same count before and after
- the app-scoped Favorites and Settings ViewModels still use `remember { }`
- the bounded Word Details ViewModel cache still uses `remember { linkedMapOf(...) }`

## Testing

- `./gradlew :composeApp:compileKotlinDesktop` — passes
- `./gradlew :composeApp:verifyLocalizationKeys` — passes
- `./gradlew :composeApp:desktopTest` — 465 tests, 5 failed
- `./gradlew :server:compileKotlin :server:compileTestKotlin` — pass
- `./gradlew :server:test` — 159 tests, 21 failed

Both failure sets are byte-identical to a clean-baseline run in this container with the branch stashed. They are the tests that reach live GitHub and AI backends (`DictionaryClientTest`, `GitHubClientTest`, `LanguageListsLoaderTest`, and the credential-dependent `ApplicationTest` routes).

Each of the three moves was checked mechanically: the 82 lines of graph, the coordinator, and the destinations all compare byte for byte against their previous location, the `private`→`internal` change on `AppDestination` aside.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FCSWCybtaTofzpkNa5cSpW)_