### PR TITLE
Tighten card prompt: tag only the learned word

### DIFF
--- a/server/src/main/kotlin/com/slovy/slovymovyapp/server/ai/enhancer/EnhancerPrompts.kt
+++ b/server/src/main/kotlin/com/slovy/slovymovyapp/server/ai/enhancer/EnhancerPrompts.kt
@@ -45,7 +45,7 @@ For synonyms and antonyms:
 * Only include synonyms that are interchangeable in typical contexts for this sense.
 * Never include the word itself or any of its inflected forms as a synonym or antonym.
 
-Provide common_phrases that must include the target word. 
+Provide common_phrases that must include the target word. Before emitting each phrase, check that the target word, or an inflected form of it, literally appears in it. If it does not, the item belongs in synonyms instead. Write each phrase in the form in which it is actually used, including number, rather than forcing it into the dictionary form of the word. 
 Semantic Filtering: Every phrase must directly correlate to the specific sense_definition.
 Idiom Restriction: Only include idiomatic phrases if the sense_definition itself is idiomatic. If the sense is literal, the phrases must be literal.
 Grammatical Fitness: Use 2–5 words. Do not use full sentences. Avoid specific subjects (pronouns or names). Ensure the word appears in the same part_of_speech as the sense. If there are no good common phrases, leave common_phrases empty. 
@@ -55,13 +55,14 @@ Provide at least 2 example sentences per sense that match its learner_level.
 Examples must:
 - Be full sentences (subject + predicate), 6–25 words.
 - Include the target word used naturally in the given sense.
+- The learned word itself must appear in every example - never a synonym, nickname or alternative name in its place.
 - Use the target word in the same part of speech as the sense_definition; do not change part of speech.
-- At least one example must incorporate any one common_phrases item, but remain a complete sentence.
+- Where a common_phrases item fits the sentence naturally, build one example around it. If none fits, simply write examples that make the sense clear. Never force a phrase into a sentence that already uses the word.
 - Never duplicate common_phrases as a standalone line.
 - If the input examples are too complex for the assigned level, replace them with simpler ones.
 - If no examples exist in the input, generate new ones following all rules.
 - Examples should sound like natural, real-world usage, not textbook constructions.
-- Wrap only the relevant form(s) of the learned word in <w></w> tags. Each tag must wrap a single word only — never a phrase or surrounding text. For separable verbs, tag each part separately (e.g., <w>bel</w> hem <w>op</w>).
+- Wrap only the relevant form(s) of the learned word in <w></w> tags. Each tag must wrap a single word only — never a phrase or surrounding text. For separable verbs, tag each part separately (e.g., <w>bel</w> hem <w>op</w>). Every tagged span in an example must be a form of the learned word itself. Before you finalise each example, name each span you tagged: if it is a synonym of the learned word, or another word of a phrase around it, remove its tags and leave it as plain text. An example may freely contain a common_phrases item: write the phrase out in full and tag only the learned word inside it, leaving the rest of the phrase as plain text.
 
 Assign semantic_group_id to group semantically close senses; leave blank if unique. Name the group according to its sense.
 


### PR DESCRIPTION
Four edits to `LANGUAGE_CARD_SYSTEM_PROMPT` targeting the defects that come up most often in the daily audit of newly generated cards. No code changes — the prompt string only.

## What changed

| line | edit |
|---|---|
| 48 | `common_phrases` must literally contain the target word, written in the form actually used |
| 57 | the learned word itself must appear in every example, never a stand-in |
| 59 | build an example around a phrase only where one fits naturally |
| 64 | the tagging rule restated as a check, plus how to include a phrase safely |

The tagging edit is the one that matters:

> Every tagged span in an example must be a form of the learned word itself. Before you finalise each example, name each span you tagged: if it is a synonym of the learned word, or another word of a phrase around it, remove its tags and leave it as plain text. An example may freely contain a common_phrases item: write the phrase out in full and tag only the learned word inside it, leaving the rest of the phrase as plain text.

## Measured

A/B run over the same 35 defect-prone English words, `gemini-3.1-flash-lite`, temperature 0, fixed seed, scored with the audit checker.

| variant | high findings | TAG_EXCESS high |
|---|---|---|
| current prompt | 31 | 28 |
| same content as a prohibition | 18 | 16 |
| **as a check (this PR)** | **4** | **2** |

The framing carries the result, not the content — a prohibition reached 16, the verifiable check reached 2.

`common_phrases` improve too: the current prompt emits `['power cut']` for *blackout*, a synonym containing no headword; with the containment check it emits `['major blackout', 'power blackout']`.

## Checked against what the new sentence could break

About 1300 cards teach a word that is itself a function word, so the check was verified not to strip those.

- **English articles and prepositions** (`a`, `for`, `between`, `against`, …): the current prompt tags 16 wrong spans across them, e.g. `<w>leaning</w> <w>against</w> the <w>wall</w>`. After the change: none. The check helps here rather than hurting.
- **Dutch separable verbs**, where a tagged particle is correct: 90% of split-form examples still tag the particle, against 96% before. Naming "a preposition" explicitly in the check made this *worse* (83%), because a stranded particle then reads as something to untag — which is why the list is kept short.

## Cost

Examples use a `common_phrases` item less often: 69% → 41% by exact match, 89% → 67% allowing for inflection. Accepted deliberately; re-strengthening the phrase instruction was tested and made over-tagging worse without recovering coverage.

## Not fixed

Both remain manual-sweep cases in the audit:
- `<w>the</w> <w>Mob</w>` — survives every variant tried; the model reads the article as part of the proper name.
- Dutch reflexive separable verbs tag the pronoun instead of the particle: `<w>bieden</w> <w>zich</w> … aan` where it should be `<w>bieden</w> zich … <w>aan</w>`.

The translation prompt is untouched; equivalent edits there are still untested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)