### PR TITLE
Translation prompt: drop "(the word ONLY)", add a read-back check

### DIFF
--- a/server/src/main/kotlin/com/slovy/slovymovyapp/server/ai/enhancer/EnhancerPrompts.kt
+++ b/server/src/main/kotlin/com/slovy/slovymovyapp/server/ai/enhancer/EnhancerPrompts.kt
@@ -121,7 +121,6 @@ Your task is to enrich the LanguageCardResponse with translation data by:
    - Provide an accurate translation to ${'$'}TARGET_LANG
    - Ensure the translation preserves the meaning and context
    - Put the translation of the word in <w> </w> tags so it can be highlighted to a learner. A translation that is several words long may be tagged as it stands; what stays outside the tags is anything that merely sits beside the translation in the sentence - an article, a modifier, a neighbouring noun. Where the input notes above state otherwise for this language, follow the notes instead.
-   - After writing each example translation, read back the sentence you have just written and name the span that carries the sense; that span is what gets tagged. If a declared translation for this sense, or an inflected form of one, is present in the sentence, it is that span.
 
 Guidelines:
 - Only provide translations that are accurate, natural, and contextually appropriate for each specific sense_definition.

--- a/server/src/main/kotlin/com/slovy/slovymovyapp/server/ai/enhancer/EnhancerPrompts.kt
+++ b/server/src/main/kotlin/com/slovy/slovymovyapp/server/ai/enhancer/EnhancerPrompts.kt
@@ -120,7 +120,8 @@ Your task is to enrich the LanguageCardResponse with translation data by:
 2. For each example in the language card:
    - Provide an accurate translation to ${'$'}TARGET_LANG
    - Ensure the translation preserves the meaning and context
-   - Put the translation of the word in <w> </w> tags (the word ONLY), so it could be highlighted to a learner. Where the input notes above state otherwise for this language, follow the notes instead.
+   - Put the translation of the word in <w> </w> tags so it can be highlighted to a learner. A translation that is several words long may be tagged as it stands; what stays outside the tags is anything that merely sits beside the translation in the sentence - an article, a modifier, a neighbouring noun. Where the input notes above state otherwise for this language, follow the notes instead.
+   - After writing each example translation, read back the sentence you have just written and name the span that carries the sense; that span is what gets tagged. If a declared translation for this sense, or an inflected form of one, is present in the sentence, it is that span.
 
 Guidelines:
 - Only provide translations that are accurate, natural, and contextually appropriate for each specific sense_definition.


### PR DESCRIPTION
Two changes to a single line of `TRANSLATION_SYSTEM_PROMPT`. No code changes.

```diff
-   - Put the translation of the word in <w> </w> tags (the word ONLY), so it could be highlighted to a learner. Where the input notes above state otherwise for this language, follow the notes instead.
+   - Put the translation of the word in <w> </w> tags so it can be highlighted to a learner. A translation that is several words long may be tagged as it stands; what stays outside the tags is anything that merely sits beside the translation in the sentence - an article, a modifier, a neighbouring noun. Where the input notes above state otherwise for this language, follow the notes instead.
+   - After writing each example translation, read back the sentence you have just written and name the span that carries the sense; that span is what gets tagged. If a declared translation for this sense, or an inflected form of one, is present in the sentence, it is that span.
```

## Why `(the word ONLY)` is wrong

A correct tagged span is often a phrase. Across a week of applied translation fixes, **12% tag a multi-word span** — 24% in Turkish, 21% in French: `<w>en couple</w>`, `<w>mít na paměti</w>`, `<w>Auf keinen Fall</w>`, `<w>Con tutto il rispetto</w>`.

And the failure mode is worse than splitting a phrase into one tag per word. When the declared translation is a phrase, **no single word satisfies the instruction, so the model tags nothing at all**:

```
junior, de, declared "Student im dritten Jahr"
  before: Er ist derzeit Student im dritten Jahr an der staatlichen Universität.
  after:  Er ist derzeit <w>Student im dritten Jahr</w> an der staatlichen Universität.
```

## Why the read-back check

Of 599 translation fixes applied over the week, **502 (84%)** were "nothing was tagged although a declared word was sitting in the sentence". German and Dutch contribute a third of those through compounds — the declared word is inside a longer word (`Stärling` → `Rotschulterstärling`, `schil` → `bananenschil`), so it isn't separately visible and the model leaves the sentence alone.

This is the same imperative→check rewrite that took the card prompt from 28 over-tags to 2 in #893.

## Measured

Two **disjoint** word sets, targets de/nl/fr/tr, identical phase-1 cards (cached, so only the translation prompt varies), production settings.

| | untagged translations | multi-word tagged spans |
|---|---|---|
| set 1 (14 words) | 1.9% → **1.0%** | 8.2% → **16.4%** |
| set 2 (13 words) | 4.0% → **3.2%** | 8.2% → **15.9%** |
| pooled | 2.8% → **1.9%** | |

The multi-word figure replicates almost exactly — identical 8.2% baseline in both sets — and is the robust result. It moves toward the empirically correct rate of ~12% observed in the fix logs. The untagged reduction is consistent in direction but its size varies with the word sample.

## Limits, stated plainly

- 27 words total is a small sample for the untagged metric.
- A Turkish regression appeared in set 1 (0 → 3) and did **not** replicate in set 2 (3 → 3).
- The test is only valid at production's `reasoningBudget = 1`. At the enhancer's default of 2000 the model performs the read-back unprompted, the baseline sits at 99.1% tagged, and the defect does not reproduce.
- Re-running with a different seed is useless here: at temperature 0 the output is byte-identical. Replication requires a different word set.

## Deliberately not included

A clause prescribing how many tag pairs a phrase gets ("one pair marks exactly the extent of the translation"). It would forbid the two-tag separable-verb pattern the per-language notes depend on, and the blank count doesn't justify that risk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)